### PR TITLE
fix: disable default inclusion of `@tag` directive

### DIFF
--- a/src/HotChocolate/Core/src/Types/SchemaOptions.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaOptions.cs
@@ -211,7 +211,7 @@ public class SchemaOptions : IReadOnlySchemaOptions
     /// <summary>
     /// Specifies that the @tag directive shall be registered with the type system.
     /// </summary>
-    public bool EnableTag { get; set; } = true;
+    public bool EnableTag { get; set; } = false;
 
     /// <summary>
     /// Creates a mutable options object from a read-only options object.


### PR DESCRIPTION
While useful, `@tag` directive is not part of the built-in directives so shouldn't be included by default. Users should opt-in to use custom directives.
