### PR TITLE
feat: IgnorePropertiesResolver on ExtendObjectType

### DIFF
--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -9,6 +9,7 @@ using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Tests;
 using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Snapshooter;
@@ -509,6 +510,19 @@ namespace HotChocolate.Types
         }
 
         [Fact]
+        public async Task Remove_Fields_Globally_With_Func()
+        {
+            Snapshot.FullName();
+
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<Remove_Fields_Globally_With_Func_PersonDto>()
+                .AddTypeExtension<Remove_Fields_Globally_With_Func_PersonResolvers>()
+                .BuildSchemaAsync()
+                .MatchSnapshotAsync();
+        }
+
+        [Fact]
         public async Task Remove_Fields()
         {
             Snapshot.FullName();
@@ -817,6 +831,27 @@ namespace HotChocolate.Types
             IgnoreProperties = new[] { "internalId" })]
         public class Remove_Fields_Globally_PersonResolvers
         {
+        }
+
+        public class Remove_Fields_Globally_With_Func_PersonDto
+        {
+            public int FriendId { get; } = 1;
+
+            public int InternalId { get; } = 1;
+        }
+
+        [ExtendObjectType(
+            typeof(Remove_Fields_Globally_With_Func_PersonDto),
+            IgnorePropertiesResolverType = typeof(Remove_Fields_Globally_With_Func_PersonResolvers),
+            IgnorePropertiesResolver = nameof(IgnorePropertiesResolver))]
+        public class Remove_Fields_Globally_With_Func_PersonResolvers
+        {
+            public static string[] IgnorePropertiesResolver(Type typeBeingExtended)
+            {
+                Assert.Equal(nameof(Remove_Fields_Globally_With_Func_PersonDto), typeBeingExtended.Name);
+
+                return new[] { nameof(Remove_Fields_Globally_With_Func_PersonDto.InternalId) };
+            }
         }
 
         public class Remove_Fields_PersonDto

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Remove_Fields_Globally_With_Func.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.Remove_Fields_Globally_With_Func.snap
@@ -1,0 +1,13 @@
+schema {
+  query: Remove_Fields_Globally_With_Func_PersonDto
+}
+
+type Remove_Fields_Globally_With_Func_PersonDto {
+  friendId: Int!
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD


### PR DESCRIPTION
Ability to define what properties should be ignored via a function that accepts the `Type` being extended.