### PR TITLE
Fix Namespace of AuthorizeAttribute

### DIFF
--- a/website/src/docs/hotchocolate/v13/security/authorization.md
+++ b/website/src/docs/hotchocolate/v13/security/authorization.md
@@ -79,7 +79,7 @@ public class User
 }
 ```
 
-> Warning: We need to use the `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
+> Warning: We need to use the `HotChocolate.Authorization.AuthorizeAttribute` instead of the `Microsoft.AspNetCore.AuthorizationAttribute`.
 
 </Annotation>
 <Code>


### PR DESCRIPTION
The `HotChocolate.AspNetCore.Authorization.AuthorizeAttribute` does not exist.

its correct name is `HotChocolate.Authorization.AuthorizeAttribute`
