### PR TITLE
Make DefaultTypeInspector.CanBeHandled virtual

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -684,7 +684,7 @@ public class DefaultTypeInspector : Convention, ITypeInspector
         return false;
     }
 
-    private bool CanBeHandled(
+    protected virtual bool CanBeHandled(
         MemberInfo member,
         bool includeIgnored,
         bool allowObjectType)


### PR DESCRIPTION
This one-liner enables custom type inspectors to automatically handle members that return System.Object as the GraphQL Any scalar. Currently `DefaultTypeInspector.CanBeHandled`, as well as every other method it relies on, is private, and cannot be reimplemented by a custom type inspector without copying large chunks of HC code.

This change is sort of an inverse to #4306.