### PR TITLE
fix: dotnet version check missing locale

### DIFF
--- a/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
+++ b/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
@@ -31,23 +31,17 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_ParseVersion">
-    <Exec Command="dotnet --version" StandardOutputImportance="Low" ConsoleToMsBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="DotNetVersion" />
-    </Exec>
-  </Target>
-
   <Target
     Name="_GenerateGraphQLCode"
     Inputs="@(GenerateGraphQLCodeItems)"
     Outputs="$(MSBuildProjectDirectory)\$(IntermediateOutputPath)berry\.build.info"
-    DependsOnTargets="_ParseVersion;_GraphQLCodeGenerationRoot"
+    DependsOnTargets="_GraphQLCodeGenerationRoot"
     Condition="'@(GraphQL)' != ''">
 
     <PropertyGroup>
-      <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 6))">6</DotNetMajor>
-      <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 7))">7</DotNetMajor>
-      <DotNetMajor Condition="$([MSBuild]::VersionGreaterThanOrEquals($(DotNetVersion), 8))">8</DotNetMajor>
+      <DotNetMajor Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">6</DotNetMajor>
+      <DotNetMajor Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">7</DotNetMajor>
+      <DotNetMajor Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">8</DotNetMajor>
     </PropertyGroup>
 
     <Error


### PR DESCRIPTION
**Describe the change**
This change refactors the dotnet version check to use the target framework of the project instead.

**Current behavior**
The command `dotnet --version` is executed which can cause issues if the required locale is missing.

**New behavior**
The target framework of the project is used to determine the major version of .NET for build steps.

**Additional context**
Closes #6441