### PR TITLE
Avoid checking for null on non-nullable property for projection

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
@@ -14,6 +14,8 @@ public class QueryableProjectionFieldHandler
         selection.Field.Member is { } &&
         selection.SelectionSet is not null;
 
+    private readonly NullabilityInfoContext _nullabilityInfoContext = new();
+
     public override bool TryHandleEnter(
         QueryableProjectionContext context,
         ISelection selection,
@@ -90,7 +92,10 @@ public class QueryableProjectionFieldHandler
             return true;
         }
 
-        if (context.InMemory)
+        // TODO: Use existing utility function/extension method? Cache?
+        var nullabilityInfo = _nullabilityInfoContext.Create(propertyInfo);
+
+        if (context.InMemory && nullabilityInfo.ReadState == NullabilityState.Nullable)
         {
             parentScope.Level
                 .Peek()

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionComplexTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionComplexTypeTests.cs
@@ -1,0 +1,63 @@
+using System.Threading.Tasks;
+using CookieCrumble;
+using HotChocolate.Execution;
+using Microsoft.EntityFrameworkCore;
+
+namespace HotChocolate.Data.Projections;
+
+#if NET8_0_OR_GREATER
+public class QueryableProjectionComplexTypeTests
+{
+    private static readonly Foo[] _fooEntities =
+    {
+        new() { Bar = new Bar { Baz = "testatest", } },
+        new() { Bar = new Bar { Baz = "testbtest", } },
+    };
+
+    private readonly SchemaCache _cache = new SchemaCache();
+
+    [Fact]
+    public async Task Create_Complex_Type()
+    {
+        // arrange
+        var tester = _cache.CreateSchema(_fooEntities, OnModelCreating);
+
+        // act
+        var res1 = await tester.ExecuteAsync(
+            QueryRequestBuilder.New()
+                .SetQuery(
+                    @"
+                        {
+                            root {
+                                bar {
+                                    baz
+                                }
+                            }
+                        }")
+                .Create());
+
+        // assert
+        await Snapshot
+            .Create()
+            .AddResult(res1)
+            .MatchAsync();
+    }
+
+    private static void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Foo>().ComplexProperty(f => f.Bar);
+    }
+
+    public class Foo
+    {
+        public int Id { get; set; }
+
+        public Bar Bar { get; set; } = null!;
+    }
+
+    public record Bar
+    {
+        public string Baz { get; set; } = null!;
+    }
+}
+#endif

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionComplexTypeTests.Create_Object_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionComplexTypeTests.Create_Object_NET8_0.snap
@@ -4,13 +4,13 @@ Result:
   "data": {
     "root": [
       {
-        "foo": {
-          "barString": "testatest"
+        "bar": {
+          "baz": "testatest"
         }
       },
       {
-        "foo": {
-          "barString": "testbtest"
+        "bar": {
+          "baz": "testbtest"
         }
       }
     ]
@@ -20,7 +20,6 @@ Result:
 
 SQL:
 ---------------
-SELECT "f"."BarString"
+SELECT "d"."Bar_Baz" AS "Baz"
 FROM "Data" AS "d"
-INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
@@ -29,11 +29,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
@@ -29,11 +29,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
@@ -29,11 +29,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
@@ -31,11 +31,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
@@ -31,11 +31,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionFilterTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
@@ -31,11 +31,11 @@ SQL:
 ---------------
 .param set @__p_0 'a'
 
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
     WHERE "f0"."BarString" = @__p_0

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionHashSetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionISetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET6_0.snap
@@ -22,7 +22,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET7_0.snap
@@ -22,7 +22,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionInterfaceTypeTests.Create_Interface_Nested_NET8_0.snap
@@ -22,7 +22,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."Name", "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionNestedTests.Create_Object_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionNestedTests.Create_Object_NET7_0.snap
@@ -20,7 +20,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString"
+SELECT "f"."BarString"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionNestedTests.Create_Object_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionNestedTests.Create_Object_NET8_0.snap
@@ -20,7 +20,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString"
+SELECT "f"."BarString"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
@@ -34,11 +34,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortedSetTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
@@ -36,11 +36,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET6_0.snap
@@ -58,11 +58,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET7_0.snap
@@ -58,11 +58,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_NET8_0.snap
@@ -58,11 +58,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET6_0.snap
@@ -60,11 +60,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET7_0.snap
@@ -60,11 +60,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_NET8_0.snap
@@ -60,11 +60,11 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "f"."BarString", "d"."Id", "f"."Id", "t"."c", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
+SELECT "f"."BarString", "d"."Id", "f"."Id", "t"."BarString", "t"."BarShort", "t"."Id", "t"."Id0"
 FROM "Data" AS "d"
 INNER JOIN "Foo" AS "f" ON "d"."FooId" = "f"."Id"
 LEFT JOIN (
-    SELECT 1 AS "c", "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
+    SELECT "f0"."BarString", "f0"."BarShort", "b"."Id", "f0"."Id" AS "Id0", "b"."FooId"
     FROM "BarDeep" AS "b"
     INNER JOIN "FooDeep" AS "f0" ON "b"."FooId1" = "f0"."Id"
 ) AS "t" ON "f"."Id" = "t"."FooId"

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET6_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET6_0.snap
@@ -20,7 +20,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET7_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET7_0.snap
@@ -20,7 +20,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET8_0.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Nested_NET8_0.snap
@@ -20,7 +20,7 @@ Result:
 
 SQL:
 ---------------
-SELECT 1, "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
+SELECT "a"."d" = 'bar', "a"."BarProp", "a"."d" = 'foo', "a"."FooProp"
 FROM "Data" AS "d"
 INNER JOIN "AbstractType" AS "a" ON "d"."NestedId" = "a"."Id"
 ---------------


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Check the nullability of properties before doing a null check.

Closes #6604.

---

- I'm not sure what `context.InMemory` is about.
- Is there an existing utility function/extension method for checking this nullability?
- Should these nullability checks be cached?