### PR TITLE
Fix wrong code in operation complexity documentation

### DIFF
--- a/website/src/docs/hotchocolate/v12/security/operation-complexity.md
+++ b/website/src/docs/hotchocolate/v12/security/operation-complexity.md
@@ -142,7 +142,7 @@ services
     {
         o.Complexity.ApplyDefaults = true;
         o.Complexity.DefaultComplexity = 1;
-        o.Complexity.DefaultDataResolverComplexity = 5;
+        o.Complexity.DefaultResolverComplexity = 5;
     });
 ```
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fix code in documentation, as it didn't compile for me

![image](https://user-images.githubusercontent.com/3625477/218437696-b95db5fa-520b-460e-90ee-96f1243ee33b.png)

I am not sure if this change should also be applied to other versions of the documentation