### PR TITLE
Fixed XML docs on UseFirstOrDefaultAttribute

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Attributes/UseFirstOrDefaultAttribute.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Attributes/UseFirstOrDefaultAttribute.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Data;
 
 /// <summary>
 /// Returns the first element of the sequence that satisfies a condition or a default value if
-/// no such element is found. Applies the <see cref="UseSingleOrDefaultAttribute"/> to the field
+/// no such element is found. Applies the <see cref="UseFirstOrDefaultAttribute"/> to the field
 /// </summary>
 public sealed class UseFirstOrDefaultAttribute
     : ObjectFieldDescriptorAttribute


### PR DESCRIPTION
Fix typo in XML Docs on `UseFirstOrDefaultAttribute`
