### PR TITLE
Feature/apollo federation docs

### DIFF
--- a/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
@@ -6,7 +6,7 @@ Hot Chocolate includes an implementation of the Apollo Federation v2 specificati
 
 [Apollo Federation documentation](https://www.apollographql.com/docs/federation/) provides a robust explanation of the different foundational concepts and principles that are referenced through the rest of this document.
 
-## Get Started
+# Get Started
 To use the Apollo Federation tools, you need to first install v12.6 or later of the `HotChocolate.ApolloFederation` package.
 
 <PackageInstallation packageName="HotChocolate.ApolloFederation"/>
@@ -20,5 +20,90 @@ services.AddGraphQLServer()
     .AddApolloFederation();
 ```
 
-## Defining an entity
-We'll first need to define an **entity**&mdash;an object type that can resolve its fields across multiple subgraphs&mdash;within the subgraph. To do this,
+# Defining an entity
+We'll first need to define an **entity**&mdash;an object type that can resolve its fields across multiple subgraphs. We'll work with a `Product` entity to provide an example of how to do this.
+
+```csharp
+public class Product
+{
+    [GraphQLType(typeof(NonNullType<IdType>))]
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public float Price { get; set; }
+}
+```
+
+Now that we have a type, we need to take the following steps:
+
+1. [Define a key](https://www.apollographql.com/docs/federation/entities#1-define-a-key) for the entity by marking one or more properties with the `[Key]` attribute.
+```csharp
+public class Product
+{
+    [GraphQLType(typeof(NonNullType<IdType>))]
+    [Key]
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public float Price { get; set; }
+}
+```
+
+2. [Define an entity reference resolver](https://www.apollographql.com/docs/federation/entities#2-define-a-reference-resolver) by creating a `static` method and annotating it with the `[ReferenceResolver]` attribute. **Note**: if you're using [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references), you should make sure the return type is marked as possibly null.
+```csharp
+public class Product
+{
+    [GraphQLType(typeof(NonNullType<IdType>))]
+    [Key]
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+
+    public float Price { get; set; }
+
+    // Note: there is no constraint on the name of the method
+    [ReferenceResolver]
+    public static async Task<Product?> ResolveReference(
+        // Represents the value that would be in the Id property of a Product
+        string id,
+        // Example of a service that can resolve the Products; a dataloader
+        // is recommended to help avoid N+1 queries within the API
+        ProductBatchDataLoader dataLoader
+    )
+    {
+        return await dataloader.LoadAsync(id);
+    }
+}
+```
+
+Once the type has a key or keys, and has a reference resolver defined, you can register the type in the GraphQL schema, which will register it as a type within the GraphQL API itself as well as within the [auto-generated `_service { sdl }` field](https://www.apollographql.com/docs/federation/subgraph-spec/#required-resolvers-for-introspection) within the API.
+
+_Entity type registration_
+```csharp
+services.AddGraphQLServer()
+    .AddApolloFederation()
+    .AddType<Product>()
+    // other registrations...
+    ;
+
+```
+
+_Apollo Federation SDL query_
+```graphql
+query {
+  _service { sdl }
+}
+```
+
+_Example SDL response_
+```json
+{
+  "data": {
+    "_service": {
+      "sdl": "type Product @key(fields: \"id\") {\r\n  id: ID!\r\n  name: String!\r\n  price: Float!\r\n}"
+    }
+  }
+}
+```

--- a/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
@@ -2,6 +2,23 @@
 title: Apollo Federation Subgraph Support
 ---
 
-> Note: Apollo Federation Support is coming with Hot Chocolate 12.6
+Hot Chocolate includes an implementation of the Apollo Federation v2 specification for creating Apollo Federated subgraphs. Through Apollo Federation, you can combine multiple GraphQL APIs into a single API for your consumers.
 
-## Example subgraphs
+[Apollo Federation documentation](https://www.apollographql.com/docs/federation/) provides a robust explanation of the different foundational concepts and principles that are referenced through the rest of this document.
+
+## Get Started
+To use the Apollo Federation tools, you need to first install v12.6 or later of the `HotChocolate.ApolloFederation` package.
+
+<PackageInstallation packageName="HotChocolate.ApolloFederation"/>
+
+After installing the necessary package, you'll need to register the Apollo Federation services with the GraphQL server.
+
+```csharp
+IServiceCollection services;
+
+services.AddGraphQLServer()
+    .AddApolloFederation();
+```
+
+## Defining an entity
+We'll first need to define an **entity**&mdash;an object type that can resolve its fields across multiple subgraphs&mdash;within the subgraph. To do this,

--- a/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
@@ -51,7 +51,9 @@ public class Product
 }
 ```
 
-2. [Define an entity reference resolver](https://www.apollographql.com/docs/federation/entities#2-define-a-reference-resolver) by creating a `static` method and annotating it with the `[ReferenceResolver]` attribute. **Note**: if you're using [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references), you should make sure the return type is marked as possibly null.
+2. [Define an entity reference resolver](https://www.apollographql.com/docs/federation/entities#2-define-a-reference-resolver) by creating a `static` method and annotating it with the `[ReferenceResolver]` attribute.
+    1. The parameter name and type used in the reference resolver **must match** the GraphQL field name of the `[Key]` attribute, e.g., if the GraphQL key field is `id: String!` or `id: ID!` then the reference resolver's paramter must be `string id`.
+    1. If you're using [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references), you should make sure the return type is marked as possibly null.
 ```csharp
 public class Product
 {
@@ -75,6 +77,18 @@ public class Product
     {
         return await dataloader.LoadAsync(id);
     }
+}
+```
+
+> If you have multiple keys for your API, you should include a reference resolver for each one so that the supergraph is able to resolve your entity regardless of which key(s) another graph uses.
+```csharp
+public class Product
+{
+    [Key]
+    public string Id { get; set; }
+
+    [Key]
+    public int Sku { get; set; }
 }
 ```
 
@@ -107,3 +121,9 @@ _Example SDL response_
   }
 }
 ```
+
+## Testing and executing your resolvers
+The `[ReferenceResolver]`
+
+# Extending an entity type
+TODO

--- a/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
+++ b/website/src/docs/hotchocolate/v12/api-reference/apollo-federation.md
@@ -1,10 +1,11 @@
 ---
 title: Apollo Federation Subgraph Support
 ---
+> If you want to read more about Apollo Federation in general, you can head over to the [Apollo Federation documentation](https://www.apollographql.com/docs/federation/), which provides a robust overview and set of examples for this GraphQL architectural pattern. Many of the core principles and concepts are refernced within this document.
 
 Hot Chocolate includes an implementation of the Apollo Federation v2 specification for creating Apollo Federated subgraphs. Through Apollo Federation, you can combine multiple GraphQL APIs into a single API for your consumers.
 
-[Apollo Federation documentation](https://www.apollographql.com/docs/federation/) provides a robust explanation of the different foundational concepts and principles that are referenced through the rest of this document.
+TODO: highlight scope of the document
 
 # Get Started
 To use the Apollo Federation tools, you need to first install v12.6 or later of the `HotChocolate.ApolloFederation` package.
@@ -51,7 +52,9 @@ public class Product
 ```
 
 ## Define a reference resolver
-Next, we'll need to [define an entity reference resolver](https://www.apollographql.com/docs/federation/entities#2-define-a-reference-resolver) so that the supergraph can resolve data across multiple graphs during a query. We do this by creating a `public static` method and annotating it with the `[ReferenceResolver]` attribute.
+Next, we'll need to [define an entity reference resolver](https://www.apollographql.com/docs/federation/entities#2-define-a-reference-resolver) so that the supergraph can resolve data across multiple graphs during a query. A reference resolver is similar to many other [data resolvers in Hot Chocolate](docs/hotchocolate/v12/fetching-data/resolvers) with some key requirements:
+1. They must be `public static` methods within the type they are resolving
+1. They must be annotated with the `[ReferenceResolver]` attribute
 ```csharp
 public class Product
 {
@@ -77,11 +80,11 @@ public class Product
 ```
 
 Some important details to highlight about `[ReferenceResolver]` methods.
-1. The name of the method decorated with the `[ReferenceResolver]` attribute does not matter. However, as with all programming endeavors, you should aim to provide a descriptive name for your method to make your code easier to read and navigate.
+1. The name of the method decorated with the `[ReferenceResolver]` attribute does not matter. However, as with all programming endeavors, you should aim to provide a descriptive name that reveals the method's intention.
 1. The parameter name and type used in the reference resolver **must match** the GraphQL field name of the `[Key]` attribute, e.g., if the GraphQL key field is `id: String!` or `id: ID!` then the reference resolver's paramter must be `string id`.
 1. If you're using [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references), you should make sure the return type is marked as possibly null.
-1. It's recommended to use a [dataloader](../fetching-data/dataloader.md) to fetch the data in a reference resolver. This helps the API avoid [an N+1 problem](https://www.apollographql.com/docs/federation/entities-advanced#handling-the-n1-problem) when a query resolves multiple items from a given subgrpah.
-1. If you have multiple keys defined for an entity, you should include a reference resolver for each one so that the supergraph is able to resolve your entity regardless of which key(s) another graph uses to reference that entity.
+1. It's recommended to use a [dataloader](/docs/hotchocolate/v12/fetching-data/dataloader) to fetch the data in a reference resolver. This helps the API avoid [an N+1 problem](https://www.apollographql.com/docs/federation/entities-advanced#handling-the-n1-problem) when a query resolves multiple items from a given subgrpah.
+1. If you have multiple keys defined for an entity, you should include a reference resolver for _each key_ so that the supergraph is able to resolve your entity regardless of which key(s) another graph uses to reference that entity.
 ```csharp
 public class Product
 {
@@ -105,8 +108,8 @@ public class Product
 }
 ```
 
-### Register the entity
-Once the type has a key or keys, and has a reference resolver defined, you can register the type in the GraphQL schema, which will register it as a type within the GraphQL API itself as well as within the [auto-generated `_service { sdl }` field](https://www.apollographql.com/docs/federation/subgraph-spec/#required-resolvers-for-introspection) within the API.
+## Register the entity
+Once the type has a key or keys and a reference resolver defined, you can register the type in the GraphQL schema, which will register it as a type within the GraphQL API itself as well as within the [auto-generated `_service { sdl }` field](https://www.apollographql.com/docs/federation/subgraph-spec/#required-resolvers-for-introspection) within the API.
 
 _Entity type registration_
 ```csharp
@@ -137,7 +140,7 @@ _Example SDL response_
 ```
 
 ### Testing and executing your resolvers
-The `[ReferenceResolver]`
+TODO
 
 # Extending an entity type
 TODO


### PR DESCRIPTION
## Summary
Updated the Hot Chocolate documentation to describe the Apollo Federation library.

-[x] Documentation on creating an entity type
-[] Documentation on testing a `[ReferenceResolver]`
-[] Documentation on extending an entity type

## Context
My team has been implementing an Apollo Federated GraphQL API using Hot Chocolate. As a way to help both my team and other developers in the community, I wanted to get the Apollo Federation documentation built out to help future developers take advantage of these tools within the framework.

I'm open to suggestions on content structure, or additional elements that should be included in the documentation, as I'm filling out information mostly from my experiences with the library at this point and I'm sure I don't know the whole set of capabilities the library has to offer yet.