### PR TITLE
Fix resolving fields with various federated arguments

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveByKeyBatch.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveByKeyBatch.cs
@@ -180,9 +180,10 @@ internal sealed class ResolveByKeyBatch : ResolverNodeBase
             batchState = ref Unsafe.Add(ref batchState, 1)!;
         }
 
-        foreach (var key in first.VariableValues.Keys)
+        foreach (var argumentType in argumentTypes)
         {
-            var expectedType = argumentTypes[key];
+            var key = argumentType.Key;
+            var expectedType = argumentType.Value;
 
             if (expectedType.IsListType())
             {


### PR DESCRIPTION
When a type has two fields which are resolved by two different subgraphs and each of them needs another argument a key not found exception was raised. That happened because the foreach iterated over all arguments of the batched context which had and argument for both fields.

- Flipped foreach loop to iterate over arguments determined in the planning phase and receive values from the batched context data
