### PR TITLE
Fix issue converting idictionary to object #3617

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "6.0.100", 
-        "rollForward": "latestMinor"
-    }
+  "sdk": {
+      "version": "6.0.100",
+      "rollForward": "latestMinor"
+  }
 }

--- a/src/HotChocolate/Core/src/Types/Utilities/ObjectToDictionaryConverter.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ObjectToDictionaryConverter.cs
@@ -90,8 +90,9 @@ internal class ObjectToDictionaryConverter
             var dict = new Dictionary<string, object>();
             setValue(dict);
 
-            if (obj is IReadOnlyDictionary<string, object> d)
+            if (obj is IReadOnlyDictionary<string, object> || obj is IDictionary<string, object>)
             {
+                var d = obj as IEnumerable<KeyValuePair<string, object>>;
                 foreach (KeyValuePair<string, object> item in d)
                 {
                     Action<object> setField = v => dict[item.Key] = v;

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/ObjectToDictionaryConverterTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/ObjectToDictionaryConverterTests.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Dynamic;
+
+using Snapshooter.Xunit;
+
+using Xunit;
+
+namespace HotChocolate.Utilities
+{
+    public class ObjectToDictionaryConverterTests
+    {
+        [Fact]
+
+        public void Convert_Object_Dictionary()
+        {
+            // arrange
+            var bar1 = new Bar { Number = 1, Baz = Baz.Bar };
+            var bar2 = new Bar { Number = 2, Baz = Baz.Bar };
+            var bar3 = new Bar { Number = 3, Baz = Baz.Foo };
+            var foo = new Foo
+            {
+                Bar = bar1,
+                Bars = new List<Bar> { bar2, bar3 }
+            };
+
+            // act
+            var converter = new ObjectToDictionaryConverter(
+                DefaultTypeConverter.Default);
+            var dict = converter.Convert(foo);
+
+            // assert
+            dict.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Convert_ObjectWithNullField_Dictionary()
+        {
+            // arrange
+            var bar2 = new Bar { Number = 2, Baz = Baz.Bar };
+            var bar3 = new Bar { Number = 3, Baz = Baz.Foo };
+            var foo = new Foo
+            {
+                Bar = null,
+                Bars = new List<Bar> { bar2, bar3 }
+            };
+
+            // act
+            var converter = new ObjectToDictionaryConverter(
+                DefaultTypeConverter.Default);
+            var dict = converter.Convert(foo);
+
+            // assert
+            dict.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Convert_ObjectWithNullElement_Dictionary()
+        {
+            // arrange
+            var bar1 = new Bar { Number = 1, Baz = Baz.Bar };
+            var bar2 = new Bar { Number = 2, Baz = Baz.Bar };
+            var foo = new Foo
+            {
+                Bar = bar1,
+                Bars = new List<Bar> { bar2, null }
+            };
+
+            // act
+            var converter = new ObjectToDictionaryConverter(
+                DefaultTypeConverter.Default);
+            var dict = converter.Convert(foo);
+
+            // assert
+            dict.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Convert_IReadOnlyDictionary_Dictionary()
+        {
+            // arrange
+            var bar1 = new Bar { Number = 1, Baz = Baz.Bar };
+            var bar2 = new Bar { Number = 2, Baz = Baz.Bar };
+
+            // it implements both IReadOnlyDictionary and IDictionary
+            var foo = new Dictionary<string, object>
+            {
+                ["Bar"] = bar1,
+                ["Bars"] = new List<Bar> { bar2, null }
+            };
+
+            // act
+            var converter = new ObjectToDictionaryConverter(
+                DefaultTypeConverter.Default);
+            var dict = converter.Convert(foo);
+
+            // assert
+            dict.MatchSnapshot();
+        }
+
+        [Fact]
+        public void Convert_IDictionary_Dictionary()
+        {
+            // arrange
+            var bar1 = new Bar { Number = 1, Baz = Baz.Bar };
+            var bar2 = new Bar { Number = 2, Baz = Baz.Bar };
+            IDictionary<string, object?> foo = new ExpandoObject(); // it doesn't implement IReadOnlyDictionary
+            foo["Bar"] = bar1;
+            foo["Bars"] = new List<Bar> { bar2, null };
+
+            // act
+            var converter = new ObjectToDictionaryConverter(
+                DefaultTypeConverter.Default);
+            var dict = converter.Convert(foo);
+
+            // assert
+            dict.MatchSnapshot();
+        }
+
+        public class Foo
+        {
+            public List<Bar> Bars { get; set; }
+
+            public Bar Bar { get; set; }
+        }
+
+        public class Bar
+        {
+            public int Number { get; set; }
+
+            public Baz Baz { get; set; }
+        }
+
+        public enum Baz
+        {
+            Foo,
+            Bar
+        }
+
+        public class DummyQuery
+        {
+            public string Foo { get; set; }
+        }
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_IDictionary_Dictionary.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_IDictionary_Dictionary.snap
@@ -1,0 +1,13 @@
+﻿{
+  "Bar": {
+    "number": 1,
+    "baz": "Bar"
+  },
+  "Bars": [
+    {
+      "number": 2,
+      "baz": "Bar"
+    },
+    null
+  ]
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_IReadOnlyDictionary_Dictionary.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_IReadOnlyDictionary_Dictionary.snap
@@ -1,0 +1,13 @@
+﻿{
+  "Bar": {
+    "number": 1,
+    "baz": "Bar"
+  },
+  "Bars": [
+    {
+      "number": 2,
+      "baz": "Bar"
+    },
+    null
+  ]
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_ObjectWithNullElement_Dictionary.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_ObjectWithNullElement_Dictionary.snap
@@ -1,0 +1,13 @@
+﻿{
+  "bars": [
+    {
+      "number": 2,
+      "baz": "Bar"
+    },
+    null
+  ],
+  "bar": {
+    "number": 1,
+    "baz": "Bar"
+  }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_ObjectWithNullField_Dictionary.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_ObjectWithNullField_Dictionary.snap
@@ -1,0 +1,13 @@
+﻿{
+  "bars": [
+    {
+      "number": 2,
+      "baz": "Bar"
+    },
+    {
+      "number": 3,
+      "baz": "Foo"
+    }
+  ],
+  "bar": null
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_Object_Dictionary.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/__snapshots__/ObjectToDictionaryConverterTests.Convert_Object_Dictionary.snap
@@ -1,0 +1,16 @@
+﻿{
+  "bars": [
+    {
+      "number": 2,
+      "baz": "Bar"
+    },
+    {
+      "number": 3,
+      "baz": "Foo"
+    }
+  ],
+  "bar": {
+    "number": 1,
+    "baz": "Bar"
+  }
+}


### PR DESCRIPTION
Allow to serialize IDictionary in AnyType.

Before `ObjectToDictionaryConverter` tried to serialize any `IDictionary` as an object instead of a dictionary when the type didn't implement `IReadOnlyDictionary`

STR:
1. Return IDictionary<string, object> from the query. Implementation of  IDictionary<string, object> shouldn't implement IReadOnlyDictionary<string, object>

Expected Result: `{ "foo": { "bar": 123 } }`
Actual Result: `{}`

Closes #3617
