### PR TITLE
Fix unhandeled exception when deserializing json

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/UpdateCommandHandler.cs
@@ -78,8 +78,7 @@ public class UpdateCommandHandler : CommandHandler<UpdateCommandArguments>
         CancellationToken cancellationToken)
     {
         var configFilePath = Combine(clientDirectory, WellKnownFiles.Config);
-        var buffer = await FileSystem.ReadAllBytesAsync(configFilePath).ConfigureAwait(false);
-        var json = Encoding.UTF8.GetString(buffer);
+        var json = File.ReadAllText(configFilePath);
         var configuration = GraphQLConfig.FromJson(json);
 
         if (await UpdateSchemaAsync(context, clientDirectory, configuration, cancellationToken)


### PR DESCRIPTION
Changing the methode of reading the GraphQL config json file from _ReadAllBytesAsync_ to _ReadAllText_ because the first one throws an unhandeled exception (Newtonsoft.Json.JsonReaderException) when deserializing the json

Closes #6745
