### PR TITLE
set RequestUri on HttpMessage when performing post calls

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Http/DefaultGraphQLHttpClient.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Http/DefaultGraphQLHttpClient.cs
@@ -107,6 +107,7 @@ public sealed class DefaultGraphQLHttpClient : IGraphQLHttpClient
         if (method == GraphQLHttpMethod.Post)
         {
             message.Content = CreatePostContent(arrayWriter, request.Body);
+            message.RequestUri = requestUri;
         }
         else if (method == GraphQLHttpMethod.Get)
         {

--- a/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/GraphQLHttpClientTests.cs
+++ b/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/GraphQLHttpClientTests.cs
@@ -18,10 +18,9 @@ public class GraphQLHttpClientTests : ServerTestBase
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         using var testServer = CreateStarWarsServer();
         var httpClient = testServer.CreateClient();
-        httpClient.BaseAddress = new Uri(CreateUrl("/graphql"));
         var client = new DefaultGraphQLHttpClient(httpClient);
-        var request = new GraphQLHttpRequest("query { hero(episode: JEDI) { name } }");
-            
+        var request = new GraphQLHttpRequest("query { hero(episode: JEDI) { name } }", new Uri(CreateUrl("/graphql")));
+
         // act
         using var response = await client.SendAsync(request, cts.Token);
 
@@ -37,14 +36,14 @@ public class GraphQLHttpClientTests : ServerTestBase
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         using var testServer = CreateStarWarsServer();
         var httpClient = testServer.CreateClient();
-        httpClient.BaseAddress = new Uri(CreateUrl("/graphql"));
         var client = new DefaultGraphQLHttpClient(httpClient);
         var request = new GraphQLHttpRequest(
-            new OperationRequest("query { hero(episode: JEDI) { name } }"))
+            new OperationRequest("query { hero(episode: JEDI) { name } }"),
+            new Uri(CreateUrl("/graphql")))
         {
             Method = GraphQLHttpMethod.Get
         };
-            
+
         // act
         var response = await client.SendAsync(request, cts.Token);
 
@@ -60,7 +59,6 @@ public class GraphQLHttpClientTests : ServerTestBase
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         using var testServer = CreateStarWarsServer();
         var httpClient = testServer.CreateClient();
-        httpClient.BaseAddress = new Uri(CreateUrl("/graphql"));
         var client = new DefaultGraphQLHttpClient(httpClient);
         var request = new GraphQLHttpRequest(
             new OperationRequest(
@@ -68,11 +66,11 @@ public class GraphQLHttpClientTests : ServerTestBase
                 variables: new Dictionary<string, object?>()
                 {
                     {"episode", "JEDI"}
-                }))
+                }), new Uri(CreateUrl("/graphql")))
         {
             Method = GraphQLHttpMethod.Get
         };
-            
+
         // act
         var response = await client.SendAsync(request, cts.Token);
 
@@ -80,7 +78,7 @@ public class GraphQLHttpClientTests : ServerTestBase
         using var body = await response.ReadAsResultAsync(cts.Token);
         body.MatchSnapshot();
     }
-    
+
     [Fact(Skip = "Needs to be implemented.")]
     public async Task Execute_Subscription_Over_SSE()
     {
@@ -92,14 +90,14 @@ public class GraphQLHttpClientTests : ServerTestBase
         var client = new DefaultGraphQLHttpClient(httpClient);
         var request = new GraphQLHttpRequest(
             new OperationRequest("subscription { onReview(episode: JEDI) { stars } }"));
-            
+
         // act
         var response = await client.SendAsync(request, cts.Token);
 
         // assert
         await foreach (var result in response.ReadAsResultStreamAsync(cts.Token).WithCancellation(cts.Token))
         {
-            result.MatchSnapshot();    
+            result.MatchSnapshot();
             cts.Cancel();
         }
     }


### PR DESCRIPTION
if the http client was not setup with a base address the request resulted in an exception

- set RequestUri on HttpMessage for post calls
