### PR TITLE
Fix #6222 InterfaceTypeDescriptor duplicating fields if CreateDefinition called more than once.

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/InterfaceTypeDescriptor.cs
@@ -78,6 +78,7 @@ public class InterfaceTypeDescriptor
 
         OnCompleteFields(fields, handledMembers);
 
+        Definition.Fields.Clear();
         Definition.Fields.AddRange(fields.Values);
 
         base.OnCreateDefinition(definition);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/InterfaceTypeDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/InterfaceTypeDescriptorTests.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace HotChocolate.Types.Descriptors;
+
 public class InterfaceTypeDescriptorTests : DescriptorTestBase
 {
     [Fact]
@@ -19,5 +14,4 @@ public class InterfaceTypeDescriptorTests : DescriptorTestBase
         descriptor.CreateDefinition();
         Assert.Single(interfaceType.Fields);
     }
-
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/InterfaceTypeDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/InterfaceTypeDescriptorTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HotChocolate.Types.Descriptors;
+public class InterfaceTypeDescriptorTests : DescriptorTestBase
+{
+    [Fact]
+    public void InterfaceType_Issue_6222_CreateDefinition_DoesNotDuplicateFields()
+    {
+        var descriptor = InterfaceTypeDescriptor.New(Context);
+        descriptor.Field("id").Type("ID!");
+
+        var interfaceType = descriptor.CreateDefinition();
+        Assert.Single(interfaceType.Fields);
+
+        descriptor.CreateDefinition();
+        Assert.Single(interfaceType.Fields);
+    }
+
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Add `Definition.Fields.Clear()` to `InterfaceTypeDescriptor.OnCreateDefinition` to match `ObjectTypeDescriptor` and prevent duplicating fields when `CreateDefinition` is called multiple times.

Closes #6222 
