### PR TITLE
Added tests that show `CompareTo` is ignore.

### DIFF
--- a/src/HotChocolate/Core/test/Types.Tests/CodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/CodeFirstTests.cs
@@ -149,6 +149,17 @@ public class CodeFirstTests
         schema.MatchSnapshot();
     }
 
+    [Fact]
+    public async Task Comparison_Is_Ignored()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryComparableEntity>()
+                .BuildSchemaAsync();
+
+        schema.MatchSnapshot();
+    }
 
     [Fact]
     public async Task Allow_PascalCasedArguments_Schema()
@@ -320,16 +331,36 @@ public class CodeFirstTests
 
     public class QueryStructEquals
     {
-        public Example Foo(Example example) => example;
+        public EquatableExample Foo(EquatableExample example) => example;
     }
 
-    public class Example : IStructuralEquatable
+    public class EquatableExample : IStructuralEquatable
     {
         public string Some { get; set; } = default!;
 
         public bool Equals(object? other, IEqualityComparer comparer) => throw new NotImplementedException();
 
         public int GetHashCode(IEqualityComparer comparer) => throw new NotImplementedException();
+    }
+
+    public class QueryComparableEntity
+    {
+        public ComparableExample Foo(ComparableExample example) => example;
+    }
+
+    public class ComparableExample : IComparable, IComparable<EquatableExample>
+    {
+        public string Some { get; set; } = default!;
+
+        public int CompareTo(object? obj)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(EquatableExample? other)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class PascalCaseQuery

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Comparison_Is_Ignored.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Comparison_Is_Ignored.graphql
@@ -1,0 +1,15 @@
+schema {
+  query: QueryComparableEntity
+}
+
+type ComparableExample {
+  some: String!
+}
+
+type QueryComparableEntity {
+  foo(example: ComparableExampleInput!): ComparableExample!
+}
+
+input ComparableExampleInput {
+  some: String!
+}

--- a/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Structural_Equality_Is_Ignored.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/__snapshots__/CodeFirstTests.Structural_Equality_Is_Ignored.graphql
@@ -2,14 +2,14 @@ schema {
   query: QueryStructEquals
 }
 
-type Example {
+type EquatableExample {
   some: String!
 }
 
 type QueryStructEquals {
-  foo(example: ExampleInput!): Example!
+  foo(example: EquatableExampleInput!): EquatableExample!
 }
 
-input ExampleInput {
+input EquatableExampleInput {
   some: String!
 }


### PR DESCRIPTION
The ignore itself was added as part of [that commit](https://github.com/shtannikov/graphql-platform/commit/35301472065248ce4e2f34894041f39124e3c7b8#diff-b06e022ac536fe3fd39b7380835ab6942a0c0dd2397b71a7b31c3e3ffc53d608R30). But it was a side change and didn't have test coverage. So I added test to make sure `CompareTo` is ignored

Closes #5285
