### PR TITLE
Add test to cover mutation conventions using naming conventions (#4803)

### DIFF
--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using HotChocolate.Execution;
 using HotChocolate.Types.Relay;
 using Microsoft.Extensions.DependencyInjection;
 using CookieCrumble;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Types;
 
@@ -357,6 +359,21 @@ public class AnnotationBasedMutations
                 .AddGraphQL()
                 .AddMutationType<SimpleMutationPayloadOverride>()
                 .AddMutationConventions(true)
+                .ModifyOptions(o => o.StrictValidation = false)
+                .BuildSchemaAsync();
+
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task SimpleMutation_NamingConvention()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddMutationType<SimpleMutation>()
+                .AddMutationConventions(true)
+                .AddConvention<INamingConventions, CustomNamingConvention>()
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
 
@@ -1302,4 +1319,46 @@ public class AnnotationBasedMutations
     }
 
     public record DoSomething2Payload(int? UserId);
+
+    private sealed class CustomNamingConvention : DefaultNamingConventions
+    {
+        public override string GetArgumentName(ParameterInfo parameter)
+        {
+            var name = base.GetArgumentName(parameter);
+            return name + "_ArgumentNamed";
+        }
+
+        public override string GetArgumentDescription(ParameterInfo parameter)
+        {
+            return "GetArgumentDescription";
+        }
+
+        public override string GetMemberDescription(MemberInfo member, MemberKind kind)
+        {
+            return "GetMemberDescription";
+        }
+
+        public override string GetTypeName(Type type, TypeKind kind)
+        {
+            var name = base.GetTypeName(type, kind);
+            return name + "_TypeNamed";
+        }
+
+        public override string GetEnumValueDescription(object value)
+        {
+            return "GetEnumValueDescription";
+        }
+
+        public override string GetMemberName(MemberInfo member, MemberKind kind)
+        {
+            var name = base.GetMemberName(member, kind);
+
+            return name + "_MemberNamed";
+        }
+
+        public override string GetTypeDescription(Type type, TypeKind kind)
+        {
+            return "GetTypeDescription";
+        }
+    }
 }

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleMutation_NamingConvention.graphql
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleMutation_NamingConvention.graphql
@@ -1,0 +1,21 @@
+schema {
+  mutation: SimpleMutation_TypeNamed
+}
+
+"GetTypeDescription"
+type DoSomething_TypeNamedPayload {
+  "GetMemberDescription"
+  string_MemberNamed: String
+}
+
+"GetTypeDescription"
+type SimpleMutation_TypeNamed {
+  "GetMemberDescription"
+  doSomething_MemberNamed("GetArgumentDescription" input: DoSomething_TypeNamedInput!): DoSomething_TypeNamedPayload!
+}
+
+"GetTypeDescription"
+input DoSomething_TypeNamedInput {
+  "GetMemberDescription"
+  name_ArgumentNamed: String!
+}


### PR DESCRIPTION
As discussed in [Slack](https://hotchocolategraphql.slack.com/archives/CD9TNKT8T/p1681647586830919?thread_ts=1681612564.191329&cid=CD9TNKT8T) it adds a failing test to display the issues using mutation conventions with naming conventions as outlined in #4803. 

I'm unsure if the naming conventions should be applied before or after the mutation convention interceptor is applied which would result in differing type names (eg; DoSomething_TypeNamedPayload vs DoSomethingPayload_TypeNamed), if it's the latter let me know and I can update the snapshot.

