### PR TITLE
Expose variables in ComplexityContext to allow custom complexity calculation

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
@@ -12,11 +12,7 @@ namespace HotChocolate.Execution.Pipeline.Complexity;
 /// </summary>
 public readonly ref struct ComplexityContext
 {
-    /// <summary>
-    /// Set to public on purpose (see https://github.com/ChilliCream/graphql-platform/issues/6251)
-    /// </summary>
-    public IVariableValueCollection Variables { get; }
-
+    private readonly IVariableValueCollection _valueCollection;
     private readonly InputParser _inputParser;
 
     /// <summary>
@@ -41,7 +37,7 @@ public readonly ref struct ComplexityContext
         DefaultMultiplier = cost?.DefaultMultiplier;
         FieldDepth = fieldDepth;
         NodeDepth = nodeDepth;
-        Variables = variables;
+        _valueCollection = variables;
         _inputParser = inputParser;
     }
 
@@ -54,6 +50,11 @@ public readonly ref struct ComplexityContext
     /// Gets the field selection that references the field in the query.
     /// </summary>
     public FieldNode Selection { get; }
+
+    /// <summary>
+    /// Gets the coerced variables of the current request.
+    /// </summary>
+    public IVariableValueCollection Variables => _valueCollection;
 
     /// <summary>
     /// Gets the field`s base complexity.
@@ -100,7 +101,7 @@ public readonly ref struct ComplexityContext
                 .Value;
 
             if (argumentValue is VariableNode variable &&
-                Variables.TryGetVariable(variable.Name.Value, out T? castedVariable))
+                _valueCollection.TryGetVariable(variable.Name.Value, out T? castedVariable))
             {
                 value = castedVariable;
                 return true;

--- a/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
@@ -12,7 +12,11 @@ namespace HotChocolate.Execution.Pipeline.Complexity;
 /// </summary>
 public readonly ref struct ComplexityContext
 {
-    private readonly IVariableValueCollection _valueCollection;
+    /// <summary>
+    /// Set to public on purpose (see https://github.com/ChilliCream/graphql-platform/issues/6251)
+    /// </summary>
+    public IVariableValueCollection Variables { get; }
+
     private readonly InputParser _inputParser;
 
     /// <summary>
@@ -26,7 +30,7 @@ public readonly ref struct ComplexityContext
         int nodeDepth,
         int childComplexity,
         int defaultComplexity,
-        IVariableValueCollection valueCollection,
+        IVariableValueCollection variables,
         InputParser inputParser)
     {
         Field = field;
@@ -37,7 +41,7 @@ public readonly ref struct ComplexityContext
         DefaultMultiplier = cost?.DefaultMultiplier;
         FieldDepth = fieldDepth;
         NodeDepth = nodeDepth;
-        _valueCollection = valueCollection;
+        Variables = variables;
         _inputParser = inputParser;
     }
 
@@ -96,7 +100,7 @@ public readonly ref struct ComplexityContext
                 .Value;
 
             if (argumentValue is VariableNode variable &&
-                _valueCollection.TryGetVariable(variable.Name.Value, out T? castedVariable))
+                Variables.TryGetVariable(variable.Name.Value, out T? castedVariable))
             {
                 value = castedVariable;
                 return true;

--- a/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityContext.cs
@@ -26,7 +26,7 @@ public readonly ref struct ComplexityContext
         int nodeDepth,
         int childComplexity,
         int defaultComplexity,
-        IVariableValueCollection variables,
+        IVariableValueCollection valueCollection,
         InputParser inputParser)
     {
         Field = field;
@@ -37,7 +37,7 @@ public readonly ref struct ComplexityContext
         DefaultMultiplier = cost?.DefaultMultiplier;
         FieldDepth = fieldDepth;
         NodeDepth = nodeDepth;
-        _valueCollection = variables;
+        _valueCollection = valueCollection;
         _inputParser = inputParser;
     }
 


### PR DESCRIPTION
Expose the variables in the ComplexityContext

- This allows developers to access them when setting up a custom complexity calculation (see #6251)
- Renamed it to `Variables` (suggested by @michaelstaib in Slack)

Closes #6251

Once this PR is approved, I can recreate them to target other branches where this is needed. Just let me know in which target branches this makes sense, please.