### PR TITLE
Fixed rider issue with file references in StrawberryShake

### DIFF
--- a/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
+++ b/src/StrawberryShake/MetaPackages/Common/MSBuild/StrawberryShake.targets
@@ -20,7 +20,7 @@
     BeforeTargets="BeforeBuild"
     DependsOnTargets="_GraphQLCodeGenerationRoot; _GenerateGraphQLCode">
     <ItemGroup>
-      <Compile Include="$(GraphQLCodeGenerationRoot)\**\*.cs" />
+      <Compile Include="$(GraphQLCodeGenerationRoot)\**\*.cs" Condition="'$(GraphQLCodeGenerationRoot)' != ''"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This pull requests fixes https://github.com/ChilliCream/graphql-platform/issues/6179  also reported here https://youtrack.jetbrains.com/issue/RIDER-91406/Rider-automatically-adds-links-to-other-project 

I did try this in the past before in #6506  but had to revert in #6538, because it basically broke everything. 

My mistake was that I tested it locally and for whatever reason, msbuild didnt let me overwrite the targets of the package. You need to explicitly import the StrawberryShake targets in your csproj for testing these things. So even though i specified the override, it apparently never happened. Well, now i know. 

I tested out a few things locally recently and i know now how to overwrite the targets. So i tried to solve this problem again. 

The issue with my initial pull request is, that the condition i specified is invalid. I used an @ instead of a $ for a property. 
Locally i could not verify if i can exclude the target with a correct condition, but what worked for me is add a condition to the compile step. 

I hope that this pull requests removes all the pain and agony that rider users experience with strawberry shake. 
