### PR TITLE
Include net8.0 tools in StrawberryShake package

### DIFF
--- a/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
+++ b/src/StrawberryShake/MetaPackages/Blazor/StrawberryShake.Blazor.csproj
@@ -26,6 +26,7 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net6.0\**\*.*" Pack="true" PackagePath="tools/net6" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net7.0\**\*.*" Pack="true" PackagePath="tools/net7" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
+++ b/src/StrawberryShake/MetaPackages/Maui/StrawberryShake.Maui.csproj
@@ -25,6 +25,7 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net6.0\**\*.*" Pack="true" PackagePath="tools/net6" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net7.0\**\*.*" Pack="true" PackagePath="tools/net7" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
+++ b/src/StrawberryShake/MetaPackages/Server/StrawberryShake.Server.csproj
@@ -25,6 +25,7 @@
     <None Include="$(MSBuildThisFileDirectory)..\Common\MSBuild\global.json" Pack="true" PackagePath="build/global.json" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net6.0\**\*.*" Pack="true" PackagePath="tools/net6" Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net7.0\**\*.*" Pack="true" PackagePath="tools/net7" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\Tooling\src\dotnet-graphql\bin\$(Configuration)\net8.0\**\*.*" Pack="true" PackagePath="tools/net8" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding StrawberryShake.Server to a dotnet 8 project will generate an error:
```
Could not execute because the specified command or file was not found.
  Possible reasons for this include:
    * You misspelled a built-in dotnet command.
    * You intended to execute a .NET program, but dotnet-/Users/antonio/.nuget/packages/strawberryshake.server/13.5.0-preview.7/build/../tools/net8/dotnet-graphql.dll does not exist.
    * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.

/Users/antonio/.nuget/packages/strawberryshake.server/13.5.0-preview.7/build/StrawberryShake.Server.targets(79,5): error MSB3073: The command "dotnet "/Users/antonio/.nuget/packages/strawberryshake.server/13.5.0-preview.7/build/../tools/net8/dotnet-graphql.dll" generate "/Users/antonio/Desktop/src/Demo" -o "/Users/antonio/Desktop/src/Demo/obj/Debug/net8.0/berry" -n Demo -a md5 -t" exited with code 1.
```

The tools directory does not have net8 subdirectory:
```
> ls /Users/antonio/.nuget/packages/strawberryshake.server/13.5.0-preview.7/tools
net6 net7
```

Tested on dotnet 8.0.100-preview.6.23330.14 with HC 13.4.0 and 13.5.0-preview.7

This PR adds the missing files to StrawberryShake package
