### PR TITLE
Fixed DotNetVersion blank

### DIFF
--- a/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
+++ b/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
@@ -24,16 +24,18 @@
     </ItemGroup>
   </Target>
 
-  <Target
-    Name="_GenerateGraphQLCode"
-    Inputs="@(GenerateGraphQLCodeItems)"
-    Outputs="$(MSBuildProjectDirectory)\$(IntermediateOutputPath)berry\.build.info"
-    Condition="'@(GraphQL)' != ''">
-
+  <Target Name="_DotNetVersion">
     <Exec Command="dotnet --version" StandardOutputImportance="Low" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="DotNetVersion" />
     </Exec>
+  </Target>
 
+  <Target
+    Name="_GenerateGraphQLCode"
+    DependsOnTargets="_DotNetVersion"
+    Inputs="@(GenerateGraphQLCodeItems)"
+    Outputs="$(MSBuildProjectDirectory)\$(IntermediateOutputPath)berry\.build.info"
+    Condition="'@(GraphQL)' != ''">
     <PropertyGroup>
       <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 6))">6</DotNetMajor>
       <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 7))">7</DotNetMajor>


### PR DESCRIPTION
This PR is a follow-up to #6012, which attempted to resolve a build issue with dotnet preview sdk.

- Extract `ExecTask` to a dependent target so that `ConsoleOutput` can be set to the `DotNetVersion` property before evaluating `PropertyGroup`.

Closes #6048 
