### PR TITLE
Fix parameter nullability in `IInputValueFormatter`

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Contracts/IInputValueFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/IInputValueFormatter.cs
@@ -22,5 +22,5 @@ public interface IInputValueFormatter
     /// Returns either the <paramref name="runtimeValue"/> or another value
     /// that represents a formatted version or it.
     /// </returns>
-    object? Format(object? runtimeValue);
+    object? Format(object runtimeValue);
 }


### PR DESCRIPTION
A `null` value is never passed to `IInputValueFormatter.Format`, so the parameter doesn't need to be marked as nullable.

Related Slack discussion: https://hotchocolategraphql.slack.com/archives/CD9TNKT8T/p1697529768155779