### PR TITLE
Set limit on serialized message size in Subscriptions.Postgres

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
@@ -101,7 +101,7 @@ internal sealed class PostgresChannelWriter : IAsyncDisposable
                 command.CommandText = "SELECT pg_notify(@channel, @message);";
 
                 command.Parameters.Add(new NpgsqlParameter("channel", _channelName));
-                command.Parameters.Add(new NpgsqlParameter("message", message.Format()));
+                command.Parameters.Add(new NpgsqlParameter("message", message.FormattedPayload));
 
                 batch.BatchCommands.Add(command);
             }

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresMessageEnvelope.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresMessageEnvelope.cs
@@ -2,6 +2,8 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using static HotChocolate.Subscriptions.Postgres.PostgresResources;
+
 
 namespace HotChocolate.Subscriptions.Postgres;
 
@@ -12,20 +14,20 @@ internal readonly struct PostgresMessageEnvelope
     private const byte separator = (byte)':';
     private const byte _messageIdLength = 24;
 
-    public PostgresMessageEnvelope(string topic, string payload)
+    public PostgresMessageEnvelope(string topic, string payload, int maxMessagePayloadSize)
     {
         Topic = topic;
-        Payload = payload;
+        FormattedPayload = Format(topic, payload, maxMessagePayloadSize);
     }
 
     public string Topic { get; }
 
-    public string Payload { get; }
+    public string FormattedPayload { get; }
 
-    public string Format()
+    private static string Format(string topic, string payload, int maxMessagePayloadSize)
     {
-        var topicMaxBytesCount = _utf8.GetMaxByteCount(Topic.Length);
-        var payloadMaxBytesCount = _utf8.GetMaxByteCount(Payload.Length);
+        var topicMaxBytesCount = _utf8.GetMaxByteCount(topic.Length);
+        var payloadMaxBytesCount = _utf8.GetMaxByteCount(payload.Length);
         // we encode the topic to base64 to ensure that we do not have the separator in the topic
         var topicMaxLength = Base64.GetMaxEncodedToUtf8Length(topicMaxBytesCount);
         var maxSize = topicMaxLength + 2 + payloadMaxBytesCount + _messageIdLength;
@@ -55,7 +57,7 @@ internal readonly struct PostgresMessageEnvelope
         slicedBuffer = slicedBuffer[1..];
 
         // write topic as base64
-        var topicLengthUtf8 = _utf8.GetBytes(Topic, slicedBuffer);
+        var topicLengthUtf8 = _utf8.GetBytes(topic, slicedBuffer);
         Base64.EncodeToUtf8InPlace(slicedBuffer, topicLengthUtf8, out var topicLengthBase64);
         slicedBuffer = slicedBuffer[topicLengthBase64..];
 
@@ -64,7 +66,7 @@ internal readonly struct PostgresMessageEnvelope
         slicedBuffer = slicedBuffer[1..];
 
         // write payload
-        var payloadLengthUtf8 = _utf8.GetBytes(Payload, slicedBuffer);
+        var payloadLengthUtf8 = _utf8.GetBytes(payload, slicedBuffer);
 
         // create string
         var endOfEncodedString = topicLengthBase64 + 2 + payloadLengthUtf8 + _messageIdLength;
@@ -73,6 +75,12 @@ internal readonly struct PostgresMessageEnvelope
         if (bufferArray is not null)
         {
             ArrayPool<byte>.Shared.Return(bufferArray);
+        }
+
+        if (endOfEncodedString > maxMessagePayloadSize)
+        {
+            var msg = string.Format(PostgresMessageEnvelope_PayloadTooLarge, endOfEncodedString, maxMessagePayloadSize);
+            throw new ArgumentException(msg, nameof(payload));
         }
 
         return result;

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresSubscriptionOptions.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresSubscriptionOptions.cs
@@ -44,6 +44,11 @@ public sealed class PostgresSubscriptionOptions
     public int MaxSendQueueSize { get; set; } = 2048;
 
     /// <summary>
+    /// The maximum serialized size of a message that can be sent using postgres notify.
+    /// </summary>
+    public int MaxMessagePayloadSize { get; set; } = 8000;
+
+    /// <summary>
     /// The subscription options that are used to configure the subscriptions.
     /// </summary>
     public SubscriptionOptions SubscriptionOptions { get; set; } = new();

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgressPubSub.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgressPubSub.cs
@@ -7,6 +7,7 @@ internal sealed class PostgresPubSub : DefaultPubSub
     private readonly IMessageSerializer _serializer;
     private readonly PostgresChannel _channel;
 
+    private readonly int _maxMessagePayloadSize;
     private readonly int _topicBufferCapacity;
     private readonly TopicBufferFullMode _topicBufferFullMode;
 
@@ -20,6 +21,7 @@ internal sealed class PostgresPubSub : DefaultPubSub
     {
         _serializer = serializer;
         _channel = channel;
+        _maxMessagePayloadSize = options.MaxMessagePayloadSize;
         _topicBufferCapacity = options.SubscriptionOptions.TopicBufferCapacity;
         _topicBufferFullMode = options.SubscriptionOptions.TopicBufferFullMode;
     }
@@ -32,7 +34,7 @@ internal sealed class PostgresPubSub : DefaultPubSub
     {
         var serialized = _serializer.Serialize(message);
 
-        var envelope = new PostgresMessageEnvelope(formattedTopic, serialized);
+        var envelope = new PostgresMessageEnvelope(formattedTopic, serialized, _maxMessagePayloadSize);
 
         await _channel.SendAsync(envelope, cancellationToken);
     }
@@ -40,7 +42,7 @@ internal sealed class PostgresPubSub : DefaultPubSub
     /// <inheritdoc />
     protected override async ValueTask OnCompleteAsync(string formattedTopic)
     {
-        var envelope = new PostgresMessageEnvelope(formattedTopic, _serializer.CompleteMessage);
+        var envelope = new PostgresMessageEnvelope(formattedTopic, _serializer.CompleteMessage, _maxMessagePayloadSize);
         await _channel.SendAsync(envelope, cancellationToken: default);
     }
 

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.Designer.cs
@@ -98,5 +98,11 @@ namespace HotChocolate.Subscriptions.Postgres {
                 return ResourceManager.GetString("ChannelWriter_FailedToSend", resourceCulture);
             }
         }
+        
+        internal static string PostgresMessageEnvelope_PayloadTooLarge {
+            get {
+                return ResourceManager.GetString("PostgresMessageEnvelope_PayloadTooLarge", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.resx
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.resx
@@ -52,4 +52,7 @@
   <data name="ChannelWriter_FailedToSend" xml:space="preserve">
     <value>The channel writer failed to send messages. Requeueing {0} messages. Error Message: {1}</value>
   </data>
+  <data name="PostgresMessageEnvelope_PayloadTooLarge" xml:space="preserve">
+    <value>Payload is too long to we written to Postgres. Serialized message is {0} bytes but limit is {1} bytes</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
@@ -67,7 +67,7 @@ public class PostgresChannelTests
 
         // Act
         await channel
-            .SendAsync(new PostgresMessageEnvelope("test", "foobar"), CancellationToken.None);
+            .SendAsync(new PostgresMessageEnvelope("test", "foobar", _options.MaxMessagePayloadSize), CancellationToken.None);
 
         // Assert
         await testChannel.WaitForNotificationAsync();
@@ -184,7 +184,7 @@ public class PostgresChannelTests
 
         // Act
         await channel
-            .SendAsync(new PostgresMessageEnvelope("test", "foobar"), CancellationToken.None);
+            .SendAsync(new PostgresMessageEnvelope("test", "foobar", _options.MaxMessagePayloadSize), CancellationToken.None);
 
         // Assert
         SpinWait.SpinUntil(() => receivedMessages.Count == 1, TimeSpan.FromSeconds(1));
@@ -210,7 +210,7 @@ public class PostgresChannelTests
             new ParallelOptions { MaxDegreeOfParallelism = 10 },
             async (_, ct) =>
             {
-                var message = new PostgresMessageEnvelope("test", "foobar");
+                var message = new PostgresMessageEnvelope("test", "foobar", _options.MaxMessagePayloadSize);
                 await channel.SendAsync(message, ct);
             });
 

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
@@ -37,7 +37,7 @@ public class PostgresChannelWriterTests
         // Arrange
         var postgresChannelWriter = new PostgresChannelWriter(_events, _options);
         await postgresChannelWriter.Initialize(CancellationToken.None);
-        var message = new PostgresMessageEnvelope("test", "test");
+        var message = new PostgresMessageEnvelope("test", "test", _options.MaxMessagePayloadSize);
         var testChannel = new TestChannel(SyncConnectionFactory, _channelName);
 
         // Act
@@ -55,7 +55,7 @@ public class PostgresChannelWriterTests
         // Arrange
         var postgresChannelWriter = new PostgresChannelWriter(_events, _options);
         await postgresChannelWriter.Initialize(CancellationToken.None);
-        var message = new PostgresMessageEnvelope("test", "test");
+        var message = new PostgresMessageEnvelope("test", "test", _options.MaxMessagePayloadSize);
         var testChannel = new TestChannel(SyncConnectionFactory, _channelName);
 
         // Act

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresMessageEnvelopeTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresMessageEnvelopeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -5,16 +6,18 @@ namespace HotChocolate.Subscriptions.Postgres;
 
 public class PostgresMessageEnvelopeTests
 {
+    private readonly PostgresSubscriptionOptions _options = new();
+
     [Theory]
     [InlineData("test", "test")]
     [InlineData("sometopic", """ { ""test"": ""test"" } """)]
     public void Should_FormatAndParse(string topic, string payload)
     {
         // arrange
-        var envelope = new PostgresMessageEnvelope(topic, payload);
+        var envelope = new PostgresMessageEnvelope(topic, payload, _options.MaxMessagePayloadSize);
 
         // act
-        var formatted = envelope.Format();
+        var formatted = envelope.FormattedPayload;
         var parsingResult = PostgresMessageEnvelope
             .TryParse(formatted, out var parsedTopic, out var parsedPayload);
 
@@ -36,10 +39,10 @@ public class PostgresMessageEnvelopeTests
         string formatted)
     {
         // arrange
-        var envelope = new PostgresMessageEnvelope(topic, payload);
+        var envelope = new PostgresMessageEnvelope(topic, payload, _options.MaxMessagePayloadSize);
 
         // act
-        var result = envelope.Format();
+        var result = envelope.FormattedPayload;
 
         // assert
         Assert.Equal(formatted, result[25..]);
@@ -54,10 +57,10 @@ public class PostgresMessageEnvelopeTests
         for (var i = 0; i < 10_000; i++)
         {
             // arrange
-            var envelope = new PostgresMessageEnvelope("test", "test");
+            var envelope = new PostgresMessageEnvelope("test", "test", _options.MaxMessagePayloadSize);
 
             // act
-            var id = envelope.Format()[..24];
+            var id = envelope.FormattedPayload[..24];
 
             // assert
             var bytes = Encoding.UTF8.GetBytes(id);
@@ -78,59 +81,38 @@ public class PostgresMessageEnvelopeTests
     }
 
     [Fact]
-    public void Should_FormatAndParseWithBigPayload()
+    public void Format_ShouldThrow_WithBigPayload()
     {
         // arrange
         var topic = "test";
         var payload = new string('a', 100_000);
-        var envelope = new PostgresMessageEnvelope(topic, payload);
 
-        // act
-        var formatted = envelope.Format();
-        var parsingResult = PostgresMessageEnvelope
-            .TryParse(formatted, out var parsedTopic, out var parsedPayload);
-
-        // assert
-        Assert.True(parsingResult);
-        Assert.Equal(topic, parsedTopic);
-        Assert.Equal(payload, parsedPayload);
+        // act, assert
+        Assert.Throws<ArgumentException>(() =>
+            new PostgresMessageEnvelope(topic, payload, _options.MaxMessagePayloadSize));
     }
 
     [Fact]
-    public void Should_FormatAndParseWithBigTopic()
+    public void Format_ShouldThrow_WithBigTopic()
     {
         // arrange
         var topic = new string('a', 100_000);
         var payload = "test";
-        var envelope = new PostgresMessageEnvelope(topic, payload);
 
-        // act
-        var formatted = envelope.Format();
-        var parsingResult = PostgresMessageEnvelope
-            .TryParse(formatted, out var parsedTopic, out var parsedPayload);
-
-        // assert
-        Assert.True(parsingResult);
-        Assert.Equal(topic, parsedTopic);
-        Assert.Equal(payload, parsedPayload);
+        // act, assert
+        Assert.Throws<ArgumentException>(() =>
+            new PostgresMessageEnvelope(topic, payload, _options.MaxMessagePayloadSize));
     }
 
     [Fact]
-    public void Should_FormatAndParseWithBigTopicAndPayload()
+    public void Format_ShouldThrow_WithBigTopicAndPayload()
     {
         // arrange
         var topic = new string('a', 100_000);
         var payload = new string('a', 100_000);
-        var envelope = new PostgresMessageEnvelope(topic, payload);
 
-        // act
-        var formatted = envelope.Format();
-        var parsingResult = PostgresMessageEnvelope
-            .TryParse(formatted, out var parsedTopic, out var parsedPayload);
-
-        // assert
-        Assert.True(parsingResult);
-        Assert.Equal(topic, parsedTopic);
-        Assert.Equal(payload, parsedPayload);
+        // act, assert
+        Assert.Throws<ArgumentException>(() =>
+            new PostgresMessageEnvelope(topic, payload, _options.MaxMessagePayloadSize));
     }
 }


### PR DESCRIPTION
Postgres has a max limit of 8000 bytes for the payload in pg_notify. Exceeding this limit will result in infinite retries as messages are requeued internally back on to the channel. Due to batching a single poison (over size) message can break delivery of all messages.

This mitigates the infinite loop by blocking the messages from being queued into the subscription system. 


Summary of the changes (Less than 80 chars)

- Throw an ArgumentException when a message is sent that exceeds the byte limit for postgres pg_notify


Closes #6658
