### PR TITLE
Add TypeContext parameter to ITypeInspector.GetMembers

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -47,6 +47,7 @@ public class DefaultTypeInspector : Convention, ITypeInspector
     /// <inheritdoc />
     public ReadOnlySpan<MemberInfo> GetMembers(
         Type type,
+        TypeContext context,
         bool includeIgnored = false,
         bool includeStatic = false,
         bool allowObject = false)
@@ -290,7 +291,7 @@ public class DefaultTypeInspector : Convention, ITypeInspector
             throw new ArgumentNullException(nameof(type));
         }
 
-        foreach (var member in GetMembers(type))
+        foreach (var member in GetMembers(type, TypeContext.Output))
         {
             if (member.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
                 member.Name.Equals("GetId", StringComparison.OrdinalIgnoreCase) ||
@@ -346,7 +347,7 @@ public class DefaultTypeInspector : Convention, ITypeInspector
 
         // if there is no static load method we will move on the check
         // for instance load methods.
-        foreach (var member in GetMembers(resolverType))
+        foreach (var member in GetMembers(resolverType, TypeContext.Output))
         {
             if (member is MethodInfo m && IsPossibleExternalNodeResolver(m, nodeType))
             {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ITypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ITypeInspector.cs
@@ -20,6 +20,9 @@ public interface ITypeInspector : IConvention
     /// <param name="type">
     /// The type that represents the object type.
     /// </param>
+    /// <param name="context">
+    /// The context defines if members are requested in an input or output context.
+    /// </param>
     /// <param name="includeIgnored">
     /// Specifies if also by default ignored members shall be returned.
     /// </param>
@@ -34,6 +37,7 @@ public interface ITypeInspector : IConvention
     /// </returns>
     ReadOnlySpan<MemberInfo> GetMembers(
         Type type,
+        TypeContext context,
         bool includeIgnored = false,
         bool includeStatic = false,
         bool allowObject = false);

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/DirectiveTypeDescriptor~1.cs
@@ -41,6 +41,7 @@ public class DirectiveTypeDescriptor<T>
         {
             FieldDescriptorUtilities.AddImplicitFields(
                 this,
+                TypeContext.None,
                 p => DirectiveArgumentDescriptor
                     .New(Context, p)
                     .CreateDefinition(),

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InputObjectTypeDescriptor.cs
@@ -106,7 +106,7 @@ public class InputObjectTypeDescriptor
             var inspector = Context.TypeInspector;
             var naming = Context.Naming;
             var type = Definition.RuntimeType;
-            var members = inspector.GetMembers(type);
+            var members = inspector.GetMembers(type, TypeContext.Input);
 
             foreach (var member in members)
             {

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor~1.cs
@@ -39,6 +39,7 @@ public class InterfaceTypeDescriptor<T>
         {
             FieldDescriptorUtilities.AddImplicitFields(
                 this,
+                TypeContext.Output,
                 p => InterfaceFieldDescriptor.New(Context, p).CreateDefinition(),
                 fields,
                 handledMembers);

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/ObjectTypeDescriptor.cs
@@ -143,7 +143,7 @@ public class ObjectTypeDescriptor
             var type = Definition.FieldBindingType;
             var isExtension = Definition.IsExtension;
             var includeStatic = (Definition.FieldBindingFlags & Static) == Static;
-            var members = inspector.GetMembers(type, isExtension, includeStatic);
+            var members = inspector.GetMembers(type, TypeContext.Output, isExtension, includeStatic);
 
             foreach (var member in members)
             {

--- a/src/HotChocolate/Core/src/Types/Types/Helpers/FieldDescriptorUtilities.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Helpers/FieldDescriptorUtilities.cs
@@ -36,6 +36,7 @@ public static class FieldDescriptorUtilities
 
     public static void AddImplicitFields<TDescriptor, TMember, TField>(
         TDescriptor descriptor,
+        TypeContext typeContext,
         Func<TMember, TField> createdFieldDefinition,
         IDictionary<string, TField> fields,
         ISet<TMember> handledMembers)
@@ -46,6 +47,7 @@ public static class FieldDescriptorUtilities
         AddImplicitFields(
             descriptor,
             descriptor.RuntimeType,
+            typeContext,
             createdFieldDefinition,
             fields,
             handledMembers);
@@ -54,6 +56,7 @@ public static class FieldDescriptorUtilities
     public static void AddImplicitFields<TDescriptor, TMember, TField>(
         TDescriptor descriptor,
         Type fieldBindingType,
+        TypeContext typeContext,
         Func<TMember, TField> createdFieldDefinition,
         IDictionary<string, TField> fields,
         ISet<TMember> handledMembers,
@@ -68,7 +71,7 @@ public static class FieldDescriptorUtilities
             var inspector = descriptor.Context.TypeInspector;
             var members = new List<TMember>();
 
-            foreach (var member in inspector.GetMembers(fieldBindingType, includeIgnoredMembers))
+            foreach (var member in inspector.GetMembers(fieldBindingType, typeContext, includeIgnoredMembers))
             {
                 if (member is TMember m)
                 {

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/ResolverTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/ResolverTypeInterceptor.cs
@@ -162,7 +162,7 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
         CompletionContext context,
         ObjectTypeDefinition objectTypeDef)
     {
-        CollectResolverMembers(context, objectTypeDef.Name);
+        CollectResolverMembers(context, objectTypeDef.Name, TypeContext.Output);
 
         if (context.Members.Count > 0)
         {
@@ -241,7 +241,7 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
         {
             if (!initialized && field.Member is null)
             {
-                CollectSourceMembers(context, objectTypeDef.RuntimeType);
+                CollectSourceMembers(context, objectTypeDef.RuntimeType, TypeContext.Output);
                 initialized = true;
             }
 
@@ -297,7 +297,7 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
         {
             if (!initialized && field.Property is null)
             {
-                CollectSourceMembers(context, inputTypeDef.RuntimeType);
+                CollectSourceMembers(context, inputTypeDef.RuntimeType, TypeContext.Input);
                 initialized = true;
             }
 
@@ -356,7 +356,7 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
         context.ValuesToName.Clear();
     }
 
-    private void CollectResolverMembers(CompletionContext context, string typeName)
+    private void CollectResolverMembers(CompletionContext context, string typeName, TypeContext typeContext)
     {
         if (!_resolverTypes.Contains(typeName))
         {
@@ -365,13 +365,13 @@ internal sealed class ResolverTypeInterceptor : TypeInterceptor
 
         foreach (var resolverType in _resolverTypes[typeName])
         {
-            CollectSourceMembers(context, resolverType);
+            CollectSourceMembers(context, resolverType, typeContext);
         }
     }
 
-    private void CollectSourceMembers(CompletionContext context, Type runtimeType)
+    private void CollectSourceMembers(CompletionContext context, Type runtimeType, TypeContext typeContext)
     {
-        foreach (var member in _typeInspector.GetMembers(runtimeType, allowObject: true))
+        foreach (var member in _typeInspector.GetMembers(runtimeType, typeContext, allowObject: true))
         {
             var name = _naming.GetMemberName(member, MemberKind.ObjectField);
             context.Members[name] = member;

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
@@ -17,7 +17,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(ObjectPropWithTypeAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(ObjectPropWithTypeAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -32,7 +32,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(ObjectPropWithDescriptorAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(ObjectPropWithDescriptorAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -47,7 +47,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(ObjectMethodWithTypeAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(ObjectMethodWithTypeAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -62,7 +62,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(ObjectMethodWithDescriptorAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(ObjectMethodWithDescriptorAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -78,7 +78,7 @@ public class DefaultTypeInspectorTests
         // act
         var discovered =
             typeInspector.GetMembers(
-                typeof(MethodAndObjectParameterWithTypeAttribute)).ToArray();
+                typeof(MethodAndObjectParameterWithTypeAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -94,7 +94,7 @@ public class DefaultTypeInspectorTests
         // act
         var discovered =
             typeInspector.GetMembers(
-                typeof(MethodAndObjectParameterWithDescriptorAttribute)).ToArray();
+                typeof(MethodAndObjectParameterWithDescriptorAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -109,7 +109,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(TaskObjectMethodWithTypeAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(TaskObjectMethodWithTypeAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -124,7 +124,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(TaskObjectMethodWithDescriptorAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(TaskObjectMethodWithDescriptorAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -139,7 +139,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var discovered =
-            typeInspector.GetMembers(typeof(ValueTaskObjectMethodWithTypeAttribute)).ToArray();
+            typeInspector.GetMembers(typeof(ValueTaskObjectMethodWithTypeAttribute), TypeContext.None).ToArray();
 
         // assert
         Assert.Collection(discovered,
@@ -155,7 +155,7 @@ public class DefaultTypeInspectorTests
         // act
         var discovered =
             typeInspector.GetMembers(
-                    typeof(ValueTaskObjectMethodWithDescriptorAttribute))
+                    typeof(ValueTaskObjectMethodWithDescriptorAttribute), TypeContext.None)
                 .ToArray();
 
         // assert
@@ -633,7 +633,7 @@ public class DefaultTypeInspectorTests
 
         // act
         var members = new List<MemberInfo>();
-        foreach (var member in typeInspector.GetMembers(typeof(DoNotInfer)))
+        foreach (var member in typeInspector.GetMembers(typeof(DoNotInfer), TypeContext.None))
         {
             members.Add(member);
         }

--- a/src/HotChocolate/Data/src/Data/Filters/FilterInputTypeDescriptor`1.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/FilterInputTypeDescriptor`1.cs
@@ -49,6 +49,7 @@ public class FilterInputTypeDescriptor<T>
             FieldDescriptorUtilities.AddImplicitFields(
                 this,
                 Definition.EntityType!,
+                TypeContext.Output, // NB: building an input type to filter output types
                 p => FilterFieldDescriptor
                     .New(Context, Definition.Scope, p)
                     .CreateDefinition(),

--- a/src/HotChocolate/Data/src/Data/Sorting/SortInputTypeDescriptor`1.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/SortInputTypeDescriptor`1.cs
@@ -50,6 +50,7 @@ public class SortInputTypeDescriptor<T>
             FieldDescriptorUtilities.AddImplicitFields(
                 this,
                 Definition.EntityType,
+                TypeContext.Output, // NB: building an input type to filter output types
                 p => SortFieldDescriptor
                     .New(Context, Definition.Scope, p)
                     .CreateDefinition(),

--- a/src/HotChocolate/Filters/src/Types.Filters/FilterInputTypeDescriptor.cs
+++ b/src/HotChocolate/Filters/src/Types.Filters/FilterInputTypeDescriptor.cs
@@ -119,7 +119,7 @@ public class FilterInputTypeDescriptor<T>
         if (Definition.Fields.IsImplicitBinding()
             && Definition.EntityType != typeof(object))
         {
-            foreach (var member in Context.TypeInspector.GetMembers(Definition.EntityType!))
+            foreach (var member in Context.TypeInspector.GetMembers(Definition.EntityType!, TypeContext.Output))
             {
                 if (member is PropertyInfo property
                     && !handledProperties.Contains(property)

--- a/src/HotChocolate/Filters/src/Types.Sorting/SortInputTypeDescriptor.cs
+++ b/src/HotChocolate/Filters/src/Types.Sorting/SortInputTypeDescriptor.cs
@@ -178,7 +178,7 @@ public class SortInputTypeDescriptor<T>
             return;
         }
 
-        foreach (var member in Context.TypeInspector.GetMembers(Definition.EntityType!))
+        foreach (var member in Context.TypeInspector.GetMembers(Definition.EntityType!, TypeContext.Output))
         {
             if (member is PropertyInfo property)
             {


### PR DESCRIPTION
Following up on [previous discussion](https://github.com/ChilliCream/graphql-platform/pull/5851#issuecomment-1446317804), this PR adds a `TypeContext` parameter to `ITypeInspector.GetMembers()` so that it is easier for custom implementations to handle situations like ignoring computed read-only properties in input types.