### PR TITLE
Adds sorting support to RavenDb

### DIFF
--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
@@ -107,7 +107,7 @@ public class QueryableFilterProvider : FilterProvider<QueryableFilterContext>
                 if (visitorContext.TryCreateLambda(
                         out Expression<Func<TEntityType, bool>>? where))
                 {
-                    input = ApplyExpression(input, where);
+                    input = ApplyToResult(input, where);
                 }
                 else
                 {
@@ -126,7 +126,7 @@ public class QueryableFilterProvider : FilterProvider<QueryableFilterContext>
         };
     }
 
-    protected virtual object? ApplyExpression<TEntityType>(
+    protected virtual object? ApplyToResult<TEntityType>(
         object? input,
         Expression<Func<TEntityType, bool>> where)
         => input switch

--- a/src/HotChocolate/Raven/src/Data/Filtering/RavenQueryableFilterProvider.cs
+++ b/src/HotChocolate/Raven/src/Data/Filtering/RavenQueryableFilterProvider.cs
@@ -33,14 +33,12 @@ internal sealed class RavenQueryableFilterProvider : QueryableFilterProvider
 
     protected override bool IsInMemoryQuery<TEntityType>(object? input) => false;
 
-    protected override object? ApplyExpression<TEntityType>(
+    protected override object? ApplyToResult<TEntityType>(
         object? input,
         Expression<Func<TEntityType, bool>> where)
         => input switch
         {
             IRavenQueryable<TEntityType> q => q.Where(where),
-            IQueryable<TEntityType> q => q.Where(where),
-            IEnumerable<TEntityType> e => e.AsQueryable().Where(where),
             IAsyncDocumentQuery<TEntityType> q => q
                 .ToQueryable()
                 .Where(where)

--- a/src/HotChocolate/Raven/src/Data/Sorting/RavenQueryableSortProvider.cs
+++ b/src/HotChocolate/Raven/src/Data/Sorting/RavenQueryableSortProvider.cs
@@ -1,6 +1,8 @@
 using HotChocolate.Data.Sorting;
 using HotChocolate.Data.Sorting.Expressions;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
 
 namespace HotChocolate.Data.Raven.Sorting;
 
@@ -10,4 +12,19 @@ public class RavenQueryableSortProvider : QueryableSortProvider
         Action<ISortProviderDescriptor<QueryableSortContext>> configure) : base(configure)
     {
     }
+
+    protected override bool IsInMemoryQuery<TEntityType>(object? input) => false;
+
+    protected override object? ApplyToResult<TEntityType>(
+        object? input,
+        Func<IQueryable<TEntityType>, IQueryable<TEntityType>> sort)
+        => input switch
+        {
+            IRavenQueryable<TEntityType> q => sort(q),
+            IAsyncDocumentQuery<TEntityType> q => sort(q.ToQueryable()).ToAsyncDocumentQuery(),
+            RavenAsyncDocumentQueryExecutable<TEntityType> ex =>
+                new RavenAsyncDocumentQueryExecutable<TEntityType>(
+                    sort(ex.Query.ToQueryable()).ToAsyncDocumentQuery()),
+            _ => input
+        };
 }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/CustomRavenDBDefaultOptions.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/CustomRavenDBDefaultOptions.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+using Squadron;
+
+namespace HotChocolate.Data.Sorting;
+
+public sealed class CustomRavenDBDefaultOptions : RavenDBDefaultOptions
+{
+    public override void Configure(ContainerResourceBuilder builder)
+    {
+        base.Configure(builder);
+        if (RuntimeInformation.ProcessArchitecture is Architecture.Arm64)
+        {
+            builder.Image("ravendb/ravendb:5.4-ubuntu-arm64v8-latest");
+        }
+    }
+}

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorBooleanTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorBooleanTests.cs
@@ -89,14 +89,10 @@ public class QueryableSortVisitorBooleanTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorComparableTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorComparableTests.cs
@@ -44,14 +44,10 @@ public class QueryableSortVisitorComparableTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -74,14 +70,10 @@ public class QueryableSortVisitorComparableTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -105,6 +97,7 @@ public class QueryableSortVisitorComparableTests
     public class FooNullable
     {
         public string? Id { get; set; }
+
         public short? BarShort { get; set; }
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorEnumTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorEnumTests.cs
@@ -49,14 +49,10 @@ public class QueryableSortVisitorEnumTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -79,14 +75,10 @@ public class QueryableSortVisitorEnumTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorExecutableTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorExecutableTests.cs
@@ -39,14 +39,10 @@ public class QueryableSortVisitorExecutableTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -68,8 +64,11 @@ public class QueryableSortVisitorExecutableTests
                 .Create());
 
         // assert
-        res1.MatchSnapshot("ASC");
-        res2.MatchSnapshot("DESC");
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
+            .MatchAsync();
     }
 
     [Fact]
@@ -91,14 +90,10 @@ public class QueryableSortVisitorExecutableTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorExpressionTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorExpressionTests.cs
@@ -13,7 +13,9 @@ public class QueryableSortVisitorExpressionTests
         new Foo { Name = "Sam", LastName = "Sampleman", Bars = new List<Bar>() },
         new Foo
         {
-            Name = "Foo", LastName = "Galoo", Bars = new List<Bar>() { new() { Value = "A" } }
+            Name = "Foo",
+            LastName = "Galoo",
+            Bars = new List<Bar>() { new() { Value = "A" } }
         }
     };
 
@@ -67,14 +69,10 @@ public class QueryableSortVisitorExpressionTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
         ;
     }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorObjectTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorObjectTests.cs
@@ -170,14 +170,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -204,14 +200,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "13")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "13")
             .MatchAsync();
     }
 
@@ -237,14 +229,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -271,14 +259,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "13")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "13")
             .MatchAsync();
     }
 
@@ -304,14 +288,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -338,14 +318,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "13")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "13")
             .MatchAsync();
     }
 
@@ -371,14 +347,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -405,14 +377,10 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "13")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "13")
             .MatchAsync();
     }
 
@@ -472,20 +440,12 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    SnapshotExtensions.AddResult(
-                        SnapshotExtensions.AddResult(
-                            Snapshot
-                                .Create(),
-                            res1,
-                            "ASC"),
-                        res2,
-                        "ASC"),
-                    res3,
-                    "DESC"),
-                res4,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "ASC")
+            .AddResult(res3, "DESC")
+            .AddResult(res4, "DESC")
             .MatchAsync();
     }
 
@@ -617,20 +577,12 @@ public class QueryableSortVisitorObjectTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    SnapshotExtensions.AddResult(
-                        SnapshotExtensions.AddResult(
-                            Snapshot
-                                .Create(),
-                            res1,
-                            "ASC"),
-                        res2,
-                        "ASC"),
-                    res3,
-                    "DESC"),
-                res4,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "ASC")
+            .AddResult(res3, "DESC")
+            .AddResult(res4, "DESC")
             .MatchAsync();
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorStringTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/QueryableSortVisitorStringTests.cs
@@ -41,14 +41,10 @@ public class QueryableSortVisitorStringTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 
@@ -71,14 +67,10 @@ public class QueryableSortVisitorStringTests
                 .Create());
 
         // assert
-        await SnapshotExtensions.AddResult(
-                SnapshotExtensions.AddResult(
-                    Snapshot
-                        .Create(),
-                    res1,
-                    "ASC"),
-                res2,
-                "DESC")
+        await Snapshot
+            .Create()
+            .AddResult(res1, "ASC")
+            .AddResult(res2, "DESC")
             .MatchAsync();
     }
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorBooleanTests.Create_Boolean_OrderBy_Nullable_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorBooleanTests.Create_Boolean_OrderBy_Nullable_NET6_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
+        "bar": null
+      },
+      {
         "bar": false
       },
       {
         "bar": true
-      },
-      {
-        "bar": null
       }
     ]
   }
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorbooleantests_foonullable as d order by CAST(d.data ->> 'Bar' as boolean)
+from 'FooNullables' order by Bar
 ---------------
 
 DESC Result:
@@ -28,13 +28,13 @@ DESC Result:
   "data": {
     "root": [
       {
-        "bar": null
-      },
-      {
         "bar": true
       },
       {
         "bar": false
+      },
+      {
+        "bar": null
       }
     ]
   }
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorbooleantests_foonullable as d order by CAST(d.data ->> 'Bar' as boolean) desc
+from 'FooNullables' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorBooleanTests.Create_Boolean_OrderBy_Nullable_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorBooleanTests.Create_Boolean_OrderBy_Nullable_NET7_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
+        "bar": null
+      },
+      {
         "bar": false
       },
       {
         "bar": true
-      },
-      {
-        "bar": null
       }
     ]
   }
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorbooleantests_foonullable as d order by CAST(d.data ->> 'Bar' as boolean)
+from 'FooNullables' order by Bar
 ---------------
 
 DESC Result:
@@ -28,13 +28,13 @@ DESC Result:
   "data": {
     "root": [
       {
-        "bar": null
-      },
-      {
         "bar": true
       },
       {
         "bar": false
+      },
+      {
+        "bar": null
       }
     ]
   }
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorbooleantests_foonullable as d order by CAST(d.data ->> 'Bar' as boolean) desc
+from 'FooNullables' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_NET6_0.snap
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foo as d order by CAST(d.data ->> 'BarShort' as smallint)
+from 'Foos' order by BarShort as long
 ---------------
 
 DESC Result:
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foo as d order by CAST(d.data ->> 'BarShort' as smallint) desc
+from 'Foos' order by BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_NET7_0.snap
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foo as d order by CAST(d.data ->> 'BarShort' as smallint)
+from 'Foos' order by BarShort as long
 ---------------
 
 DESC Result:
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foo as d order by CAST(d.data ->> 'BarShort' as smallint) desc
+from 'Foos' order by BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_Nullable_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_Nullable_NET6_0.snap
@@ -4,6 +4,9 @@ ASC Result:
   "data": {
     "root": [
       {
+        "barShort": null
+      },
+      {
         "barShort": 12
       },
       {
@@ -11,9 +14,6 @@ ASC Result:
       },
       {
         "barShort": 14
-      },
-      {
-        "barShort": null
       }
     ]
   }
@@ -22,7 +22,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foonullable as d order by CAST(d.data ->> 'BarShort' as smallint)
+from 'FooNullables' order by BarShort as long
 ---------------
 
 DESC Result:
@@ -31,9 +31,6 @@ DESC Result:
   "data": {
     "root": [
       {
-        "barShort": null
-      },
-      {
         "barShort": 14
       },
       {
@@ -41,6 +38,9 @@ DESC Result:
       },
       {
         "barShort": 12
+      },
+      {
+        "barShort": null
       }
     ]
   }
@@ -49,5 +49,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foonullable as d order by CAST(d.data ->> 'BarShort' as smallint) desc
+from 'FooNullables' order by BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_Nullable_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorComparableTests.Create_Short_OrderBy_Nullable_NET7_0.snap
@@ -4,6 +4,9 @@ ASC Result:
   "data": {
     "root": [
       {
+        "barShort": null
+      },
+      {
         "barShort": 12
       },
       {
@@ -11,9 +14,6 @@ ASC Result:
       },
       {
         "barShort": 14
-      },
-      {
-        "barShort": null
       }
     ]
   }
@@ -22,7 +22,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foonullable as d order by CAST(d.data ->> 'BarShort' as smallint)
+from 'FooNullables' order by BarShort as long
 ---------------
 
 DESC Result:
@@ -31,9 +31,6 @@ DESC Result:
   "data": {
     "root": [
       {
-        "barShort": null
-      },
-      {
         "barShort": 14
       },
       {
@@ -41,6 +38,9 @@ DESC Result:
       },
       {
         "barShort": 12
+      },
+      {
+        "barShort": null
       }
     ]
   }
@@ -49,5 +49,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorcomparabletests_foonullable as d order by CAST(d.data ->> 'BarShort' as smallint) desc
+from 'FooNullables' order by BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_NET6_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
-        "barEnum": "FOO"
-      },
-      {
         "barEnum": "BAR"
       },
       {
         "barEnum": "BAZ"
+      },
+      {
+        "barEnum": "FOO"
       },
       {
         "barEnum": "QUX"
@@ -22,7 +22,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foo as d order by CAST(d.data ->> 'BarEnum' as integer)
+from 'Foos' order by BarEnum
 ---------------
 
 DESC Result:
@@ -34,13 +34,13 @@ DESC Result:
         "barEnum": "QUX"
       },
       {
+        "barEnum": "FOO"
+      },
+      {
         "barEnum": "BAZ"
       },
       {
         "barEnum": "BAR"
-      },
-      {
-        "barEnum": "FOO"
       }
     ]
   }
@@ -49,5 +49,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foo as d order by CAST(d.data ->> 'BarEnum' as integer) desc
+from 'Foos' order by BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_NET7_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
-        "barEnum": "FOO"
-      },
-      {
         "barEnum": "BAR"
       },
       {
         "barEnum": "BAZ"
+      },
+      {
+        "barEnum": "FOO"
       },
       {
         "barEnum": "QUX"
@@ -22,7 +22,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foo as d order by CAST(d.data ->> 'BarEnum' as integer)
+from 'Foos' order by BarEnum
 ---------------
 
 DESC Result:
@@ -34,13 +34,13 @@ DESC Result:
         "barEnum": "QUX"
       },
       {
+        "barEnum": "FOO"
+      },
+      {
         "barEnum": "BAZ"
       },
       {
         "barEnum": "BAR"
-      },
-      {
-        "barEnum": "FOO"
       }
     ]
   }
@@ -49,5 +49,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foo as d order by CAST(d.data ->> 'BarEnum' as integer) desc
+from 'Foos' order by BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_Nullable_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_Nullable_NET6_0.snap
@@ -4,7 +4,7 @@ ASC Result:
   "data": {
     "root": [
       {
-        "barEnum": "FOO"
+        "barEnum": null
       },
       {
         "barEnum": "BAR"
@@ -13,10 +13,10 @@ ASC Result:
         "barEnum": "BAZ"
       },
       {
-        "barEnum": "QUX"
+        "barEnum": "FOO"
       },
       {
-        "barEnum": null
+        "barEnum": "QUX"
       }
     ]
   }
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foonullable as d order by CAST(d.data ->> 'BarEnum' as integer)
+from 'FooNullables' order by BarEnum
 ---------------
 
 DESC Result:
@@ -34,10 +34,10 @@ DESC Result:
   "data": {
     "root": [
       {
-        "barEnum": null
+        "barEnum": "QUX"
       },
       {
-        "barEnum": "QUX"
+        "barEnum": "FOO"
       },
       {
         "barEnum": "BAZ"
@@ -46,7 +46,7 @@ DESC Result:
         "barEnum": "BAR"
       },
       {
-        "barEnum": "FOO"
+        "barEnum": null
       }
     ]
   }
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foonullable as d order by CAST(d.data ->> 'BarEnum' as integer) desc
+from 'FooNullables' order by BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_Nullable_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorEnumTests.Create_Enum_OrderBy_Nullable_NET7_0.snap
@@ -4,7 +4,7 @@ ASC Result:
   "data": {
     "root": [
       {
-        "barEnum": "FOO"
+        "barEnum": null
       },
       {
         "barEnum": "BAR"
@@ -13,10 +13,10 @@ ASC Result:
         "barEnum": "BAZ"
       },
       {
-        "barEnum": "QUX"
+        "barEnum": "FOO"
       },
       {
-        "barEnum": null
+        "barEnum": "QUX"
       }
     ]
   }
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foonullable as d order by CAST(d.data ->> 'BarEnum' as integer)
+from 'FooNullables' order by BarEnum
 ---------------
 
 DESC Result:
@@ -34,10 +34,10 @@ DESC Result:
   "data": {
     "root": [
       {
-        "barEnum": null
+        "barEnum": "QUX"
       },
       {
-        "barEnum": "QUX"
+        "barEnum": "FOO"
       },
       {
         "barEnum": "BAZ"
@@ -46,7 +46,7 @@ DESC Result:
         "barEnum": "BAR"
       },
       {
-        "barEnum": "FOO"
+        "barEnum": null
       }
     ]
   }
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorenumtests_foonullable as d order by CAST(d.data ->> 'BarEnum' as integer) desc
+from 'FooNullables' order by BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_List_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_List_NET6_0.snap
@@ -2,12 +2,12 @@ ASC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testatest"
+        "bar": false
       },
       {
-        "bar": "testbtest"
+        "bar": true
       }
     ]
   }
@@ -23,12 +23,12 @@ DESC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testbtest"
+        "bar": true
       },
       {
-        "bar": "testatest"
+        "bar": false
       }
     ]
   }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_List_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_List_NET7_0.snap
@@ -2,12 +2,12 @@ ASC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testatest"
+        "bar": false
       },
       {
-        "bar": "testbtest"
+        "bar": true
       }
     ]
   }
@@ -23,12 +23,12 @@ DESC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testbtest"
+        "bar": true
       },
       {
-        "bar": "testatest"
+        "bar": false
       }
     ]
   }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_NET6_0.snap
@@ -2,12 +2,12 @@ ASC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testatest"
+        "bar": false
       },
       {
-        "bar": "testbtest"
+        "bar": true
       }
     ]
   }
@@ -23,12 +23,12 @@ DESC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testbtest"
+        "bar": true
       },
       {
-        "bar": "testatest"
+        "bar": false
       }
     ]
   }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_NET7_0.snap
@@ -2,12 +2,12 @@ ASC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testatest"
+        "bar": false
       },
       {
-        "bar": "testbtest"
+        "bar": true
       }
     ]
   }
@@ -23,12 +23,12 @@ DESC Result:
 ---------------
 {
   "data": {
-    "root": [
+    "rootExecutable": [
       {
-        "bar": "testbtest"
+        "bar": true
       },
       {
-        "bar": "testatest"
+        "bar": false
       }
     ]
   }

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_Nullable_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_Nullable_NET6_0.snap
@@ -1,8 +1,11 @@
-ASC
+ASC Result:
 ---------------
 {
   "data": {
     "rootExecutable": [
+      {
+        "bar": null
+      },
       {
         "bar": false
       },
@@ -14,7 +17,12 @@ ASC
 }
 ---------------
 
-DESC
+ASC SQL:
+---------------
+from 'FooNullables' order by Bar
+---------------
+
+DESC Result:
 ---------------
 {
   "data": {
@@ -24,8 +32,16 @@ DESC
       },
       {
         "bar": false
+      },
+      {
+        "bar": null
       }
     ]
   }
 }
+---------------
+
+DESC SQL:
+---------------
+from 'FooNullables' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_Nullable_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExecutableTests.Create_Boolean_OrderBy_Nullable_NET7_0.snap
@@ -1,13 +1,37 @@
-ASC
+ASC Result:
 ---------------
 {
   "data": {
     "rootExecutable": [
       {
+        "bar": null
+      },
+      {
         "bar": false
       },
       {
         "bar": true
+      }
+    ]
+  }
+}
+---------------
+
+ASC SQL:
+---------------
+from 'FooNullables' order by Bar
+---------------
+
+DESC Result:
+---------------
+{
+  "data": {
+    "rootExecutable": [
+      {
+        "bar": true
+      },
+      {
+        "bar": false
       },
       {
         "bar": null
@@ -17,21 +41,7 @@ ASC
 }
 ---------------
 
-DESC
+DESC SQL:
 ---------------
-{
-  "data": {
-    "rootExecutable": [
-      {
-        "bar": null
-      },
-      {
-        "bar": true
-      },
-      {
-        "bar": false
-      }
-    ]
-  }
-}
+from 'FooNullables' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExpressionTests.Create_CollectionLengthExpression_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExpressionTests.Create_CollectionLengthExpression_NET6_0.snap
@@ -18,7 +18,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorexpressiontests_foo as d order by jsonb_array_length(CAST(d.data ->> 'Bars' as jsonb))
+from 'Foos' order by Bars.Count as long
 ---------------
 
 DESC Result:
@@ -41,5 +41,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorexpressiontests_foo as d order by jsonb_array_length(CAST(d.data ->> 'Bars' as jsonb)) desc
+from 'Foos' order by Bars.Count as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExpressionTests.Create_CollectionLengthExpression_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorExpressionTests.Create_CollectionLengthExpression_NET7_0.snap
@@ -18,7 +18,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorexpressiontests_foo as d order by jsonb_array_length(CAST(d.data ->> 'Bars' as jsonb))
+from 'Foos' order by Bars.Count as long
 ---------------
 
 DESC Result:
@@ -41,5 +41,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorexpressiontests_foo as d order by jsonb_array_length(CAST(d.data ->> 'Bars' as jsonb)) desc
+from 'Foos' order by Bars.Count as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectBool_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectBool_OrderBy_NET6_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarBool
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectBool_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectBool_OrderBy_NET7_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarBool
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectEnum_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectEnum_OrderBy_NET6_0.snap
@@ -5,17 +5,17 @@ ASC Result:
     "root": [
       {
         "foo": {
-          "barEnum": "FOO"
-        }
-      },
-      {
-        "foo": {
           "barEnum": "BAR"
         }
       },
       {
         "foo": {
           "barEnum": "BAZ"
+        }
+      },
+      {
+        "foo": {
+          "barEnum": "FOO"
         }
       }
     ]
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer)
+from 'Bars' order by Foo.BarEnum
 ---------------
 
 DESC Result:
@@ -35,17 +35,17 @@ DESC Result:
     "root": [
       {
         "foo": {
+          "barEnum": "FOO"
+        }
+      },
+      {
+        "foo": {
           "barEnum": "BAZ"
         }
       },
       {
         "foo": {
           "barEnum": "BAR"
-        }
-      },
-      {
-        "foo": {
-          "barEnum": "FOO"
         }
       }
     ]
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer) desc
+from 'Bars' order by Foo.BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectEnum_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectEnum_OrderBy_NET7_0.snap
@@ -5,17 +5,17 @@ ASC Result:
     "root": [
       {
         "foo": {
-          "barEnum": "FOO"
-        }
-      },
-      {
-        "foo": {
           "barEnum": "BAR"
         }
       },
       {
         "foo": {
           "barEnum": "BAZ"
+        }
+      },
+      {
+        "foo": {
+          "barEnum": "FOO"
         }
       }
     ]
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer)
+from 'Bars' order by Foo.BarEnum
 ---------------
 
 DESC Result:
@@ -35,17 +35,17 @@ DESC Result:
     "root": [
       {
         "foo": {
+          "barEnum": "FOO"
+        }
+      },
+      {
+        "foo": {
           "barEnum": "BAZ"
         }
       },
       {
         "foo": {
           "barEnum": "BAR"
-        }
-      },
-      {
-        "foo": {
-          "barEnum": "FOO"
         }
       }
     ]
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer) desc
+from 'Bars' order by Foo.BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableBool_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableBool_OrderBy_NET6_0.snap
@@ -4,6 +4,14 @@ ASC Result:
   "data": {
     "root": [
       {
+        "foo": null
+      },
+      {
+        "foo": {
+          "barBool": null
+        }
+      },
+      {
         "foo": {
           "barBool": false
         }
@@ -17,14 +25,6 @@ ASC Result:
         "foo": {
           "barBool": true
         }
-      },
-      {
-        "foo": {
-          "barBool": null
-        }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'BarNullables' order by Foo.BarBool
 ---------------
 
 13 Result:
@@ -43,14 +43,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
     "root": [
       {
         "foo": {
-          "barBool": null
-        }
-      },
-      {
-        "foo": null
-      },
-      {
-        "foo": {
           "barBool": true
         }
       },
@@ -63,6 +55,14 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barBool": false
         }
+      },
+      {
+        "foo": {
+          "barBool": null
+        }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'BarNullables' order by Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableBool_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableBool_OrderBy_NET7_0.snap
@@ -4,6 +4,14 @@ ASC Result:
   "data": {
     "root": [
       {
+        "foo": null
+      },
+      {
+        "foo": {
+          "barBool": null
+        }
+      },
+      {
         "foo": {
           "barBool": false
         }
@@ -17,14 +25,6 @@ ASC Result:
         "foo": {
           "barBool": true
         }
-      },
-      {
-        "foo": {
-          "barBool": null
-        }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'BarNullables' order by Foo.BarBool
 ---------------
 
 13 Result:
@@ -43,14 +43,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
     "root": [
       {
         "foo": {
-          "barBool": null
-        }
-      },
-      {
-        "foo": null
-      },
-      {
-        "foo": {
           "barBool": true
         }
       },
@@ -63,6 +55,14 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barBool": false
         }
+      },
+      {
+        "foo": {
+          "barBool": null
+        }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'BarNullables' order by Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableEnum_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableEnum_OrderBy_NET6_0.snap
@@ -4,9 +4,7 @@ ASC Result:
   "data": {
     "root": [
       {
-        "foo": {
-          "barEnum": "FOO"
-        }
+        "foo": null
       },
       {
         "foo": {
@@ -20,11 +18,13 @@ ASC Result:
       },
       {
         "foo": {
-          "barEnum": "QUX"
+          "barEnum": "FOO"
         }
       },
       {
-        "foo": null
+        "foo": {
+          "barEnum": "QUX"
+        }
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer)
+from 'BarNullables' order by Foo.BarEnum
 ---------------
 
 13 Result:
@@ -42,11 +42,13 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
   "data": {
     "root": [
       {
-        "foo": null
+        "foo": {
+          "barEnum": "QUX"
+        }
       },
       {
         "foo": {
-          "barEnum": "QUX"
+          "barEnum": "FOO"
         }
       },
       {
@@ -60,9 +62,7 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         }
       },
       {
-        "foo": {
-          "barEnum": "FOO"
-        }
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer) desc
+from 'BarNullables' order by Foo.BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableEnum_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableEnum_OrderBy_NET7_0.snap
@@ -4,9 +4,7 @@ ASC Result:
   "data": {
     "root": [
       {
-        "foo": {
-          "barEnum": "FOO"
-        }
+        "foo": null
       },
       {
         "foo": {
@@ -20,11 +18,13 @@ ASC Result:
       },
       {
         "foo": {
-          "barEnum": "QUX"
+          "barEnum": "FOO"
         }
       },
       {
-        "foo": null
+        "foo": {
+          "barEnum": "QUX"
+        }
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer)
+from 'BarNullables' order by Foo.BarEnum
 ---------------
 
 13 Result:
@@ -42,11 +42,13 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
   "data": {
     "root": [
       {
-        "foo": null
+        "foo": {
+          "barEnum": "QUX"
+        }
       },
       {
         "foo": {
-          "barEnum": "QUX"
+          "barEnum": "FOO"
         }
       },
       {
@@ -60,9 +62,7 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         }
       },
       {
-        "foo": {
-          "barEnum": "FOO"
-        }
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarEnum' as integer) desc
+from 'BarNullables' order by Foo.BarEnum desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableShort_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableShort_OrderBy_NET6_0.snap
@@ -5,6 +5,14 @@ ASC Result:
     "root": [
       {
         "foo": {
+          "barShort": null
+        }
+      },
+      {
+        "foo": null
+      },
+      {
+        "foo": {
           "barShort": 12
         }
       },
@@ -17,14 +25,6 @@ ASC Result:
         "foo": {
           "barShort": 14
         }
-      },
-      {
-        "foo": {
-          "barShort": null
-        }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'BarNullables' order by Foo.BarShort as long
 ---------------
 
 13 Result:
@@ -43,14 +43,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
     "root": [
       {
         "foo": {
-          "barShort": null
-        }
-      },
-      {
-        "foo": null
-      },
-      {
-        "foo": {
           "barShort": 14
         }
       },
@@ -63,6 +55,14 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barShort": 12
         }
+      },
+      {
+        "foo": {
+          "barShort": null
+        }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'BarNullables' order by Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableShort_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableShort_OrderBy_NET7_0.snap
@@ -5,6 +5,14 @@ ASC Result:
     "root": [
       {
         "foo": {
+          "barShort": null
+        }
+      },
+      {
+        "foo": null
+      },
+      {
+        "foo": {
           "barShort": 12
         }
       },
@@ -17,14 +25,6 @@ ASC Result:
         "foo": {
           "barShort": 14
         }
-      },
-      {
-        "foo": {
-          "barShort": null
-        }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'BarNullables' order by Foo.BarShort as long
 ---------------
 
 13 Result:
@@ -43,14 +43,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
     "root": [
       {
         "foo": {
-          "barShort": null
-        }
-      },
-      {
-        "foo": null
-      },
-      {
-        "foo": {
           "barShort": 14
         }
       },
@@ -63,6 +55,14 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barShort": 12
         }
+      },
+      {
+        "foo": {
+          "barShort": null
+        }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'BarNullables' order by Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableString_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableString_OrderBy_NET6_0.snap
@@ -4,6 +4,9 @@ ASC Result:
   "data": {
     "root": [
       {
+        "foo": null
+      },
+      {
         "foo": {
           "barString": "testatest"
         }
@@ -22,9 +25,6 @@ ASC Result:
         "foo": {
           "barString": "testdtest"
         }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by d.data -> 'Foo' ->> 'BarString'
+from 'BarNullables' order by Foo.BarString
 ---------------
 
 13 Result:
@@ -41,9 +41,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 {
   "data": {
     "root": [
-      {
-        "foo": null
-      },
       {
         "foo": {
           "barString": "testdtest"
@@ -63,6 +60,9 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barString": "testatest"
         }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by d.data -> 'Foo' ->> 'BarString' desc
+from 'BarNullables' order by Foo.BarString desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableString_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectNullableString_OrderBy_NET7_0.snap
@@ -4,6 +4,9 @@ ASC Result:
   "data": {
     "root": [
       {
+        "foo": null
+      },
+      {
         "foo": {
           "barString": "testatest"
         }
@@ -22,9 +25,6 @@ ASC Result:
         "foo": {
           "barString": "testdtest"
         }
-      },
-      {
-        "foo": null
       }
     ]
   }
@@ -33,7 +33,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by d.data -> 'Foo' ->> 'BarString'
+from 'BarNullables' order by Foo.BarString
 ---------------
 
 13 Result:
@@ -41,9 +41,6 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 {
   "data": {
     "root": [
-      {
-        "foo": null
-      },
       {
         "foo": {
           "barString": "testdtest"
@@ -63,6 +60,9 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
         "foo": {
           "barString": "testatest"
         }
+      },
+      {
+        "foo": null
       }
     ]
   }
@@ -71,5 +71,5 @@ select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullab
 
 13 SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_barnullable as d order by d.data -> 'Foo' ->> 'BarString' desc
+from 'BarNullables' order by Foo.BarString desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectShort_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectShort_OrderBy_NET6_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarShort as long
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectShort_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectShort_OrderBy_NET7_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarShort as long
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_NET6_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by d.data -> 'Foo' ->> 'BarString'
+from 'Bars' order by Foo.BarString
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by d.data -> 'Foo' ->> 'BarString' desc
+from 'Bars' order by Foo.BarString desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_NET7_0.snap
@@ -25,7 +25,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by d.data -> 'Foo' ->> 'BarString'
+from 'Bars' order by Foo.BarString
 ---------------
 
 DESC Result:
@@ -55,5 +55,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by d.data -> 'Foo' ->> 'BarString' desc
+from 'Bars' order by Foo.BarString desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_NET6_0.snap
@@ -28,7 +28,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean), CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarBool, Foo.BarShort as long
 ---------------
 
 ASC Result:
@@ -61,7 +61,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean), CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarBool, Foo.BarShort as long
 ---------------
 
 DESC Result:
@@ -94,7 +94,7 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc, CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarBool desc, Foo.BarShort as long desc
 ---------------
 
 DESC Result:
@@ -127,5 +127,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc, CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarBool desc, Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_NET7_0.snap
@@ -28,7 +28,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean), CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarBool, Foo.BarShort as long
 ---------------
 
 ASC Result:
@@ -61,7 +61,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean), CAST(d.data -> 'Foo' ->> 'BarShort' as smallint)
+from 'Bars' order by Foo.BarBool, Foo.BarShort as long
 ---------------
 
 DESC Result:
@@ -94,7 +94,7 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc, CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarBool desc, Foo.BarShort as long desc
 ---------------
 
 DESC Result:
@@ -127,5 +127,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc, CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc
+from 'Bars' order by Foo.BarBool desc, Foo.BarShort as long desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_Variables_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_Variables_NET6_0.snap
@@ -28,7 +28,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint), CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarShort as long, Foo.BarBool
 ---------------
 
 ASC Result:
@@ -61,7 +61,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint), CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarShort as long, Foo.BarBool
 ---------------
 
 DESC Result:
@@ -94,7 +94,7 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc, CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarShort as long desc, Foo.BarBool desc
 ---------------
 
 DESC Result:
@@ -127,5 +127,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc, CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarShort as long desc, Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_Variables_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorObjectTests.Create_ObjectString_OrderBy_TwoProperties_Variables_NET7_0.snap
@@ -28,7 +28,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint), CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarShort as long, Foo.BarBool
 ---------------
 
 ASC Result:
@@ -61,7 +61,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint), CAST(d.data -> 'Foo' ->> 'BarBool' as boolean)
+from 'Bars' order by Foo.BarShort as long, Foo.BarBool
 ---------------
 
 DESC Result:
@@ -94,7 +94,7 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc, CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarShort as long desc, Foo.BarBool desc
 ---------------
 
 DESC Result:
@@ -127,5 +127,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorobjecttests_bar as d order by CAST(d.data -> 'Foo' ->> 'BarShort' as smallint) desc, CAST(d.data -> 'Foo' ->> 'BarBool' as boolean) desc
+from 'Bars' order by Foo.BarShort as long desc, Foo.BarBool desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_NET7_0.snap
@@ -16,7 +16,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foo as d order by d.data ->> 'Bar'
+from 'Foos' order by Bar
 ---------------
 
 DESC Result:
@@ -37,5 +37,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foo as d order by d.data ->> 'Bar' desc
+from 'Foos' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_Nullable_NET6_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_Nullable_NET6_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
+        "bar": null
+      },
+      {
         "bar": "testatest"
       },
       {
         "bar": "testbtest"
-      },
-      {
-        "bar": null
       }
     ]
   }
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foonullable as d order by d.data ->> 'Bar'
+from 'FooNullables' order by Bar
 ---------------
 
 DESC Result:
@@ -28,13 +28,13 @@ DESC Result:
   "data": {
     "root": [
       {
-        "bar": null
-      },
-      {
         "bar": "testbtest"
       },
       {
         "bar": "testatest"
+      },
+      {
+        "bar": null
       }
     ]
   }
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foonullable as d order by d.data ->> 'Bar' desc
+from 'FooNullables' order by Bar desc
 ---------------

--- a/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_Nullable_NET7_0.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Sorting.Tests/__snapshots__/QueryableSortVisitorStringTests.Create_String_OrderBy_Nullable_NET7_0.snap
@@ -4,13 +4,13 @@ ASC Result:
   "data": {
     "root": [
       {
+        "bar": null
+      },
+      {
         "bar": "testatest"
       },
       {
         "bar": "testbtest"
-      },
-      {
-        "bar": null
       }
     ]
   }
@@ -19,7 +19,7 @@ ASC Result:
 
 ASC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foonullable as d order by d.data ->> 'Bar'
+from 'FooNullables' order by Bar
 ---------------
 
 DESC Result:
@@ -28,13 +28,13 @@ DESC Result:
   "data": {
     "root": [
       {
-        "bar": null
-      },
-      {
         "bar": "testbtest"
       },
       {
         "bar": "testatest"
+      },
+      {
+        "bar": null
       }
     ]
   }
@@ -43,5 +43,5 @@ DESC Result:
 
 DESC SQL:
 ---------------
-select d.id, d.data from public.mt_doc_queryablesortvisitorstringtests_foonullable as d order by d.data ->> 'Bar' desc
+from 'FooNullables' order by Bar desc
 ---------------


### PR DESCRIPTION
- Adds filtering to ravendb (#5772)
- Add paging to ravendb (#5777)
- Rollback filtering changes (#5778)
- Adds missing filtering operations for raven (#5781)
- Adds executable for RavenDb (#5782)
- Adds sorting support to ravendb

Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Closes #bugnumber (in this specific format)
