### PR TITLE
Fix Utf8JsonWriterHelper to not ignore null dictionary values

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
@@ -195,14 +195,7 @@ internal static class Utf8JsonWriterHelper
         foreach (var item in dict)
         {
             writer.WritePropertyName(item.Key);
-            if (item.Value is null)
-            {
-                writer.WriteNullValue();
-            }
-            else
-            {
-                WriteFieldValue(writer, item.Value);
-            }
+            WriteFieldValue(writer, item.Value);
         }
 
         writer.WriteEndObject();

--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8JsonWriterHelper.cs
@@ -194,13 +194,15 @@ internal static class Utf8JsonWriterHelper
 
         foreach (var item in dict)
         {
+            writer.WritePropertyName(item.Key);
             if (item.Value is null)
             {
-                continue;
+                writer.WriteNullValue();
             }
-
-            writer.WritePropertyName(item.Key);
-            WriteFieldValue(writer, item.Value);
+            else
+            {
+                WriteFieldValue(writer, item.Value);
+            }
         }
 
         writer.WriteEndObject();

--- a/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/OperationRequestTests.cs
+++ b/src/HotChocolate/AspNetCore/test/Transport.Http.Tests/OperationRequestTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Text;
+using System.Text.Json;
+using CookieCrumble;
+using Moq;
+
+namespace HotChocolate.Transport.Http.Tests;
+
+public class OperationRequestTests
+{
+    [Fact]
+    public async Task Should_WriteNullValues()
+    {
+        // arrange
+        var request = new OperationRequest(
+            null,
+            "abc",
+            "myOperation",
+            variables: new Dictionary<string, object?>()
+            {
+                ["abc"] = "def",
+                ["hij"] = null
+            });
+
+        using var memory = new MemoryStream();
+        await using var writer = new Utf8JsonWriter(memory);
+
+        // act
+        request.WriteTo(writer);
+        await writer.FlushAsync();
+
+        // assert
+        var result = Encoding.UTF8.GetString(memory.ToArray());
+        Assert.Equal(
+            """{"id":"abc","operationName":"myOperation","variables":{"abc":"def","hij":null}}""",
+            result);
+    }
+}


### PR DESCRIPTION
There is a problem with the `Utf8JsonWriterHelper` such that if a null value is given to a dictionary it never writes the key and the null value in the resulting json.

For example, this would avoid sending any null values from StrawberryShake in such a way that if you wanted to set a null value on a request, you could not.  They will always come back as unassigned on the server side and it would never see the `null` value given.

Closes #6681 

NOTE: this and #6683 both exist in (at least) [13.7.0](https://www.nuget.org/packages/StrawberryShake/13.7.0) as well, and should likely be hot fixed.