### PR TITLE
Updated Docs: AddOpenTelemetryTracing was removed in OpenTelemetry v1.4.0

### DIFF
--- a/website/src/docs/hotchocolate/v13/server/instrumentation.md
+++ b/website/src/docs/hotchocolate/v13/server/instrumentation.md
@@ -268,14 +268,16 @@ builder.Logging.AddOpenTelemetry(
         b.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Demo"));
     });
 
-builder.Services.AddOpenTelemetryTracing(
-    b =>
-    {
-        b.AddHttpClientInstrumentation();
-        b.AddAspNetCoreInstrumentation();
-        b.AddHotChocolateInstrumentation();
-        b.AddJaegerExporter();
-    });
+builder.Services
+    .AddOpenTelemetryTracing()
+    .WithTracing(
+      b =>
+      {
+          b.AddHttpClientInstrumentation();
+          b.AddAspNetCoreInstrumentation();
+          b.AddHotChocolateInstrumentation();
+          b.AddJaegerExporter();
+      });
 ```
 
 `AddHotChocolateInstrumentation` will register the Hot Chocolate instrumentation events with OpenTelemetry.
@@ -296,14 +298,16 @@ builder.Services
 builder.Logging.AddOpenTelemetry(
     b => b.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Demo")));
 
-builder.Services.AddOpenTelemetryTracing(
-    b =>
-    {
-        b.AddHttpClientInstrumentation();
-        b.AddAspNetCoreInstrumentation();
-        b.AddHotChocolateInstrumentation();
-        b.AddJaegerExporter();
-    });
+builder.Services
+    .AddOpenTelemetryTracing()
+    .WithTracing(
+      b =>
+      {
+          b.AddHttpClientInstrumentation();
+          b.AddAspNetCoreInstrumentation();
+          b.AddHotChocolateInstrumentation();
+          b.AddJaegerExporter();
+      });
 
 var app = builder.Build();
 app.MapGraphQL();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- `AddOpenTelemetryTracing` removed in 1.4.0. Use `AddOpenTelemetry` instead.
-  Source: [CHANGELOG v1.4.0](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md#140)
