### PR TITLE
Fix typo in Banana Cake Pop docs

### DIFF
--- a/website/src/pages/products/bananacakepop.tsx
+++ b/website/src/pages/products/bananacakepop.tsx
@@ -105,7 +105,7 @@ const BananaCakePopPage: FC = () => {
                 <h2>Organization Workspaces</h2>
               </header>
               <p>
-                Organize your GraphQL APIs and collaborate with colleges across
+                Organize your GraphQL APIs and collaborate with colleagues across
                 your organization with ease.
               </p>
             </CardOffer>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Colleagues was misspelled as colleges