### PR TITLE
Fix typo in documentation

### DIFF
--- a/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
+++ b/website/src/docs/hotchocolate/v12/defining-a-schema/interfaces.md
@@ -23,7 +23,7 @@ type Query {
 
 # Usage
 
-GIven is the schema from above.
+Given is the schema from above.
 
 When querying a field returning an interface, we can query the fields defined in the interface like we would query a regular object type.
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Closes #bugnumber (in this specific format)
