### PR TITLE
Fixed extensions/locations confusion in error extraction.

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Execution/ExecutorUtils.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/ExecutorUtils.cs
@@ -383,7 +383,7 @@ internal static class ExecutorUtils
             if (error.TryGetProperty("locations", out var locations) &&
                 locations.ValueKind is JsonValueKind.Array)
             {
-                foreach (var location in extensions.EnumerateArray())
+                foreach (var location in locations.EnumerateArray())
                 {
                     if (location.TryGetProperty("line", out var lineValue) &&
                         location.TryGetProperty("column", out var columnValue) &&


### PR DESCRIPTION
When the Fusion execution encounters an error from a subgraph, it tries to extract information such as the location and the errors. Due to a small mixup in JSON parsing, it currently throws
`System.InvalidOperationException: The requested operation requires an element of type 'Array', but the target element has type 'Object'.`