### PR TITLE
WIP: Add failing tests for extending Code-First types

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -231,6 +231,8 @@ internal class TypeInitializer
             _globalComps,
             _isOfType);
 
+        // todo: this fails, when using the ExtendsType<T> API
+        //       without specifying a name for the object type extension.
         registeredType.Type.CompleteName(registeredType);
 
         if (registeredType.IsNamedType || registeredType.IsDirectiveType)
@@ -313,7 +315,6 @@ internal class TypeInitializer
                         .Where(t =>
                             t.Type is INamedType n &&
                             n.Kind == namedTypeExtension.Kind))
-
                     {
                         if (isSchemaType &&
                             extendsType.IsInstanceOfType(possibleMatchingType))

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -590,6 +590,45 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public async Task ObjectTypeExtension_ExtendsType_CodeFirstType()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<CodeFirstQueryType>()
+                .AddTypeExtension<CodeFirstQueryExtensionType>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
+        }
+
+        [Fact]
+        public async Task ExtendObjectTypeAttribute_AddFields()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<AnnotationBasedQuery>()
+                .AddTypeExtension<ExtendAnnotationBasedType>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
+        }
+
+        [Fact]
+        public async Task ExtendObjectTypeAttribute_Extend_ObjectType()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<CodeFirstQueryType>()
+                .AddTypeExtension<ExtendCodeFirstType>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
+        }
+
+        [Fact]
         public async Task Ensure_Member_And_ResolverMember_Are_Correctly_Set_When_Extending()
         {
             ISchema schema =
@@ -938,6 +977,43 @@ namespace HotChocolate.Types
                     return default;
                 });
             }
+        }
+
+        public class AnnotationBasedQuery
+        {
+            public string Field1() => "";
+        }
+
+        [ExtendObjectType(typeof(AnnotationBasedQuery))]
+        public class ExtendAnnotationBasedType
+        {
+            public string Field2() => "";
+        }
+
+        public class CodeFirstQueryType : ObjectType
+        {
+            protected override void Configure(IObjectTypeDescriptor descriptor)
+            {
+                descriptor.Name("Query");
+
+                descriptor.Field("field1").Resolve("");
+            }
+        }
+
+        public class CodeFirstQueryExtensionType : ObjectTypeExtension
+        {
+            protected override void Configure(IObjectTypeDescriptor descriptor)
+            {
+                descriptor.ExtendsType<CodeFirstQueryType>();
+
+                descriptor.Field("field2").Resolve("");
+            }
+        }
+
+        [ExtendObjectType(typeof(CodeFirstQueryType))]
+        public class ExtendCodeFirstType
+        {
+            public string Field2 => "";
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_AddFields.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_AddFields.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: AnnotationBasedQuery
+}
+
+type AnnotationBasedQuery {
+  field1: String!
+  field2: String!
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_Extend_ObjectType.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_Extend_ObjectType.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  field1: String
+  field2: String!
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_ExtendsType_CodeFirstType.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ObjectTypeExtension_ExtendsType_CodeFirstType.snap
@@ -1,0 +1,14 @@
+﻿schema {
+  query: Query
+}
+
+type Query {
+  field1: String
+  field2: String
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD


### PR DESCRIPTION
While playing around with Type Extension I've noticed that the following two cases do not work:

Extending a Code-first type from the Annotation-based approach:
```csharp
public class CodeFirstType : ObjectType
{
    protected override void Configure(IObjectTypeDescriptor descriptor)
    {
        descriptor.Name("Query");

        descriptor.Field("field1").Resolve("");
    }
}

[ExtendObjectType(typeof(CodeFirstType))]
public class ExtendCodeFirstType
{
    public string Field2 => "";
}
```

Extending a Code-first type using `ExtendsType<T>()`:
```csharp
public class CodeFirstType : ObjectType
{
    protected override void Configure(IObjectTypeDescriptor descriptor)
    {
        descriptor.Name("Query");

        descriptor.Field("field1").Resolve("");
    }
}

public class CodeFirstTypeExtension : ObjectTypeExtension
{
    protected override void Configure(IObjectTypeDescriptor descriptor)
    {
        descriptor.ExtendsType<CodeFirstType>();

        descriptor.Field("field2").Resolve("");
    }
}
```

I wasn't sure whether these are intentional limitations or whether they are bugs and how to best go about solving them. In the end I just added these tests to showcase the issue.