### PR TITLE
Fix DotNetVersion parse order (#6180)

### DIFF
--- a/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
+++ b/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
@@ -24,15 +24,18 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="_ParseVersion">
+    <Exec Command="dotnet --version" StandardOutputImportance="Low" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="DotNetVersion" />
+    </Exec>
+  </Target>
+
   <Target
     Name="_GenerateGraphQLCode"
     Inputs="@(GenerateGraphQLCodeItems)"
     Outputs="$(MSBuildProjectDirectory)\$(IntermediateOutputPath)berry\.build.info"
+    DependsOnTargets="_ParseVersion"
     Condition="'@(GraphQL)' != ''">
-
-    <Exec Command="dotnet --version" StandardOutputImportance="Low" ConsoleToMsBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="DotNetVersion" />
-    </Exec>
 
     <PropertyGroup>
       <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 6))">6</DotNetMajor>


### PR DESCRIPTION
The errors noted in #6180 are due to a race condition between the evaluation of the property and the execution of the dotnet --version command.

Closes #6180 
