### PR TITLE
Fix DefaultTypeInspector.CollectNullability() return value

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Sockets.Client/Protocols/GraphQLOverWebSocket/MessageHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Sockets.Client/Protocols/GraphQLOverWebSocket/MessageHelper.cs
@@ -82,7 +82,7 @@ internal static class MessageHelper
             WriteFieldValue(jsonWriter, request.Extensions);
         }
 
-        if (request.Variables is not null)
+        if (request.VariablesNode is not null)
         {
             jsonWriter.WritePropertyName(VariablesProp);
             WriteFieldValue(jsonWriter, request.VariablesNode);

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -349,7 +349,7 @@ internal sealed class TypeInitializer
 
                     {
                         if (isSchemaType &&
-                            extendsType.IsInstanceOfType(possibleMatchingType))
+                            extendsType.IsInstanceOfType(possibleMatchingType.Type))
                         {
                             MergeTypeExtension(
                                 extensionArray,

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Tools.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Tools.cs
@@ -144,7 +144,7 @@ internal sealed partial class ExtendedType
             }
 
             written = buffer.Length;
-            return false;
+            return true;
         }
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeExtensionTests.cs
@@ -754,6 +754,19 @@ public class ObjectTypeExtensionTests
         SnapshotExtensions.MatchSnapshot(result);
     }
 
+    [Fact]
+    public async Task ExtendObjectTypeAttribute_Extends_SchemaType()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryType>()
+                .AddTypeExtension<QueryExtensions>()
+                .BuildSchemaAsync();
+
+        SnapshotExtensions.MatchSnapshot(schema);
+    }
+
     public class FooType : ObjectType<Foo>
     {
         protected override void Configure(IObjectTypeDescriptor<Foo> descriptor)
@@ -1138,4 +1151,18 @@ public class ObjectTypeExtensionTests
             => query.Abc;
     }
 
+    public class QueryType : ObjectType
+    {
+        protected override void Configure(IObjectTypeDescriptor descriptor)
+        {
+            descriptor.Name("Query");
+            descriptor.Field("foo").Resolve("bar");
+        }
+    }
+
+    [ExtendObjectType<QueryType>]
+    public class QueryExtensions
+    {
+        public string Bar() => "baz";
+    }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_Extends_SchemaType.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeExtensionTests.ExtendObjectTypeAttribute_Extends_SchemaType.graphql
@@ -1,0 +1,8 @@
+schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+  bar: String!
+}

--- a/src/HotChocolate/Neo4J/src/Data/Filtering/Neo4JFilterCombinator.cs
+++ b/src/HotChocolate/Neo4J/src/Data/Filtering/Neo4JFilterCombinator.cs
@@ -33,7 +33,7 @@ public class Neo4JFilterCombinator
 
     private static CompoundCondition CombineWithAnd(IReadOnlyCollection<Condition> operations)
     {
-        if (operations.Count < 0)
+        if (operations.Count == 0)
         {
             throw new InvalidOperationException();
         }
@@ -49,7 +49,7 @@ public class Neo4JFilterCombinator
 
     private static Condition CombineWithOr(IReadOnlyCollection<Condition> operations)
     {
-        if (operations.Count < 0)
+        if (operations.Count == 0)
         {
             throw new InvalidOperationException();
         }


### PR DESCRIPTION
Fixes typo which made `DefaultTypeInspector.CollectNullability()` always return false, whether it succeeded or not.