### PR TITLE
Add extension point to DocumentAnalyzer to change schema transformation before creating OperationModel

### DIFF
--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DefaultSchemaDocumentRewriter.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DefaultSchemaDocumentRewriter.cs
@@ -1,0 +1,11 @@
+﻿using StrawberryShake.CodeGeneration.Utilities;
+
+namespace StrawberryShake.CodeGeneration.Analyzers;
+
+class DefaultSchemaDocumentRewriter : ISchemaDocumentRewriter
+{
+    public DocumentNode RewriteSchemaForOperationModel(DocumentNode document, ISchema schema)
+    {
+        QueryDocumentRewriter.Rewrite(document, schema);
+    }
+}

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DocumentAnalyzer.CollectOutputTypes.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DocumentAnalyzer.CollectOutputTypes.cs
@@ -11,7 +11,7 @@ public partial class DocumentAnalyzer
 {
     private static readonly InterfaceTypeSelectionSetAnalyzer _selectionAnalyzer = new();
 
-    private static OperationModel CreateOperationModel(
+    private OperationModel CreateOperationModel(
         IDocumentAnalyzerContext context)
     {
         CollectEnumTypes(context);
@@ -20,7 +20,7 @@ public partial class DocumentAnalyzer
         return new(
             context.OperationName,
             context.OperationType,
-            QueryDocumentRewriter.Rewrite(context.Document, context.Schema),
+            _schemaDocumentRewriter.RewriteSchemaForOperationModel(context.Document, context.Schema),
             context.OperationDefinition.Operation,
             CreateOperationArguments(context),
             GetResultType(context),

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DocumentAnalyzer.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/DocumentAnalyzer.cs
@@ -1,20 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using HotChocolate;
-using HotChocolate.Language;
 using StrawberryShake.CodeGeneration.Analyzers.Models;
-using StrawberryShake.CodeGeneration.Utilities;
 using static StrawberryShake.CodeGeneration.Utilities.OperationDocumentHelper;
 
 namespace StrawberryShake.CodeGeneration.Analyzers;
 
 public partial class DocumentAnalyzer
 {
+    private readonly ISchemaDocumentRewriter _schemaDocumentRewriter;
     private readonly List<DocumentNode> _documents = new();
     private ISchema? _schema;
 
     public static DocumentAnalyzer New() => new();
+
+    public DocumentAnalyzer(ISchemaDocumentRewriter? schemaDocumentRewriter = null)
+    {
+        _schemaDocumentRewriter = schemaDocumentRewriter ?? new DefaultSchemaDocumentRewriter();
+    }
 
     public DocumentAnalyzer SetSchema(ISchema schema)
     {

--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/ISchemaDocumentRewriter.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Analyzers/ISchemaDocumentRewriter.cs
@@ -1,0 +1,6 @@
+﻿namespace StrawberryShake.CodeGeneration.Analyzers;
+
+public interface ISchemaDocumentRewriter
+{
+    DocumentNode RewriteSchemaForOperationModel(DocumentNode document, ISchema schema);
+}


### PR DESCRIPTION
Hi,

I would like to use Strawberryshake.CodeGeneration library to create my own tool for generating Graphql clients.
However,  I need to get an Operation model for the original schema, without any modifications so I abstracted away the part responsible for rewriting the schema before creating OperationModel. This is a small refactor that does not introduce any functional changes.

