### PR TITLE
Enable resolver for query alias.

### DIFF
--- a/src/HotChocolate/Core/src/Types.Json/JsonObjectTypeExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Json/JsonObjectTypeExtensions.cs
@@ -258,7 +258,12 @@ public static class JsonObjectTypeExtensions
     }
 
     private static JsonElement? GetProperty(this IPureResolverContext context, string propertyName)
-        => context.Parent<JsonElement>().TryGetProperty(propertyName, out var element)
+    {
+        var aliasName = context.Selection.SyntaxNode.Alias?.Value;
+        var property = !string.IsNullOrWhiteSpace(aliasName) ? aliasName : propertyName;
+
+        return context.Parent<JsonElement>().TryGetProperty(property!, out var element)
             ? element
             : null;
+    }
 }

--- a/src/HotChocolate/Core/test/Types.Json.Tests/FromJsonDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Json.Tests/FromJsonDescriptorTests.cs
@@ -94,6 +94,34 @@ public class FromJsonDescriptorTests
             }
             """);
     }
+    
+    [Fact]
+    public async Task MapField_With_Alias()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryWithAlias>()
+                .AddObjectType(
+                    d =>
+                    {
+                        d.Name("Foo");
+                        d.Field("baz").Type<StringType>().FromJson("bar");
+                    })
+                .AddJsonSupport()
+                .ExecuteRequestAsync("{ foo { alias: baz } }");
+
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "foo": {
+                  "alias": "abc"
+                }
+              }
+            }
+            """);
+    }
 
     [Fact]
     public void FromJson_1_Descriptor_Is_Null()
@@ -417,6 +445,12 @@ public class FromJsonDescriptorTests
     {
         [GraphQLType("Foo")]
         public JsonElement GetFoo() => JsonDocument.Parse(@"{ ""bar"": null }").RootElement;
+    }
+     
+    public class QueryWithAlias
+    {
+        [GraphQLType("Foo")]
+        public JsonElement GetFoo() => JsonDocument.Parse(@"{ ""alias"": ""abc"" }").RootElement;
     }
 
     public class FooType : ObjectType


### PR DESCRIPTION
In case alias is being used in query, those fields were not getting resolved as parent json will have alias name in place of property name. 

So in proposed solution: its taking alias for current field from context if there is any, and fetching data from parent json based on that name.
