### PR TITLE
Make CustomOptionsFlags public

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
@@ -88,7 +88,7 @@ public class Selection : ISelection
     /// <inheritdoc />
     public int Id { get; }
 
-    internal CustomOptionsFlags CustomOptions { get; private set; }
+    public CustomOptionsFlags CustomOptions { get; private set; }
 
     /// <inheritdoc />
     public SelectionExecutionStrategy Strategy { get; private set; }
@@ -320,7 +320,7 @@ public class Selection : ISelection
         _flags |= Flags.Stream;
     }
 
-    internal void SetOption(CustomOptionsFlags customOptions)
+    public void SetOption(CustomOptionsFlags customOptions)
     {
         if ((_flags & Flags.Sealed) == Flags.Sealed)
         {
@@ -390,7 +390,7 @@ public class Selection : ISelection
     }
 
     [Flags]
-    internal enum CustomOptionsFlags : byte
+    public enum CustomOptionsFlags : byte
     {
         None = 0,
         Option1 = 1,

--- a/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
@@ -397,7 +397,9 @@ public class Selection : ISelection
         Option2 = 2,
         Option3 = 4,
         Option4 = 8,
-        Option5 = 16
+        Option5 = 16,
+        Option6 = 32,
+        Option7 = 64
     }
 
     internal sealed class Sealed : Selection

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/ISelection.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/ISelection.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;


### PR DESCRIPTION
Make CustomOptionsFlags of Selection public in order to let users provide additional contextual information about selections