### PR TITLE
Avoid writing BOM in StrawberryShake Tools

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/DefaultFileSystem.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/DefaultFileSystem.cs
@@ -65,7 +65,10 @@ public class DefaultFileSystem : IFileSystem
     }
 
     public Task WriteTextAsync(string fileName, string text) =>
-        Task.Run(() => File.WriteAllText(fileName, text, Encoding.UTF8));
+        Task.Run(() => File.WriteAllText(
+            fileName,
+            text,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)));
 
     public Task<byte[]> ReadAllBytesAsync(string fileName) =>
         Task.Run(() => File.ReadAllBytes(fileName));


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated `WriteTextAsync` so that it doesn't write a BOM.

Relates to #6745.