### PR TITLE
Use structs with non-default constructors as input types w/o configuring

### DIFF
--- a/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectConstructorResolver.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/Serialization/InputObjectConstructorResolver.cs
@@ -24,7 +24,7 @@ internal static class InputObjectConstructorResolver
 
         if (AllPropertiesCanWrite(fields))
         {
-            if (constructors.Length == 0)
+            if (constructors.Length == 0 || type.IsValueType)
             {
                 return null;
             }


### PR DESCRIPTION
**Product**: HotChocolate

Currently structs with all writable properties and non-default constructors cannot be used as input types without explicit configuration (schema build fails with `No compatible constructor found for input type type 'T'`). However structs always have an implicit default constructor, which is used by `Expression.New(type)`.