### PR TITLE
Update apollo-federation.md

### DIFF
--- a/website/src/docs/hotchocolate/v13/api-reference/apollo-federation.md
+++ b/website/src/docs/hotchocolate/v13/api-reference/apollo-federation.md
@@ -5,3 +5,6 @@ title: Apollo Federation Subgraph Support
 > Note: Apollo Federation Support is coming with Hot Chocolate 12.6
 
 ## Example subgraphs
+
+* [Code First](https://github.com/ChilliCream/graphql-platform/tree/main/src/HotChocolate/ApolloFederation/examples/CodeFirst)
+* [Annotation Based](https://github.com/ChilliCream/graphql-platform/tree/main/src/HotChocolate/ApolloFederation/examples/AnnotationBased)


### PR DESCRIPTION
Add links to example projects for quick reference

Summary of the changes (Less than 80 chars)

On Apollo Federation documentation, rather than a blank page, provide links to examples on the main branch in the github repo.
