### PR TITLE
Fix update command not updating schema file

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
@@ -108,6 +108,10 @@ public class UpdateCommandHandler : CommandHandler<UpdateCommandArguments>
             if (!await DownloadSchemaAsync(context, uri, tempFile, cancellationToken)
                 .ConfigureAwait(false))
             {
+                hasErrors = true;
+            }
+            else
+            {
                 // if the schema download succeeded we will replace the old schema with the
                 // new one.
                 if (File.Exists(schemaFilePath))
@@ -116,8 +120,6 @@ public class UpdateCommandHandler : CommandHandler<UpdateCommandArguments>
                 }
 
                 File.Move(tempFile, schemaFilePath);
-
-                hasErrors = true;
             }
 
             // in any case we will make sure the temp file is removed at the end.


### PR DESCRIPTION
`dotnet graphql update` command is broken in commit https://github.com/ChilliCream/graphql-platform/commit/4b7ad3c4d8a67967f08ebc110575d0f1eb7924c5#r84609687, that attempts to fix #5260.

This PR is a follow-up to the fix, and inverts if clause of the positive condition.

Closes  #5863