### PR TITLE
Add SetUser extension to IQueryRequestBuilder

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Authorization.Tests/AuthorizeSchemaTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Authorization.Tests/AuthorizeSchemaTests.cs
@@ -23,7 +23,7 @@ public class AuthorizeSchemaTests
                 QueryRequestBuilder
                     .New()
                     .SetQuery("{ bar }")
-                    .AddGlobalState(nameof(ClaimsPrincipal), new ClaimsPrincipal())
+                    .SetUser(new ClaimsPrincipal())
                     .Create());
 
         result.MatchSnapshot();

--- a/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Claims;
 
 namespace HotChocolate.Execution;
 
@@ -83,6 +84,14 @@ public static class QueryRequestBuilderExtensions
         this IQueryRequestBuilder builder,
         int maximumAllowedDepth) =>
         builder.SetGlobalState(WellKnownContextData.MaxAllowedExecutionDepth, maximumAllowedDepth);
+
+    /// <summary>
+    /// Sets the user for this request.
+    /// </summary>
+    public static IQueryRequestBuilder SetUser(
+        this IQueryRequestBuilder builder,
+        ClaimsPrincipal claimsPrincipal) =>
+        builder.SetGlobalState(nameof(ClaimsPrincipal), claimsPrincipal);
 
     /// <summary>
     /// Registers a cleanup task for execution resources with the <see cref="IQueryResultBuilder"/>.

--- a/src/HotChocolate/Core/test/Authorization.Tests/AnnotationBasedAuthorizationTests.cs
+++ b/src/HotChocolate/Core/test/Authorization.Tests/AnnotationBasedAuthorizationTests.cs
@@ -650,7 +650,7 @@ public class AnnotationBasedAuthorizationTests
                           }
                         }
                         """)
-                    .SetGlobalState(nameof(ClaimsPrincipal), new ClaimsPrincipal()));
+                    .SetUser(new ClaimsPrincipal()));
 
         // assert
         Snapshot

--- a/src/HotChocolate/Core/test/Types.Tests/ResolverContextStateExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/ResolverContextStateExtensionTests.cs
@@ -39,7 +39,7 @@ public class ResolverContextStateExtensionTests
             .ExecuteRequestAsync(
                 QueryRequestBuilder.New()
                     .SetQuery("{ foo }")
-                    .SetGlobalState(nameof(ClaimsPrincipal), user)
+                    .SetUser(user)
                     .Create())
             .MatchSnapshotAsync();
     }


### PR DESCRIPTION
We already created such an extension in our own project, but I was reminded again today by Michael's video that it would probably be a good idea to expose this method as part of the library.
I called the method `SetUser` to have a symmetry to the already existing `GetUser` method on the `IResolverContext`. 

Example:

```csharp
var request = QueryRequestBuilder.New()
    .SetQuery("{ me { name } }")
    .SetUser(new ClaimsPrincipal())
    .Create();
```