### PR TITLE
StackExchange.Redis from version 2.2.88 to 2.6.80 in HotChocolate.Stitching.Redis

### DIFF
--- a/src/HotChocolate/Stitching/src/Stitching.Redis/HotChocolate.Stitching.Redis.csproj
+++ b/src/HotChocolate/Stitching/src/Stitching.Redis/HotChocolate.Stitching.Redis.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Summary

- StackExchange.Redis from version 2.2.88 to 2.6.80 in HotChocolate.Stitching.Redis

Why?

- Has dependency to System.Drawing.Common which contains vulnerability https://www.cve.org/CVERecord?id=CVE-2021-24112