### PR TITLE
Prevent expression reduce when looking for ordering method

### DIFF
--- a/src/HotChocolate/Data/src/Data/Sorting/Expressions/Extensions/QueryableSortContextExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/Expressions/Extensions/QueryableSortContextExtensions.cs
@@ -64,6 +64,8 @@ public static class QueryableSortVisitorContextExtensions
             return base.Visit(node);
         }
 
+        protected override Expression VisitExtension(Expression node) => node.CanReduce ? base.VisitExtension(node) : node;
+
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             var name = node.Method.Name;


### PR DESCRIPTION
Change visitor to prevent attempts to reduce children when disallowed.


Closes #6254
