### PR TITLE
StrawberryShake: remove temp directory after update

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
@@ -127,6 +127,20 @@ public class UpdateCommandHandler : CommandHandler<UpdateCommandArguments>
             {
                 File.Delete(tempFile);
             }
+
+            // remove the temp directory.
+            var tempDirectory = GetDirectoryName(tempFile);
+            if (Directory.Exists(tempDirectory))
+            {
+                try
+                {
+                    Directory.Delete(tempDirectory);
+                }
+                catch (IOException)
+                {
+                    // ignore error when directory is not empty.
+                }
+            }
         }
 
         return !hasErrors;


### PR DESCRIPTION
Fixes #6184

This change removes the temporary directory created by `dotnet graphql update`.
Another solution would be to not use a temporary directory at all, but just write to the base temp directory, perhaps leveraging something like `Path.GetTempFileName()`.
