### PR TITLE
Fix issue `JSON` scalar crashes on JsonElement inputs #6023

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
@@ -181,7 +181,7 @@ public sealed class JsonType : ScalarType<JsonElement>
             using var jsonWriter = new Utf8JsonWriter(bufferWriter);
             _visitor.Visit(node, new JsonFormatterContext(jsonWriter));
 
-            var jsonReader = new Utf8JsonReader(bufferWriter.GetSpan());
+            var jsonReader = new Utf8JsonReader(bufferWriter.GetSpan(jsonWriter.BytesPending));
             return JsonElement.ParseValue(ref jsonReader);
         }
 

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
@@ -180,8 +180,9 @@ public sealed class JsonType : ScalarType<JsonElement>
             using var bufferWriter = new ArrayWriter();
             using var jsonWriter = new Utf8JsonWriter(bufferWriter);
             _visitor.Visit(node, new JsonFormatterContext(jsonWriter));
+            jsonWriter.Flush();
 
-            var jsonReader = new Utf8JsonReader(bufferWriter.GetSpan(jsonWriter.BytesPending));
+            var jsonReader = new Utf8JsonReader(bufferWriter.Body.Span);
             return JsonElement.ParseValue(ref jsonReader);
         }
 

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -128,6 +128,27 @@ public class AnnotationBasedMutations
     }
 
     [Fact]
+    public async Task SimpleJsonMutationExtension_Inferred_Execute()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddMutationType()
+                .AddTypeExtension<SimpleJsonMutationExtension>()
+                .AddMutationConventions(
+                    new MutationConventionOptions { ApplyToAllMutations = true })
+                .ModifyOptions(o => o.StrictValidation = false)
+                .ExecuteRequestAsync(
+                    @"mutation {
+                        doSomething(input: { something: 10 }) {
+                            string
+                        }
+                    }");
+
+        result.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task Ensure_That_Directive_Middleware_Play_Nice()
     {
         var result =
@@ -981,6 +1002,13 @@ public class AnnotationBasedMutations
     {
         public string DoSomething(string something)
             => something;
+    }
+
+    [ExtendObjectType("Mutation")]
+    public class SimpleJsonMutationExtension
+    {
+        public string DoSomething(System.Text.Json.JsonElement something)
+            => "Done";
     }
 
     public class SimpleMutationAttribute

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleJsonMutationExtension_Inferred_Execute.snap
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleJsonMutationExtension_Inferred_Execute.snap
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "doSomething": {
+      "string": "Done"
+    }
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
@@ -205,9 +205,9 @@ public class JsonTypeTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task Input_Json_Bool_Literal(bool value)
+    [InlineData("true")]
+    [InlineData("false")]
+    public async Task Input_Json_Bool_Literal(string value)
     {
         var result =
             await new ServiceCollection()

--- a/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CookieCrumble;
@@ -119,6 +120,111 @@ public class JsonTypeTests
                 "inputJson": {
                   "a": "abc"
                 }
+              }
+            }
+            """);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-15)]
+    [InlineData(-10.5)]
+    [InlineData(1.5)]
+    [InlineData(1e15)]
+    public async Task Input_Json_Number_Literal(decimal value)
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    $$"""
+                    {
+                        inputJson(input: {{value}})
+                    }
+                    """);
+
+        result.MatchInlineSnapshot(
+            $$"""
+            {
+              "data": {
+                "inputJson": {{value}}
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Input_Json_BigInt_Literal()
+    {
+        var value = BigInteger.Parse("100000000000000000000000050");
+
+        var result =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    $$"""
+                    {
+                        inputJson(input: {{value}})
+                    }
+                    """);
+
+        result.MatchInlineSnapshot(
+            $$"""
+            {
+              "data": {
+                "inputJson": {{value}}
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Input_Json_Exponent_Literal()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    """
+                    {
+                        inputJson(input: 1e1345)
+                    }
+                    """);
+
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "inputJson": 1e1345
+              }
+            }
+            """);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Input_Json_Bool_Literal(bool value)
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    $$"""
+                    {
+                        inputJson(input: {{value}})
+                    }
+                    """);
+
+        result.MatchInlineSnapshot(
+            $$"""
+            {
+              "data": {
+                "inputJson": {{value}}
               }
             }
             """);


### PR DESCRIPTION
Fix issue parsing JSON scalar inputs

- Adds a 'bytes written' to call to `GetSpan` so that JsonElement.ParseValue only attempts to read the actual bytes written, rather than continuing to read the underlying buffer.
- Added test case

Closes #6023 