### PR TITLE
Fixed argument naming conventions for mutation conventions.

### DIFF
--- a/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorMiddleware.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorMiddleware.cs
@@ -1,17 +1,11 @@
 namespace HotChocolate.Types;
 
-internal sealed class ErrorMiddleware
+internal sealed class ErrorMiddleware(FieldDelegate next, IReadOnlyList<CreateError> errorHandlers)
 {
-    private readonly FieldDelegate _next;
-    private readonly IReadOnlyList<CreateError> _errorHandlers;
-
-    public ErrorMiddleware(FieldDelegate next, IReadOnlyList<CreateError> errorHandlers)
-    {
-        _next = next ??
-            throw new ArgumentNullException(nameof(next));
-        _errorHandlers = errorHandlers ??
-            throw new ArgumentNullException(nameof(errorHandlers));
-    }
+    private readonly FieldDelegate _next = next ??
+        throw new ArgumentNullException(nameof(next));
+    private readonly IReadOnlyList<CreateError> _errorHandlers = errorHandlers ??
+        throw new ArgumentNullException(nameof(errorHandlers));
 
     public async ValueTask InvokeAsync(IMiddlewareContext context)
     {

--- a/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorNullMiddleware.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorNullMiddleware.cs
@@ -2,7 +2,8 @@ namespace HotChocolate.Types;
 
 internal sealed class ErrorNullMiddleware(FieldDelegate next)
 {
-    private readonly FieldDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
+    private readonly FieldDelegate _next = next ?? 
+        throw new ArgumentNullException(nameof(next));
 
     public async ValueTask InvokeAsync(IMiddlewareContext context)
     {

--- a/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorObjectType.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorObjectType.cs
@@ -1,7 +1,5 @@
 using System.Linq;
 
-#nullable enable
-
 namespace HotChocolate.Types;
 
 internal sealed class ErrorObjectType<T> : ObjectType<T>

--- a/src/HotChocolate/Core/src/Types.Mutations/Extensions/MutationObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Extensions/MutationObjectFieldDescriptorExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace HotChocolate.Types;
 
 /// <summary>

--- a/src/HotChocolate/Core/src/Types.Mutations/Extensions/ObjectFieldDefinitionExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Extensions/ObjectFieldDefinitionExtensions.cs
@@ -1,8 +1,6 @@
 using static HotChocolate.Properties.TypeResources;
 using static HotChocolate.Types.ErrorContextDataKeys;
 
-#nullable enable
-
 namespace HotChocolate.Types;
 
 /// <summary>

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationContextData.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationContextData.cs
@@ -4,43 +4,31 @@ namespace HotChocolate.Types;
 /// This internal data structure is used to store the effective mutation options of a field
 /// on the context so that the type interceptor can access them.
 /// </summary>
-internal sealed class MutationContextData
+internal sealed class MutationContextData(
+    ObjectFieldDefinition definition,
+    string? inputTypeName,
+    string? inputArgumentName,
+    string? payloadTypeName,
+    string? payloadFieldName,
+    string? payloadErrorTypeName,
+    string? payloadErrorsFieldName,
+    bool enabled)
 {
-    public MutationContextData(
-        ObjectFieldDefinition definition,
-        string? inputTypeName,
-        string? inputArgumentName,
-        string? payloadTypeName,
-        string? payloadFieldName,
-        string? payloadErrorTypeName,
-        string? payloadErrorsFieldName,
-        bool enabled)
-    {
-        Definition = definition;
-        InputTypeName = inputTypeName;
-        InputArgumentName = inputArgumentName;
-        PayloadTypeName = payloadTypeName;
-        PayloadFieldName = payloadFieldName;
-        PayloadPayloadErrorTypeName = payloadErrorTypeName;
-        PayloadErrorsFieldName = payloadErrorsFieldName;
-        Enabled = enabled;
-    }
-
     public string Name => Definition.Name;
 
-    public ObjectFieldDefinition Definition { get; }
+    public ObjectFieldDefinition Definition { get; } = definition;
 
-    public string? InputTypeName { get; }
+    public string? InputTypeName { get; } = inputTypeName;
 
-    public string? InputArgumentName { get; }
+    public string? InputArgumentName { get; } = inputArgumentName;
 
-    public string? PayloadFieldName { get; }
+    public string? PayloadFieldName { get; } = payloadFieldName;
 
-    public string? PayloadTypeName { get; }
+    public string? PayloadTypeName { get; } = payloadTypeName;
 
-    public string? PayloadPayloadErrorTypeName { get; }
+    public string? PayloadPayloadErrorTypeName { get; } = payloadErrorTypeName;
 
-    public string? PayloadErrorsFieldName { get; }
+    public string? PayloadErrorsFieldName { get; } = payloadErrorsFieldName;
 
-    public bool Enabled { get; }
+    public bool Enabled { get; } = enabled;
 }

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationContextDataKeys.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationContextDataKeys.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace HotChocolate.Types;
 
 internal static class MutationContextDataKeys

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationConventionMiddleware.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationConventionMiddleware.cs
@@ -8,24 +8,17 @@ namespace HotChocolate.Types;
 /// This middleware ensures that the rewritten argument structure is remapped so that the
 /// resolver can request the arguments in the original structure.
 /// </summary>
-internal sealed class MutationConventionMiddleware
+internal sealed class MutationConventionMiddleware(
+    FieldDelegate next,
+    string inputArgumentName,
+    IReadOnlyList<ResolverArgument> resolverArguments)
 {
-    private readonly FieldDelegate _next;
-    private readonly string _inputArgumentName;
-    private readonly IReadOnlyList<ResolverArgument> _resolverArguments;
-
-    public MutationConventionMiddleware(
-        FieldDelegate next,
-        string inputArgumentName,
-        IReadOnlyList<ResolverArgument> resolverArguments)
-    {
-        _next = next ??
-            throw new ArgumentNullException(nameof(next));
-        _inputArgumentName = inputArgumentName ??
-            throw new ArgumentNullException(nameof(inputArgumentName));
-        _resolverArguments = resolverArguments ??
-            throw new ArgumentNullException(nameof(resolverArguments));
-    }
+    private readonly FieldDelegate _next = next ??
+        throw new ArgumentNullException(nameof(next));
+    private readonly string _inputArgumentName = inputArgumentName ??
+        throw new ArgumentNullException(nameof(inputArgumentName));
+    private readonly IReadOnlyList<ResolverArgument> _resolverArguments = resolverArguments ??
+        throw new ArgumentNullException(nameof(resolverArguments));
 
     public async ValueTask InvokeAsync(IMiddlewareContext context)
     {

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using HotChocolate.Types.Helpers;
 using static HotChocolate.WellKnownMiddleware;
 using static HotChocolate.Types.Descriptors.TypeReference;
 using static HotChocolate.Resolvers.FieldClassMiddlewareFactory;
@@ -191,7 +192,7 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
 
         if (mutation.Member is not null)
         {
-            var argumentNameMap = new Dictionary<ParameterInfo, string>();
+            var argumentNameMap = TypeMemHelper.RentArgumentNameMap();
 
             foreach (var arg in mutation.Arguments)
             {
@@ -207,6 +208,8 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
                     mutation.SourceType,
                     mutation.ResolverType,
                     argumentNameMap);
+            
+            TypeMemHelper.Return(argumentNameMap);
         }
 
         var inputTypeName = options.FormatInputTypeName(mutation.Name);

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationResultTypeDiscoveryHandler.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationResultTypeDiscoveryHandler.cs
@@ -2,14 +2,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace HotChocolate.Types;
 
-internal sealed class MutationResultTypeDiscoveryHandler : TypeDiscoveryHandler
+internal sealed class MutationResultTypeDiscoveryHandler(ITypeInspector typeInspector) : TypeDiscoveryHandler
 {
-    private readonly ITypeInspector _typeInspector;
-
-    public MutationResultTypeDiscoveryHandler(ITypeInspector typeInspector)
-    {
-        _typeInspector = typeInspector ?? throw new ArgumentNullException(nameof(typeInspector));
-    }
+    private readonly ITypeInspector _typeInspector = typeInspector ?? 
+        throw new ArgumentNullException(nameof(typeInspector));
 
     public override bool TryInferType(
         TypeReference typeReference,

--- a/src/HotChocolate/Core/src/Types.Mutations/ResolverArgument.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/ResolverArgument.cs
@@ -1,35 +1,24 @@
-#nullable enable
-
 namespace HotChocolate.Types;
 
-internal sealed class ResolverArgument : IInputFieldInfo
+internal sealed class ResolverArgument(
+    string name,
+    FieldCoordinate coordinate,
+    IInputType type,
+    Type runtimeType,
+    IValueNode? defaultValue,
+    IInputValueFormatter? formatter)
+    : IInputFieldInfo
 {
-    public ResolverArgument(
-        string name,
-        FieldCoordinate coordinate,
-        IInputType type,
-        Type runtimeType,
-        IValueNode? defaultValue,
-        IInputValueFormatter? formatter)
-    {
-        Name = name;
-        Coordinate = coordinate;
-        RuntimeType = runtimeType;
-        Type = type;
-        DefaultValue = defaultValue;
-        Formatter = formatter;
-    }
+    public string Name { get; } = name;
 
-    public string Name { get; }
+    public FieldCoordinate Coordinate { get; } = coordinate;
 
-    public FieldCoordinate Coordinate { get; }
+    public IInputType Type { get; } = type;
 
-    public IInputType Type { get; }
+    public Type RuntimeType { get; } = runtimeType;
 
-    public Type RuntimeType { get; }
+    public IValueNode? DefaultValue { get; } = defaultValue;
 
-    public IValueNode? DefaultValue { get; }
-
-    public IInputValueFormatter? Formatter { get; }
+    public IInputValueFormatter? Formatter { get; } = formatter;
 }
 

--- a/src/HotChocolate/Core/src/Types.Mutations/UseMutationConventionAttribute.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/UseMutationConventionAttribute.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace HotChocolate.Types;
 
 /// <summary>

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -1213,26 +1213,29 @@ public class AnnotationBasedMutations
                 .ModifyOptions(o => o.StrictValidation = false)
                 .ExecuteRequestAsync(
                     """
-                        mutation {
-                            doSomething_Named(input: { name_Named: "coco" }) {
-                                user_Named {
-                                    id_Named
-                                    name_Named
-                                }
+                    mutation {
+                        doSomething_Named(input: { name_Named: "coco" }) {
+                            user_Named {
+                                id_Named
+                                name_Named
                             }
                         }
-                        """);
+                    }
+                    """);
 
         result.MatchInlineSnapshot(
             """
-                {
-                  "data": {
-                    "doSomething_Named": {
-                      "name_Named": "coco"
-                    }
+            {
+              "data": {
+                "doSomething_Named": {
+                  "user_Named": {
+                    "id_Named": "00000000-0000-0000-0000-000000000000",
+                    "name_Named": "coco"
                   }
                 }
-                """);
+              }
+            }
+            """);
     }
 
     public class SimpleMutation

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using CookieCrumble;
 using HotChocolate.Configuration;
@@ -1200,6 +1201,40 @@ public class AnnotationBasedMutations
         result.Print().MatchSnapshot();
     }
 
+    [Fact]
+    public async Task Mutation_With_MutationConventionsAndNamingConventions()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddMutationType<MutationConventionsAndNamingConventionsMutation>()
+                .AddConvention<INamingConventions, CustomNamingConvention>()
+                .AddMutationConventions()
+                .ModifyOptions(o => o.StrictValidation = false)
+                .ExecuteRequestAsync(
+                    """
+                        mutation {
+                            doSomething_Named(input: { name_Named: "coco" }) {
+                                user_Named {
+                                    id_Named
+                                    name_Named
+                                }
+                            }
+                        }
+                        """);
+
+        result.MatchInlineSnapshot(
+            """
+                {
+                  "data": {
+                    "doSomething_Named": {
+                      "name_Named": "coco"
+                    }
+                  }
+                }
+                """);
+    }
+
     public class SimpleMutation
     {
         public string DoSomething(string something)
@@ -1355,6 +1390,14 @@ public class AnnotationBasedMutations
         public string DoSomething(string something1, string something2)
         {
             throw new Exception();
+        }
+    }
+
+    public class MutationConventionsAndNamingConventionsMutation
+    {
+        public User DoSomething(string name)
+        {
+            return new User { Name = name };
         }
     }
 
@@ -1628,7 +1671,7 @@ public class AnnotationBasedMutations
     {
         /// <inheritdoc />
         public string Message => string.Empty;
-        
+
         /// <inheritdoc />
         public string Name => string.Empty;
     }
@@ -1653,5 +1696,46 @@ public class AnnotationBasedMutations
     public interface IErrorInterface
     {
         public string Message { get; }
+    }
+
+    public class CustomNamingConvention : DefaultNamingConventions
+    {
+        public override string GetArgumentName(ParameterInfo parameter)
+        {
+            var name = base.GetArgumentName(parameter);
+            return name + "_Named";
+        }
+
+        public override string GetArgumentDescription(ParameterInfo parameter)
+        {
+            return "GetArgumentDescription";
+        }
+
+        public override string GetMemberDescription(MemberInfo member, MemberKind kind)
+        {
+            return "GetMemberDescription";
+        }
+
+        public override string GetTypeName(Type type, TypeKind kind)
+        {
+            var name = base.GetTypeName(type, kind);
+            return name + "_Named";
+        }
+
+        public override string GetEnumValueDescription(object value)
+        {
+            return "GetEnumValueDescription";
+        }
+
+        public override string GetMemberName(MemberInfo member, MemberKind kind)
+        {
+            var name = base.GetMemberName(member, kind);
+            return name + "_Named";
+        }
+
+        public override string GetTypeDescription(Type type, TypeKind kind)
+        {
+            return "GetTypeDescription";
+        }
     }
 }


### PR DESCRIPTION
- adds failing test to outline issue when enabling mutation conventions + custom naming conventions

Relates to [#3088](https://github.com/ChilliCream/graphql-platform/issues/3088)
