### PR TITLE
Batch parallel execution, follow-up/refresh

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.Enumerable.cs
@@ -6,9 +6,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using HotChocolate.Execution.Processing;
+using HotChocolate.Fetching;
 using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using static HotChocolate.Execution.ThrowHelper;
 
 namespace HotChocolate.Execution.Batching;
@@ -27,13 +29,15 @@ internal partial class BatchExecutor
         private readonly CollectVariablesVisitationMap _visitationMap = new();
         private DocumentNode? _previous;
         private Dictionary<string, FragmentDefinitionNode>? _fragments;
+        private bool _allowParallelExecution;
 
         public BatchExecutorEnumerable(
             IReadOnlyList<IQueryRequest> requestBatch,
             IRequestExecutor requestExecutor,
             IErrorHandler errorHandler,
             ITypeConverter typeConverter,
-            InputFormatter inputFormatter)
+            InputFormatter inputFormatter,
+            bool allowParallelExecution)
         {
             _requestBatch = requestBatch ??
                 throw new ArgumentNullException(nameof(requestBatch));
@@ -46,9 +50,80 @@ internal partial class BatchExecutor
             _inputFormatter = inputFormatter ??
                 throw new ArgumentNullException(nameof(inputFormatter));
             _visitor = new CollectVariablesVisitor(requestExecutor.Schema);
+            _allowParallelExecution = allowParallelExecution;
         }
 
-        public async IAsyncEnumerator<IQueryResult> GetAsyncEnumerator(
+        public IAsyncEnumerator<IQueryResult> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default)
+        {
+            if (_allowParallelExecution)
+            {
+                return GetParallelAsyncEnumerator(cancellationToken);
+            }
+            else
+            {
+                return GetSequentialAsyncEnumerator(cancellationToken);
+            }
+        }
+
+        private async IAsyncEnumerator<IQueryResult> GetParallelAsyncEnumerator(
+            CancellationToken cancellationToken = default)
+        {
+            var pending = new List<Task<IQueryResult>>();
+            var exportCount = _exportedVariables.Count;
+            var hasMutatedState = false;
+            BatchScheduler? scheduler = null;
+            foreach (IQueryRequest queryRequest in _requestBatch)
+            {
+                var nextScheduler = queryRequest.Services.GetRequiredService<IBatchDispatcher>() as BatchScheduler;
+                if (scheduler != nextScheduler)
+                {
+                    if (scheduler != null)
+                    {
+                        throw new InvalidOperationException("Too many schedulers");
+                    }
+
+                    scheduler = nextScheduler;
+                }
+                scheduler?.Suspend();
+                var request = (IReadOnlyQueryRequest)queryRequest;
+                var canMutateState = CanAffectState(request);
+                if (_exportedVariables.Count > exportCount || canMutateState || hasMutatedState)
+                {
+                    exportCount = _exportedVariables.Count;
+                    scheduler?.Resume();
+                    await Task.WhenAll(pending).ConfigureAwait(false);
+                    scheduler.Suspend();
+                }
+
+                hasMutatedState = canMutateState;
+                pending.Add(ExecuteNextAsync(request, cancellationToken));
+            }
+            scheduler?.Resume();
+
+            foreach (Task<IQueryResult> task in pending)
+            {
+                IQueryResult result = await task.ConfigureAwait(false);
+                yield return result;
+
+                if (result.Data is null)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static bool CanAffectState(IQueryRequest request)
+        {
+            if (request.Query is QueryDocument doc && doc.Document.Definitions[0] is OperationDefinitionNode op)
+            {
+                return op.Operation != OperationType.Query;
+            }
+
+            return false;
+        }
+
+        private async IAsyncEnumerator<IQueryResult> GetSequentialAsyncEnumerator(
             CancellationToken cancellationToken = default)
         {
             for (var i = 0; i < _requestBatch.Count; i++)

--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
@@ -33,5 +33,6 @@ internal partial class BatchExecutor
             requestExecutor,
             _errorHandler,
             _typeConverter,
-            _inputFormatter);
+            _inputFormatter,
+            allowParallelExecution);
 }

--- a/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/Batching/BatchExecutor.cs
@@ -26,7 +26,8 @@ internal partial class BatchExecutor
 
     public IAsyncEnumerable<IQueryResult> ExecuteAsync(
         IRequestExecutor requestExecutor,
-        IReadOnlyList<IQueryRequest> requestBatch)
+        IReadOnlyList<IQueryRequest> requestBatch,
+        bool allowParallelExecution)
         => new BatchExecutorEnumerable(
             requestBatch,
             requestExecutor,

--- a/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
@@ -127,7 +127,7 @@ internal sealed class RequestExecutor : IRequestExecutor
 
         return Task.FromResult<IResponseStream>(
             new ResponseStream(
-                () => _batchExecutor.ExecuteAsync(this, requestBatch, allowParallelExecution),
+                () => _batchExecutor.ExecuteAsync(this, requestBatch, allowParallelExecution: true),
                 ExecutionResultKind.BatchResult));
     }
 

--- a/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutor.cs
@@ -127,7 +127,7 @@ internal sealed class RequestExecutor : IRequestExecutor
 
         return Task.FromResult<IResponseStream>(
             new ResponseStream(
-                () => _batchExecutor.ExecuteAsync(this, requestBatch),
+                () => _batchExecutor.ExecuteAsync(this, requestBatch, allowParallelExecution),
                 ExecutionResultKind.BatchResult));
     }
 

--- a/src/HotChocolate/Stitching/src/Stitching/Requests/RemoteRequestExecutor.cs
+++ b/src/HotChocolate/Stitching/src/Stitching/Requests/RemoteRequestExecutor.cs
@@ -51,11 +51,6 @@ internal sealed class RemoteRequestExecutor
                 _batchScheduler.Schedule(() => ExecuteRequestsInternal(cancellationToken));
                 _taskRegistered = true;
             }
-
-            if (t != null)
-            {
-                await t.Value.ConfigureAwait(false);
-            }
         }
         finally
         {


### PR DESCRIPTION
This is a follow-up of PR #5303 which was done in HC 12 and not pursued further on that branch.

We are still seeing problems and would like to pursue this futher. This PR tries to address issues with batch requests run in sequence by

- Trying to batch them together where appropriate (specifically in the case where they don't mutate state or if variables are exported). If in doubt, parallellism is broken where discovered. This could be improved further by actually analyzing dependencies, but we have found that it is is a significant improvement for our use cases and the further improvement possible would probably not improve any of our use cases.
- By improving execution in the stitching layer by not firing off requests too quickly, we can optimize batching to the stitched domain services and this improve request overhead and batch loader usage in the domain services.

We are willing to spend some more time helping out with this, but it would be good to judge if there is still interest in pursuing improvements here and if this is an approach that will work.

Some thoughts/questions:

- This is currently written against the main-version-13 branch since main became 14 before I got around to create this PR. Happy to port it to main, but I'd first need to verify what kind of migration that entails for us. We're quite heavily invested in the current stitching API, for example.
- I left open configurability for whether or not to allow parallel execution. I am not sure if this level of configurability is desired, or if it should just be removed. It is also not hooked up to anything currently, as I am not sure what would be the appropriate level to configure this.
- We would prefer if this worked with the current stitching (as well as Fusion in the future) as we are heavily invested in this and migrating to Fusion will take a significant effort from our side (which we will likely want to do, only it's going to take significant time until we are there)