### PR TITLE
Bug Reproduction

### DIFF
--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/SchemaGeneratorTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/SchemaGeneratorTests.cs
@@ -74,6 +74,13 @@ public class SchemaGeneratorTests
                     query: Query
                 }
 
+                # Breaks generation
+                scalar JSON
+
+                type TypeWithJsonScalar {
+                    json: JSON
+                }
+
                 type Query {
                     newsItems(skip: Int take: Int query: String!): NewsItemCollectionSegment
                 }


### PR DESCRIPTION
```
[xUnit.net 00:00:12.30]     StrawberryShake.CodeGeneration.CSharp.SchemaGeneratorTests.Create_Query_With_Skip_Take [FAIL]
  Failed StrawberryShake.CodeGeneration.CSharp.SchemaGeneratorTests.Create_Query_With_Skip_Take [8 ms]
  Error Message:
   HotChocolate.SchemaException : For more details look at the `Errors` property.

1. An item with the same key has already been added. Key: JSON

  Stack Trace:
     at HotChocolate.Configuration.TypeInitializer.DiscoverTypes() in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs:line 133
   at HotChocolate.Configuration.TypeInitializer.Initialize() in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs:line 81
   at HotChocolate.SchemaBuilder.Setup.InitializeTypes(SchemaBuilder builder, IDescriptorContext context, IReadOnlyList`1 types) in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs:line 198
   at HotChocolate.SchemaBuilder.Setup.Create(SchemaBuilder builder, LazySchema lazySchema, IDescriptorContext context) in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs:line 63
   at HotChocolate.SchemaBuilder.Setup.Create(SchemaBuilder builder) in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs:line 28
   at HotChocolate.SchemaBuilder.Create() in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/SchemaBuilder.Create.cs:line 10
   at HotChocolate.SchemaBuilder.HotChocolate.ISchemaBuilder.Create() in /Users/cliedeman/projects/github.com/ChilliCream/hotchocolate/src/HotChocolate/Core/src/Types/SchemaBuilder.Create.cs:line 29
```

Ref: #5904