### PR TITLE
SDK roll forward (1 line change)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100"
+    "version": "7.0.100",
+    "rollForward": "minor"
   }
 }


### PR DESCRIPTION
Currently builds fail if you don't have the exact version SDK specified in `global.json`:

    $ dotnet build

```
Requested SDK version: 7.0.100
global.json file: C:\Users\kylem\Repositories\graphql-platform\global.json

Installed SDKs:
7.0.201 [C:\Program Files\dotnet\sdk]

Install the [7.0.100] .NET SDK or update [C:\Users\kylem\Repositories\graphql-platform\global.json] to match an installed SDK.
```

Is this deliberate? If not, should we configure an appropriate ["roll forward" behavior](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward)? Here I've specified "minor," so that any .NET 7 SDK will satisfy.