### PR TITLE
Docs: Update middleware attribute example to proper access modifier.

### DIFF
--- a/website/src/docs/hotchocolate/v13/execution-engine/field-middleware.md
+++ b/website/src/docs/hotchocolate/v13/execution-engine/field-middleware.md
@@ -225,7 +225,7 @@ public class UseMyMiddlewareAttribute : ObjectFieldDescriptorAttribute
         Order = order;
     }
 
-    public override void OnConfigure(IDescriptorContext context,
+    protected override void OnConfigure(IDescriptorContext context,
         IObjectFieldDescriptor descriptor, MemberInfo member)
     {
         descriptor.UseMyMiddleware();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updates the example middleware attribute to use the proper access modifier.
