### PR TITLE
[Spatial] Remove test for geojsonpointinput type based on input parser revisions

### DIFF
--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
@@ -198,7 +198,6 @@ public class GeoJsonPointSerializerTests
     }
 
     [Theory]
-    [InlineData(PointInputName)]
     [InlineData(GeometryTypeName)]
     public void ParseLiteral_Should_Throw_When_NoGeometryType(string typeName)
     {
@@ -475,7 +474,6 @@ public class GeoJsonPointSerializerTests
     }
 
     [Theory]
-    [InlineData(PointInputName)]
     [InlineData(GeometryTypeName)]
     public void Deserialize_Should_Fail_WhenTypeNameIsMissing(string typeName)
     {

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
@@ -198,6 +198,7 @@ public class GeoJsonPointSerializerTests
     }
 
     [Theory]
+    [InlineData(CoordinatesTypeName)]
     [InlineData(GeometryTypeName)]
     public void ParseLiteral_Should_Throw_When_NoGeometryType(string typeName)
     {
@@ -474,6 +475,7 @@ public class GeoJsonPointSerializerTests
     }
 
     [Theory]
+    [InlineData(CoordinatesTypeName)]
     [InlineData(GeometryTypeName)]
     public void Deserialize_Should_Fail_WhenTypeNameIsMissing(string typeName)
     {


### PR DESCRIPTION
revise tests based on changes in https://github.com/ChilliCream/hotchocolate/commit/0b98f7879364b2f71d7303030828a98e501e526a