### PR TITLE
Memory Optimization on Schema

### DIFF
--- a/src/HotChocolate/Core/src/Types/Schema.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.Initialization.cs
@@ -9,7 +9,7 @@ namespace HotChocolate;
 
 public partial class Schema
 {
-    private readonly Action<ISchemaTypeDescriptor> _configure;
+    private Action<ISchemaTypeDescriptor> _configure;
     private bool _sealed;
 
     protected internal Schema()
@@ -24,16 +24,28 @@ public partial class Schema
 
     protected virtual void Configure(ISchemaTypeDescriptor descriptor) { }
 
-    protected sealed override SchemaTypeDefinition CreateDefinition(
-        ITypeDiscoveryContext context)
+    protected sealed override SchemaTypeDefinition CreateDefinition(ITypeDiscoveryContext context)
     {
-        var descriptor = SchemaTypeDescriptor.New(
-            context.DescriptorContext,
-            GetType());
+        var descriptor = SchemaTypeDescriptor.New(context.DescriptorContext, GetType());
 
         _configure(descriptor);
 
         return descriptor.CreateDefinition();
+    }
+
+    protected override void OnAfterInitialize(
+        ITypeDiscoveryContext context,
+        DefinitionBase definition)
+    {
+        base.OnAfterInitialize(context, definition);
+
+        // we clear the configuration delegate to make sure that we do not hold on to any references
+        // if we do not do this all the instances used during initialization will be kept in memory
+        // until the schema is phased out.
+        // We do this in OnAfterInitialized because after this point the schema is marked as
+        // initialized. This means that a subsequent call to Initialize will throw anyway and
+        // therefore we do not need to keep the configuration delegate.
+        _configure = null;
     }
 
     protected override void OnRegisterDependencies(
@@ -46,10 +58,7 @@ public partial class Schema
         {
             foreach (var directive in definition.Directives)
             {
-                context.Dependencies.Add(
-                    new(
-                        directive.Type,
-                        TypeDependencyFulfilled.Completed));
+                context.Dependencies.Add(new(directive.Type, TypeDependencyFulfilled.Completed));
             }
         }
 
@@ -65,15 +74,12 @@ public partial class Schema
     {
         base.OnCompleteType(context, definition);
 
-        Directives = DirectiveCollection.CreateAndComplete(
-            context,
-            this,
-            definition.GetDirectives());
+        Directives = DirectiveCollection
+            .CreateAndComplete(context, this, definition.GetDirectives());
         Services = context.Services;
     }
 
-    internal void CompleteSchema(
-        SchemaTypesDefinition schemaTypesDefinition)
+    internal void CompleteSchema(SchemaTypesDefinition schemaTypesDefinition)
     {
         if (schemaTypesDefinition is null)
         {

--- a/src/HotChocolate/Core/src/Types/Schema.Initialization.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.Initialization.cs
@@ -74,8 +74,10 @@ public partial class Schema
     {
         base.OnCompleteType(context, definition);
 
-        Directives = DirectiveCollection
-            .CreateAndComplete(context, this, definition.GetDirectives());
+        Directives = DirectiveCollection.CreateAndComplete(
+            context,
+            this,
+            definition.GetDirectives());
         Services = context.Services;
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/DirectiveType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/DirectiveType.cs
@@ -11,16 +11,17 @@ using static HotChocolate.Properties.TypeResources;
 namespace HotChocolate.Types;
 
 /// <summary>
+/// <para>
 /// A GraphQL schema describes directives which are used to annotate various parts of a
 /// GraphQL document as an indicator that they should be evaluated differently by a
 /// validator, executor, or client tool such as a code generator.
-///
-/// http://spec.graphql.org/draft/#sec-Type-System.Directives
+/// </para>
+/// <para>http://spec.graphql.org/draft/#sec-Type-System.Directives</para>
 /// </summary>
 public partial class DirectiveType
     : TypeSystemObjectBase<DirectiveTypeDefinition>
-        , IHasRuntimeType
-        , IHasTypeIdentity
+    , IHasRuntimeType
+    , IHasTypeIdentity
 {
     private Action<IDirectiveTypeDescriptor>? _configure;
     private Func<object?[], object> _createInstance = default!;
@@ -81,12 +82,11 @@ public partial class DirectiveType
     /// <summary>
     /// Gets the directive field middleware.
     /// </summary>
-    public DirectiveMiddleware? Middleware { get; private set; } =
-        default!;
+    public DirectiveMiddleware? Middleware { get; private set; }
 
     /// <summary>
-    /// Defines that this directive can be used in executable GraphQL documents.
-    ///
+    /// <para>Defines that this directive can be used in executable GraphQL documents.</para>
+    /// <para>
     /// In order to be executable a directive must at least be valid
     /// in one of the following locations:
     /// QUERY (<see cref="DirectiveLocation.Query"/>)
@@ -97,12 +97,13 @@ public partial class DirectiveType
     /// FRAGMENT_SPREAD (<see cref="DirectiveLocation.FragmentSpread"/>)
     /// INLINE_FRAGMENT (<see cref="DirectiveLocation.InlineFragment"/>)
     /// VARIABLE_DEFINITION (<see cref="DirectiveLocation.VariableDefinition"/>)
+    /// </para>
     /// </summary>
     public bool IsExecutableDirective { get; private set; }
 
     /// <summary>
-    /// Defines that this directive can be applied to type system members.
-    ///
+    /// <para>Defines that this directive can be applied to type system members.</para>
+    /// <para>
     /// In order to be a type system directive it must at least be valid
     /// in one of the following locations:
     /// SCHEMA (<see cref="DirectiveLocation.Schema"/>)
@@ -116,6 +117,7 @@ public partial class DirectiveType
     /// ENUM_VALUE (<see cref="DirectiveLocation.EnumValue"/>)
     /// INPUT_OBJECT (<see cref="DirectiveLocation.InputObject"/>)
     /// INPUT_FIELD_DEFINITION (<see cref="DirectiveLocation.InputFieldDefinition"/>)
+    /// </para>
     /// </summary>
     public bool IsTypeSystemDirective { get; private set; }
 


### PR DESCRIPTION
Previously, the method `OnAfterInitialize` in the type discovery context held onto its configuration delegate even after initialization. As a result, all instances used during this initialization phase remained in memory until the schema was phased out, leading to unnecessary static memory allocation.

With this change, we now explicitly clear the `_configure` delegate after the initialization phase in the `OnAfterInitialize` method. The clearing is performed at this stage because any subsequent calls to `Initialize` would throw an exception, indicating that the schema has already been initialized and the configuration delegate is no longer needed.