### PR TITLE
Fixed large json read corruption 

### DIFF
--- a/src/HotChocolate/Fusion/src/Abstractions/JsonElementExtensions.cs
+++ b/src/HotChocolate/Fusion/src/Abstractions/JsonElementExtensions.cs
@@ -11,7 +11,8 @@ internal static class JsonElementExtensions
         using var jsonWriter = new Utf8JsonWriter(writer);
 
         element.WriteTo(jsonWriter);
-        var reader = new Utf8JsonReader(writer.GetSpan(), true, default);
+        jsonWriter.Flush();
+        var reader = new Utf8JsonReader(writer.GetWrittenSpan(), true, default);
 
         return JsonElement.ParseValue(ref reader);
     }

--- a/src/StrawberryShake/Client/src/Core/Serialization/JsonSerializer.cs
+++ b/src/StrawberryShake/Client/src/Core/Serialization/JsonSerializer.cs
@@ -20,9 +20,10 @@ public class JsonSerializer : ScalarSerializer<JsonElement, JsonElement>
         // write json value to buffer.
         using var jsonWriter = new Utf8JsonWriter(writer);
         serializedValue.WriteTo(jsonWriter);
+        jsonWriter.Flush();
         
         // now we read the buffer and create an element that does not need to be disposed. 
-        var reader = new Utf8JsonReader(writer.GetSpan(), true, default);
+        var reader = new Utf8JsonReader(writer.GetWrittenSpan(), true, default);
         return JsonElement.ParseValue(ref reader);
     }
 

--- a/src/StrawberryShake/Client/test/Core.Tests/Serialization/JsonSerializerTests.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Serialization/JsonSerializerTests.cs
@@ -22,6 +22,19 @@ public class JsonSerializerTests
     }
 
     [Fact]
+    public void ParseLarge()
+    {
+        // arrange
+        var json = System.Text.Json.JsonSerializer.SerializeToElement($@"""{"padding",10000}""");
+
+        // act
+        var serialized = _serializer.Parse(json);
+
+        // assert
+        Assert.Equal(json.ToString(), serialized.ToString());
+    }
+
+    [Fact]
     public void Format()
     {
         // arrange

--- a/src/StrawberryShake/Client/test/Core.Tests/Serialization/JsonSerializerTests.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Serialization/JsonSerializerTests.cs
@@ -35,6 +35,22 @@ public class JsonSerializerTests
     }
 
     [Fact]
+    public void UseAfterDispose()
+    {
+        // arrange
+        var json = JsonDocument.Parse(@"{ ""abc"": {""def"":""def""} }");
+        var element = json.RootElement.EnumerateObject().First().Value;
+
+        // act
+        var serialized = _serializer.Parse(element);
+        var expected = element.ToString();
+        json.Dispose();
+
+        // assert
+        Assert.Equal(expected, serialized.ToString());
+    }
+
+    [Fact]
     public void Format()
     {
         // arrange


### PR DESCRIPTION
`GetSpan()` worked when json is small

fixes #6683