### PR TITLE
Use scheme provided by arguments

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/AuthArgumentsBase.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/AuthArgumentsBase.cs
@@ -41,15 +41,15 @@ public sealed class AuthArguments
         IConsoleOutput output,
         CancellationToken cancellationToken)
     {
+        string? scheme = null;
+
+        if (!NoScheme.HasValue())
+        {
+            scheme = Scheme.HasValue() ? Scheme.Value()!.Trim() : _defaultScheme;
+        }
+
         if (Token.HasValue())
         {
-            string? scheme = null;
-
-            if (!NoScheme.HasValue())
-            {
-                scheme = Scheme.HasValue() ? Scheme.Value()!.Trim() : _defaultScheme;
-            }
-
             return new AccessToken(
                 Token.Value()!.Trim(),
                 scheme);
@@ -69,7 +69,7 @@ public sealed class AuthArguments
                     scopes,
                     cancellationToken)
                 .ConfigureAwait(false);
-            return new AccessToken(token, _defaultScheme);
+            return new AccessToken(token, scheme);
         }
 
         return null;


### PR DESCRIPTION
dotnet graphql init did not respect --no-scheme and --scheme arguments

- When using the CLI to generate the GraphQL client, and using client credentials to obtain a token, the --no-scheme and --scheme arguments weren't respected. The client always sent the default "bearer" value. This isn't the case when passing the token manually. Fixed it so that the access token scheme uses the same scheme logic
