### PR TITLE
Trailing commas in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 rulers = 120
 
-# ReSharper inspection severities
-resharper_arrange_trailing_comma_in_multiline_lists_highlighting = error
-
 [*.md]
 trim_trailing_whitespace = false
 
@@ -105,12 +102,56 @@ dotnet_style_require_accessibility_modifiers = always
 dotnet_diagnostic.rs0016.severity = warning
 
 # Require braces on all control statements
-resharper_csharp_braces_for_ifelse = required
-resharper_csharp_braces_for_for = required
-resharper_csharp_braces_for_foreach = required
-resharper_csharp_braces_for_while = required
-resharper_csharp_braces_for_using = required
-resharper_csharp_braces_for_lock = required
-resharper_csharp_braces_for_fixed = required
+resharper_braces_for_for = required
+resharper_braces_for_foreach = required
+resharper_braces_for_ifelse = required
+resharper_braces_for_while = required
 
-# Trailing commas
+# ReSharper inspection severities
+resharper_arrange_trailing_comma_in_multiline_lists_highlighting = error
+resharper_enforce_do_while_statement_braces_highlighting = error
+resharper_enforce_fixed_statement_braces_highlighting = error
+resharper_enforce_foreach_statement_braces_highlighting = error
+resharper_enforce_for_statement_braces_highlighting = error
+resharper_enforce_if_statement_braces_highlighting = error
+resharper_enforce_lock_statement_braces_highlighting = error
+resharper_enforce_using_statement_braces_highlighting = error
+resharper_enforce_while_statement_braces_highlighting = error
+
+# Non-default naming for private static fields
+dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_constants_rule.resharper_style = _ + aaBb
+dotnet_naming_rule.private_constants_rule.severity = error
+dotnet_naming_rule.private_constants_rule.style = private_static_field_style
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+
+dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_fields_rule.resharper_style = _ + aaBb
+dotnet_naming_rule.private_static_fields_rule.severity = error
+dotnet_naming_rule.private_static_fields_rule.style = private_static_field_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+
+dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_readonly_rule.resharper_style = _ + aaBb
+dotnet_naming_rule.private_static_readonly_rule.severity = error
+dotnet_naming_rule.private_static_readonly_rule.style = private_static_field_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
+
+dotnet_naming_style.private_static_field_style.capitalization = camel_case
+dotnet_naming_style.private_static_field_style.required_prefix = _
+
+# ReSharper properties
+resharper_align_multiline_binary_expressions_chain = false
+resharper_trailing_comma_in_multiline_lists = true
+resharper_wrap_before_binary_pattern_op = false
+resharper_wrap_chained_binary_expressions = chop_if_long
+resharper_wrap_chained_binary_patterns = chop_if_long

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,7 +31,6 @@ dotnet_style_predefined_type_for_member_access = true:error
 
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = always
-csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async
 
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion
@@ -101,3 +100,12 @@ dotnet_style_require_accessibility_modifiers = always
 
 # Public API
 dotnet_diagnostic.RS0016.severity = warning
+
+# Require braces on all control statements
+resharper_csharp_braces_for_ifelse = required
+resharper_csharp_braces_for_for = required
+resharper_csharp_braces_for_foreach = required
+resharper_csharp_braces_for_while = required
+resharper_csharp_braces_for_using = required
+resharper_csharp_braces_for_lock = required
+resharper_csharp_braces_for_fixed = required

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 rulers = 120
 
+# ReSharper inspection severities
+resharper_arrange_trailing_comma_in_multiline_lists_highlighting = error
+
 [*.md]
 trim_trailing_whitespace = false
 
@@ -99,7 +102,7 @@ csharp_preserve_single_line_blocks = true
 dotnet_style_require_accessibility_modifiers = always
 
 # Public API
-dotnet_diagnostic.RS0016.severity = warning
+dotnet_diagnostic.rs0016.severity = warning
 
 # Require braces on all control statements
 resharper_csharp_braces_for_ifelse = required
@@ -109,3 +112,5 @@ resharper_csharp_braces_for_while = required
 resharper_csharp_braces_for_using = required
 resharper_csharp_braces_for_lock = required
 resharper_csharp_braces_for_fixed = required
+
+# Trailing commas

--- a/.editorconfig
+++ b/.editorconfig
@@ -29,9 +29,6 @@ dotnet_style_qualification_for_event = false:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:error
 dotnet_style_predefined_type_for_member_access = true:error
 
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = always
-
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
@@ -117,37 +114,6 @@ resharper_enforce_if_statement_braces_highlighting = error
 resharper_enforce_lock_statement_braces_highlighting = error
 resharper_enforce_using_statement_braces_highlighting = error
 resharper_enforce_while_statement_braces_highlighting = error
-
-# Non-default naming for private static fields
-dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_constants_rule.resharper_style = _ + aaBb
-dotnet_naming_rule.private_constants_rule.severity = error
-dotnet_naming_rule.private_constants_rule.style = private_static_field_style
-dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
-dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
-
-dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_static_fields_rule.resharper_style = _ + aaBb
-dotnet_naming_rule.private_static_fields_rule.severity = error
-dotnet_naming_rule.private_static_fields_rule.style = private_static_field_style
-dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
-dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
-
-dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
-dotnet_naming_rule.private_static_readonly_rule.resharper_style = _ + aaBb
-dotnet_naming_rule.private_static_readonly_rule.severity = error
-dotnet_naming_rule.private_static_readonly_rule.style = private_static_field_style
-dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
-dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
-dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
-
-dotnet_naming_style.private_static_field_style.capitalization = camel_case
-dotnet_naming_style.private_static_field_style.required_prefix = _
 
 # ReSharper properties
 resharper_align_multiline_binary_expressions_chain = false

--- a/src/CookieCrumble/src/CookieCrumble/Formatters/ExecutionResultSnapshotValueFormatter.cs
+++ b/src/CookieCrumble/src/CookieCrumble/Formatters/ExecutionResultSnapshotValueFormatter.cs
@@ -229,7 +229,7 @@ internal class JsonResultPatcher
                 {
                     JsonValueKind.String => current[last.Value.GetString()!]!,
                     JsonValueKind.Number => current[last.Value.GetInt32()]!,
-                    _ => throw new NotSupportedException("Path segment must be int or string.")
+                    _ => throw new NotSupportedException("Path segment must be int or string."),
                 };
             }
 

--- a/src/CookieCrumble/src/CookieCrumble/Formatters/JsonSnapshotValueFormatter.cs
+++ b/src/CookieCrumble/src/CookieCrumble/Formatters/JsonSnapshotValueFormatter.cs
@@ -17,7 +17,7 @@ internal sealed class JsonSnapshotValueFormatter : ISnapshotValueFormatter
             DateFormatHandling = DateFormatHandling.IsoDateFormat,
             Culture = CultureInfo.InvariantCulture,
             ContractResolver = ChildFirstContractResolver.Instance,
-            Converters = new List<JsonConverter> { new StringEnumConverter() }
+            Converters = new List<JsonConverter> { new StringEnumConverter() },
         };
 
     public bool CanHandle(object? value)

--- a/src/GreenDonut/src/Core/ResultKind.cs
+++ b/src/GreenDonut/src/Core/ResultKind.cs
@@ -18,5 +18,5 @@ public enum ResultKind
     /// <summary>
     /// The result is an error.
     /// </summary>
-    Error
+    Error,
 }

--- a/src/GreenDonut/test/Core.Tests/DataLoaderOptionsTests.cs
+++ b/src/GreenDonut/test/Core.Tests/DataLoaderOptionsTests.cs
@@ -15,7 +15,7 @@ public class DataLoaderOptionsTests
             Cache = new TaskCache(1),
             Caching = true,
             MaxBatchSize = 1,
-            DiagnosticEvents = new DataLoaderDiagnosticEventListener()
+            DiagnosticEvents = new DataLoaderDiagnosticEventListener(),
         };
 
         // assert
@@ -34,7 +34,7 @@ public class DataLoaderOptionsTests
             Cache = null,
             Caching = false,
             MaxBatchSize = 10,
-            DiagnosticEvents = null
+            DiagnosticEvents = null,
         };
 
         // assert
@@ -66,7 +66,7 @@ public class DataLoaderOptionsTests
             Cache = new TaskCache(1),
             Caching = true,
             MaxBatchSize = 1,
-            DiagnosticEvents = new DataLoaderDiagnosticEventListener()
+            DiagnosticEvents = new DataLoaderDiagnosticEventListener(),
         };
 
         // act

--- a/src/GreenDonut/test/Core.Tests/DataLoaderTests.cs
+++ b/src/GreenDonut/test/Core.Tests/DataLoaderTests.cs
@@ -124,7 +124,7 @@ public class DataLoaderTests
             batchScheduler,
             new DataLoaderOptions
             {
-                Caching = false
+                Caching = false,
             });
         var key = "Foo";
 
@@ -293,7 +293,7 @@ public class DataLoaderTests
             batchScheduler,
             new DataLoaderOptions
             {
-                Caching = false
+                Caching = false,
             });
         var keys = new List<string> { "Foo" };
 
@@ -314,7 +314,7 @@ public class DataLoaderTests
             { "Foo", "Bar" },
             { "Bar", null },
             { "Baz", "Foo" },
-            { "Qux", null }
+            { "Qux", null },
         };
 
         ValueTask Fetch(
@@ -359,7 +359,7 @@ public class DataLoaderTests
         {
             { "Foo", "Bar" },
             { "Bar", "Baz" },
-            { "Baz", "Foo" }
+            { "Baz", "Foo" },
         };
 
         ValueTask Fetch(
@@ -469,7 +469,7 @@ public class DataLoaderTests
         var options = new DataLoaderOptions
         {
             Caching = caching,
-            MaxBatchSize = batching ? 1 : maxBatchSize
+            MaxBatchSize = batching ? 1 : maxBatchSize,
         };
 
         var batchScheduler = new ManualBatchScheduler();

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Descriptors/EntityResolverDescriptor.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Descriptors/EntityResolverDescriptor.cs
@@ -57,7 +57,7 @@ public sealed class EntityResolverDescriptor<TEntity>
                     EntityResolver,
                     new List<ReferenceResolverDefinition>
                     {
-                        Definition.ResolverDefinition.Value
+                        Definition.ResolverDefinition.Value,
                     });
             }
         }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationSchemaPrinter.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationSchemaPrinter.cs
@@ -14,8 +14,8 @@ namespace HotChocolate.ApolloFederation;
 /// </summary>
 public static partial class FederationSchemaPrinter
 {
-    private static readonly HashSet<string> _builtInDirectives = new()
-    {
+    private static readonly HashSet<string> _builtInDirectives =
+    [
         WellKnownTypeNames.External,
         WellKnownTypeNames.Requires,
         WellKnownTypeNames.Provides,
@@ -25,8 +25,8 @@ public static partial class FederationSchemaPrinter
         WellKnownDirectives.Skip,
         WellKnownDirectives.Include,
         WellKnownDirectives.Deprecated,
-        SpecifiedByDirectiveType.Names.SpecifiedBy
-    };
+        SpecifiedByDirectiveType.Names.SpecifiedBy,
+    ];
 
     /// <summary>
     /// Creates a <see cref="string" /> representation of the given
@@ -99,7 +99,7 @@ public static partial class FederationSchemaPrinter
             UnionType type => SerializeUnionType(type, context),
             EnumType type => SerializeEnumType(type, context),
             ScalarType type => SerializeScalarType(type, context),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
         return definitionNode is not null;
     }
@@ -114,7 +114,7 @@ public static partial class FederationSchemaPrinter
                 (INullableTypeNode)SerializeType(nt.Type, context)),
             ListType lt => new ListTypeNode(SerializeType(lt.ElementType, context)),
             INamedType namedType => SerializeNamedType(namedType, context),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
     }
 

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Helpers/ReferenceResolverHelper.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Helpers/ReferenceResolverHelper.cs
@@ -32,7 +32,7 @@ internal static class ReferenceResolverHelper
                 "The entity for the given representation could not be resolved.",
                 extensions: new Dictionary<string, object?>
                 {
-                    { nameof(representation), representation }
+                    { nameof(representation), representation },
                 }));
     }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/CertificationTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/CertificationTests.cs
@@ -61,8 +61,8 @@ public class CertificationTests
                 {
                     new ObjectValueNode(
                         new ObjectFieldNode("__typename", "Product"),
-                        new ObjectFieldNode("id", "apollo-federation"))
-                }
+                        new ObjectFieldNode("id", "apollo-federation")),
+                },
             });
 
         // assert
@@ -91,8 +91,8 @@ public class CertificationTests
                     new ObjectValueNode(
                         new ObjectFieldNode("__typename", "Product"),
                         new ObjectFieldNode("sku", "federation"),
-                        new ObjectFieldNode("package", "@apollo/federation"))
-                }
+                        new ObjectFieldNode("package", "@apollo/federation")),
+                },
             });
 
         // assert
@@ -123,8 +123,8 @@ public class CertificationTests
                         new ObjectFieldNode("sku", "federation"),
                         new ObjectFieldNode("variation",
                             new ObjectValueNode(
-                                new ObjectFieldNode("id", "OSS"))))
-                }
+                                new ObjectFieldNode("id", "OSS")))),
+                },
             });
 
         // assert
@@ -146,7 +146,7 @@ public class CertificationTests
             }",
             new Dictionary<string, object?>
             {
-                ["id"] = "apollo-federation"
+                ["id"] = "apollo-federation",
             });
 
         // assert
@@ -168,7 +168,7 @@ public class CertificationTests
             }",
             new Dictionary<string, object?>
             {
-                ["id"] = "apollo-federation"
+                ["id"] = "apollo-federation",
             });
 
         // assert

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/Types/Data.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/Types/Data.cs
@@ -7,6 +7,6 @@ public class Data
     public List<Product> Products { get; } = new()
     {
         new("apollo-federation", "federation", "@apollo/federation", "OSS"),
-        new("apollo-studio", "studio", string.Empty, "platform")
+        new("apollo-studio", "studio", string.Empty, "platform"),
     };
 }

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/CertificationTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/CertificationTests.cs
@@ -61,8 +61,8 @@ public class CertificationTests
                 {
                     new ObjectValueNode(
                         new ObjectFieldNode("__typename", "Product"),
-                        new ObjectFieldNode("id", "apollo-federation"))
-                }
+                        new ObjectFieldNode("id", "apollo-federation")),
+                },
             });
 
         // assert
@@ -91,8 +91,8 @@ public class CertificationTests
                     new ObjectValueNode(
                         new ObjectFieldNode("__typename", "Product"),
                         new ObjectFieldNode("sku", "federation"),
-                        new ObjectFieldNode("package", "@apollo/federation"))
-                }
+                        new ObjectFieldNode("package", "@apollo/federation")),
+                },
             });
 
         // assert
@@ -123,8 +123,8 @@ public class CertificationTests
                         new ObjectFieldNode("sku", "federation"),
                         new ObjectFieldNode("variation",
                             new ObjectValueNode(
-                                new ObjectFieldNode("id", "OSS"))))
-                }
+                                new ObjectFieldNode("id", "OSS")))),
+                },
             });
 
         // assert
@@ -146,7 +146,7 @@ public class CertificationTests
             }",
             new Dictionary<string, object?>
             {
-                ["id"] = "apollo-federation"
+                ["id"] = "apollo-federation",
             });
 
         // assert
@@ -168,7 +168,7 @@ public class CertificationTests
             }",
             new Dictionary<string, object?>
             {
-                ["id"] = "apollo-federation"
+                ["id"] = "apollo-federation",
             });
 
         // assert

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/Types/Data.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/Types/Data.cs
@@ -7,6 +7,6 @@ public class Data
     public List<Product> Products { get; } = new()
     {
         new("apollo-federation", "federation", "@apollo/federation", "OSS"),
-        new("apollo-studio", "studio", string.Empty, "platform")
+        new("apollo-studio", "studio", string.Empty, "platform"),
     };
 }

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntitiesResolverTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntitiesResolverTests.cs
@@ -29,7 +29,7 @@ public class EntitiesResolverTests
             new("ForeignType",
                 new ObjectValueNode(
                     new ObjectFieldNode("id", "1"),
-                    new ObjectFieldNode("someExternalField", "someExternalField")))
+                    new ObjectFieldNode("someExternalField", "someExternalField"))),
         };
 
         // assert
@@ -58,7 +58,7 @@ public class EntitiesResolverTests
             new("MixedFieldTypes",
                 new ObjectValueNode(
                     new ObjectFieldNode("id", "1"),
-                    new ObjectFieldNode("intField", 25)))
+                    new ObjectFieldNode("intField", 25))),
         };
 
         // assert
@@ -84,7 +84,7 @@ public class EntitiesResolverTests
         var representations = new List<Representation>
         {
             new("TypeWithReferenceResolver",
-                new ObjectValueNode(new ObjectFieldNode("Id", "1")))
+                new ObjectValueNode(new ObjectFieldNode("Id", "1"))),
         };
 
         // assert
@@ -117,7 +117,7 @@ public class EntitiesResolverTests
         {
             new("FederatedType", new ObjectValueNode(new ObjectFieldNode("Id", "1"))),
             new("FederatedType", new ObjectValueNode(new ObjectFieldNode("Id", "2"))),
-            new("FederatedType", new ObjectValueNode(new ObjectFieldNode("Id", "3")))
+            new("FederatedType", new ObjectValueNode(new ObjectFieldNode("Id", "3"))),
         };
 
         // act
@@ -143,7 +143,7 @@ public class EntitiesResolverTests
         // act
         var representations = new List<Representation>
         {
-            new("NonExistingTypeName", new ObjectValueNode())
+            new("NonExistingTypeName", new ObjectValueNode()),
         };
 
         // assert
@@ -164,7 +164,7 @@ public class EntitiesResolverTests
         // act
         var representations = new List<Representation>
         {
-            new("TypeWithoutRefResolver", new ObjectValueNode())
+            new("TypeWithoutRefResolver", new ObjectValueNode()),
         };
 
         // assert
@@ -189,8 +189,8 @@ public class EntitiesResolverTests
                 new ObjectValueNode(new[]
                 {
                     new ObjectFieldNode("detail",
-                        new ObjectValueNode(new[] { new ObjectFieldNode("id", "testId") }))
-                }))
+                        new ObjectValueNode(new[] { new ObjectFieldNode("id", "testId") })),
+                })),
         };
 
         var result = await EntitiesResolver.ResolveAsync(schema, representations, context);
@@ -219,8 +219,8 @@ public class EntitiesResolverTests
                 new ObjectValueNode(new[]
                 {
                     new ObjectFieldNode("detail",
-                        new ObjectValueNode(new[] { new ObjectFieldNode("id", "testId") }))
-                }))
+                        new ObjectValueNode(new[] { new ObjectFieldNode("id", "testId") })),
+                })),
         };
 
         var result = await EntitiesResolver.ResolveAsync(schema, representations, context);
@@ -345,7 +345,7 @@ public class EntitiesResolverTests
             {
                 ["1"] = new FederatedType {Id = "1", SomeField = "SomeField-1"},
                 ["2"] = new FederatedType {Id = "2", SomeField = "SomeField-2"},
-                ["3"] = new FederatedType {Id = "3", SomeField = "SomeField-3"}
+                ["3"] = new FederatedType {Id = "3", SomeField = "SomeField-3"},
             };
 
             return Task.FromResult<IReadOnlyDictionary<string, FederatedType>>(result);

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/FederationSchemaPrinterTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/FederationSchemaPrinterTests.cs
@@ -304,7 +304,7 @@ public class FederationSchemaPrinterTests
         [Obsolete]
         Deprecated2,
 
-        Active
+        Active,
     }
 
     public class CustomDirectiveAttribute : DescriptorAttribute

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ReferenceResolverAttributeTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ReferenceResolverAttributeTests.cs
@@ -276,7 +276,7 @@ public class ReferenceResolverAttributeTests
             return Task.FromResult(
                 new InClassRefResolver()
                 {
-                    Id = nameof(InClassRefResolver)
+                    Id = nameof(InClassRefResolver),
                 });
         }
     }
@@ -346,7 +346,7 @@ public class ReferenceResolverAttributeTests
             return Task.FromResult(
                 new ExternalRefResolver()
                 {
-                    Id = nameof(ExternalRefResolverRenamedMethod)
+                    Id = nameof(ExternalRefResolverRenamedMethod),
                 });
         }
     }
@@ -359,7 +359,7 @@ public class ReferenceResolverAttributeTests
             return Task.FromResult(
                 new ExternalRefResolver()
                 {
-                    Id = nameof(ExternalRefResolver)
+                    Id = nameof(ExternalRefResolver),
                 });
         }
     }

--- a/src/HotChocolate/Caching/src/Caching/CacheControlConstraintsOptimizer.cs
+++ b/src/HotChocolate/Caching/src/Caching/CacheControlConstraintsOptimizer.cs
@@ -35,7 +35,7 @@ internal sealed class CacheControlConstraintsOptimizer : IOperationOptimizer
             {
                 CacheControlScope.Private => _cacheControlPrivateScope,
                 CacheControlScope.Public => _cacheControlPublicScope,
-                _ => throw ThrowHelper.UnexpectedCacheControlScopeValue(constraints.Scope)
+                _ => throw ThrowHelper.UnexpectedCacheControlScopeValue(constraints.Scope),
             };
 
             var headerValue = string.Format(

--- a/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
@@ -128,7 +128,7 @@ internal static class TestServerExtensions
         {
             Headers = response.Headers,
             ContentHeaders = response.Content.Headers,
-            Body = await response.Content.ReadAsStringAsync()
+            Body = await response.Content.ReadAsStringAsync(),
         };
 
         return result;

--- a/src/HotChocolate/Core/src/Abstractions/DataLoaderServiceScope.cs
+++ b/src/HotChocolate/Core/src/Abstractions/DataLoaderServiceScope.cs
@@ -21,5 +21,5 @@ public enum DataLoaderServiceScope
     /// Defines that the DataLoader should resolve services
     /// from the passed in <see cref="IServiceProvider"/>.
     /// </summary>
-    OriginalScope = 2
+    OriginalScope = 2,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Execution/ExecutionResultKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/ExecutionResultKind.cs
@@ -23,5 +23,5 @@ public enum ExecutionResultKind
     /// <summary>
     /// A subscription response stream.
     /// </summary>
-    SubscriptionResult
+    SubscriptionResult,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Execution/ExecutionStrategy.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/ExecutionStrategy.cs
@@ -13,5 +13,5 @@ public enum ExecutionStrategy
     /// <summary>
     /// Defines that a task or execution step can be executed in parallel.
     /// </summary>
-    Parallel
+    Parallel,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Execution/GraphQLRequestFlags.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/GraphQLRequestFlags.cs
@@ -41,5 +41,5 @@ public enum GraphQLRequestFlags
     /// <summary>
     /// Everything is allowed.
     /// </summary>
-    AllowAll = AllowQuery | AllowMutation | AllowSubscription | AllowStreams
+    AllowAll = AllowQuery | AllowMutation | AllowSubscription | AllowStreams,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilder.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/QueryRequestBuilder.cs
@@ -342,7 +342,7 @@ public class QueryRequestBuilder : IQueryRequestBuilder
             _readOnlyContextData = request.ContextData,
             _readOnlyExtensions = request.Extensions,
             _services = request.Services,
-            _flags = request.Flags
+            _flags = request.Flags,
         };
 
         if (builder._query is null && builder._queryName is null)

--- a/src/HotChocolate/Core/src/Abstractions/Execution/QueryResultHelper.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/QueryResultHelper.cs
@@ -76,7 +76,7 @@ internal static class QueryResultHelper
             serializedLocations[i] = new OrderedDictionary<string, int>
                 {
                     { _line, location.Line },
-                    { _column, location.Column }
+                    { _column, location.Column },
                 };
         }
 

--- a/src/HotChocolate/Core/src/Abstractions/Execution/Tasks/ExecutionTaskKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/Tasks/ExecutionTaskKind.cs
@@ -18,5 +18,5 @@ public enum ExecutionTaskKind
     /// <summary>
     /// Tasks that have no side-effects and are synchronous.
     /// </summary>
-    Pure
+    Pure,
 }

--- a/src/HotChocolate/Core/src/Abstractions/GraphQLException.cs
+++ b/src/HotChocolate/Core/src/Abstractions/GraphQLException.cs
@@ -40,7 +40,7 @@ public class GraphQLException : Exception
             ErrorBuilder.New()
                 .SetMessage(message)
                 .SetException(innerException)
-                .Build()
+                .Build(),
         };
     }
 

--- a/src/HotChocolate/Core/src/Abstractions/ModuleOptions.cs
+++ b/src/HotChocolate/Core/src/Abstractions/ModuleOptions.cs
@@ -21,5 +21,5 @@ public enum ModuleOptions
     /// <summary>
     /// Register DataLoader with the source generated module.
     /// </summary>
-    RegisterDataLoader = 2
+    RegisterDataLoader = 2,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Path.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Path.cs
@@ -21,7 +21,7 @@ public abstract class Path : IEquatable<Path>
         _parent = null;
         Length = 0;
     }
-    
+
     protected Path(Path parent)
     {
         _parent = parent ?? throw new ArgumentNullException(nameof(parent));
@@ -68,7 +68,7 @@ public abstract class Path : IEquatable<Path>
             throw new InvalidOperationException(
                 "Appending a indexer on the root segment is not allowed.");
         }
-        
+
         return new IndexerPathSegment(this, index);
     }
 
@@ -84,7 +84,7 @@ public abstract class Path : IEquatable<Path>
         {
             return "/";
         }
-        
+
         var sb = new StringBuilder();
         var current = this;
 
@@ -107,7 +107,7 @@ public abstract class Path : IEquatable<Path>
                 default:
                     throw new NotSupportedException();
             }
-            
+
             current = current.Parent;
         }
 
@@ -177,7 +177,7 @@ public abstract class Path : IEquatable<Path>
         {
             null => false,
             Path p => Equals(p),
-            _ => false
+            _ => false,
         };
 
     /// <summary>
@@ -189,7 +189,7 @@ public abstract class Path : IEquatable<Path>
     public override int GetHashCode()
         => HashCode.Combine(Parent, Length);
 
-    internal static Path FromList(params object[] elements) 
+    internal static Path FromList(params object[] elements)
         => FromList((IReadOnlyList<object>)elements);
 
     internal static Path FromList(IReadOnlyList<object> path)
@@ -212,7 +212,7 @@ public abstract class Path : IEquatable<Path>
             {
                 string n => segment.Append(n),
                 int n => segment.Append(n),
-                _ => throw new NotSupportedException()
+                _ => throw new NotSupportedException(),
             };
         }
 

--- a/src/HotChocolate/Core/src/Abstractions/ServiceKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/ServiceKind.cs
@@ -34,5 +34,5 @@ public enum ServiceKind
     /// A service that is retrieved from a IServiceScope that is bound to the resolver
     /// execution.
     /// </summary>
-    Resolver
+    Resolver,
 }

--- a/src/HotChocolate/Core/src/Abstractions/StateKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/StateKind.cs
@@ -23,5 +23,5 @@ public enum StateKind
     /// <summary>
     /// The response state.
     /// </summary>
-    Response
+    Response,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Subscriptions/TopicBufferFullMode.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Subscriptions/TopicBufferFullMode.cs
@@ -20,5 +20,5 @@ public enum TopicBufferFullMode
     /// <summary>
     /// Drop the item being written.
     /// </summary>
-    DropWrite
+    DropWrite,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Types/TypeKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Types/TypeKind.cs
@@ -169,5 +169,5 @@ public enum TypeKind
     /// </para>
     /// <para>https://spec.graphql.org/draft/#sec-Type-System.Directives</para>
     /// </summary>
-    Directive = 128
+    Directive = 128,
 }

--- a/src/HotChocolate/Core/src/Abstractions/Types/ValueKind.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Types/ValueKind.cs
@@ -10,5 +10,5 @@ public enum ValueKind
     Object,
     List,
     Null,
-    Unknown
+    Unknown,
 }

--- a/src/HotChocolate/Core/src/Authorization/AuthorizeMiddleware.cs
+++ b/src/HotChocolate/Core/src/Authorization/AuthorizeMiddleware.cs
@@ -107,6 +107,6 @@ internal sealed class AuthorizeMiddleware
                             : ErrorCodes.Authentication.NotAuthenticated)
                     .SetPath(context.Path)
                     .AddLocation(context.Selection.SyntaxNode)
-                    .Build()
+                    .Build(),
         };
 }

--- a/src/HotChocolate/Core/src/Authorization/AuthorizeResult.cs
+++ b/src/HotChocolate/Core/src/Authorization/AuthorizeResult.cs
@@ -28,5 +28,5 @@ public enum AuthorizeResult
     /// <summary>
     /// The specified authorization policy was not found.
     /// </summary>
-    PolicyNotFound
+    PolicyNotFound,
 }

--- a/src/HotChocolate/Core/src/Authorization/AuthorizeValidationResultAggregator.cs
+++ b/src/HotChocolate/Core/src/Authorization/AuthorizeValidationResultAggregator.cs
@@ -73,7 +73,7 @@ internal sealed class AuthorizeValidationResultAggregator : IValidationResultAgg
                     .SetCode(result == AuthorizeResult.NotAllowed
                         ? ErrorCodes.Authentication.NotAuthorized
                         : ErrorCodes.Authentication.NotAuthenticated)
-                    .Build()
+                    .Build(),
         };
     }
 }

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/InternalSchemaServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/InternalSchemaServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ public static class InternalSchemaServiceCollectionExtensions
             {
                 0 => new NoopExecutionDiagnosticEvents(),
                 1 => listeners[0],
-                _ => new AggregateExecutionDiagnosticEvents(listeners)
+                _ => new AggregateExecutionDiagnosticEvents(listeners),
             };
         });
         return services;

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/InternalServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/InternalServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ internal static class InternalServiceCollectionExtensions
                 sp.GetRequiredService<ObjectPool<ResolverTask>>()));
         return services;
     }
-    
+
     internal static IServiceCollection TryAddOperationCompilerPool(
         this IServiceCollection services)
     {
@@ -131,7 +131,7 @@ internal static class InternalServiceCollectionExtensions
                 {
                     0 => new DataLoaderDiagnosticEventListener(),
                     1 => listeners[0],
-                    _ => new AggregateDataLoaderDiagnosticEventListener(listeners)
+                    _ => new AggregateDataLoaderDiagnosticEventListener(listeners),
                 };
             });
 
@@ -141,7 +141,7 @@ internal static class InternalServiceCollectionExtensions
                 Caching = true,
                 Cache = sp.GetRequiredService<TaskCacheOwner>().Cache,
                 DiagnosticEvents = sp.GetService<IDataLoaderDiagnosticEvents>(),
-                MaxBatchSize = 1024
+                MaxBatchSize = 1024,
             });
         return services;
     }

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.UseRequest.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.UseRequest.cs
@@ -141,7 +141,7 @@ public static partial class RequestExecutorBuilderExtensions
                     error,
                     new Dictionary<string, object?>
                     {
-                        { WellKnownContextData.HttpStatusCode, HttpStatusCode.BadRequest }
+                        { WellKnownContextData.HttpStatusCode, HttpStatusCode.BadRequest },
                     });
 
                 context.DiagnosticEvents.RequestError(context, new GraphQLException(error));

--- a/src/HotChocolate/Core/src/Execution/ErrorHelper.cs
+++ b/src/HotChocolate/Core/src/Execution/ErrorHelper.cs
@@ -130,7 +130,7 @@ internal static class ErrorHelper
                 .Build(),
             new Dictionary<string, object?>
             {
-                { WellKnownContextData.HttpStatusCode, HttpStatusCode.BadRequest }
+                { WellKnownContextData.HttpStatusCode, HttpStatusCode.BadRequest },
             });
 
     public static IQueryResult StateInvalidForOperationResolver() =>
@@ -178,7 +178,7 @@ internal static class ErrorHelper
                 .Build(),
             new Dictionary<string, object?>
             {
-                    { WellKnownContextData.OperationNotAllowed, null }
+                    { WellKnownContextData.OperationNotAllowed, null },
             });
 
     public static IQueryResult RequestTimeout(TimeSpan timeout) =>
@@ -203,13 +203,13 @@ internal static class ErrorHelper
                 extensions: new Dictionary<string, object?>
                 {
                     { nameof(complexity), complexity },
-                    { nameof(allowedComplexity), allowedComplexity }
+                    { nameof(allowedComplexity), allowedComplexity },
                 }),
             contextData: new Dictionary<string, object?>
             {
-                { WellKnownContextData.ValidationErrors, true }
+                { WellKnownContextData.ValidationErrors, true },
             });
-    
+
     public static IError MaxComplexityReached() =>
         new Error(
             ErrorHelper_MaxComplexityReached,
@@ -249,7 +249,7 @@ internal static class ErrorHelper
             .SetMessage("PersistedQueryNotFound")
             .SetCode(ErrorCodes.Execution.PersistedQueryNotFound)
             .Build();
-    
+
     public static IError NoNullBubbling_ArgumentValue_NotAllowed(
         ArgumentNode argument)
     {

--- a/src/HotChocolate/Core/src/Execution/Options/TracingPreference.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/TracingPreference.cs
@@ -6,5 +6,5 @@ public enum TracingPreference
 
     OnDemand = 1,
 
-    Always = 2
+    Always = 2,
 }

--- a/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityAnalyzerCompiler.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/Complexity/ComplexityAnalyzerCompiler.cs
@@ -101,7 +101,7 @@ internal sealed class ComplexityAnalyzerCompiler : TypeDocumentValidatorVisitor
         {
             0 => CreateCalculateExpression(context, field, selection, _zero),
             1 => CreateCalculateExpression(context, field, selection, children[0]),
-            _ => CreateCalculateExpression(context, field, selection, Combine(children))
+            _ => CreateCalculateExpression(context, field, selection, Combine(children)),
         };
     }
 
@@ -140,7 +140,7 @@ internal sealed class ComplexityAnalyzerCompiler : TypeDocumentValidatorVisitor
         {
             throw new GraphQLException(ErrorHelper.MaxComplexityReached());
         }
-        
+
         var combinedComplexity = expressions[0];
 
         for (var i = 1; i < expressions.Count; i++)

--- a/src/HotChocolate/Core/src/Execution/Pipeline/DocumentValidationMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/DocumentValidationMiddleware.cs
@@ -60,7 +60,7 @@ internal sealed class DocumentValidationMiddleware
                         // create result context data that indicate that validation has failed.
                         var resultContextData = new Dictionary<string, object?>
                         {
-                            { ValidationErrors, true }
+                            { ValidationErrors, true },
                         };
 
                         // if one of the validation rules proposed a status code we will add

--- a/src/HotChocolate/Core/src/Execution/Pipeline/OnlyPersistedQueriesAllowedMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/OnlyPersistedQueriesAllowedMiddleware.cs
@@ -15,7 +15,7 @@ internal sealed class OnlyPersistedQueriesAllowedMiddleware
     private readonly GraphQLException _exception;
     private readonly Dictionary<string, object?> _statusCode = new()
     {
-        { WellKnownContextData.HttpStatusCode, 400 }
+        { WellKnownContextData.HttpStatusCode, 400 },
     };
 
     public OnlyPersistedQueriesAllowedMiddleware(

--- a/src/HotChocolate/Core/src/Execution/Pipeline/OperationExecutionMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/OperationExecutionMiddleware.cs
@@ -203,7 +203,7 @@ internal sealed class OperationExecutionMiddleware
             OperationType.Query => (request.Flags & AllowQuery) == AllowQuery,
             OperationType.Mutation => (request.Flags & AllowMutation) == AllowMutation,
             OperationType.Subscription => (request.Flags & AllowSubscription) == AllowSubscription,
-            _ => true
+            _ => true,
         };
 
         if (allowed && operation.HasIncrementalParts)

--- a/src/HotChocolate/Core/src/Execution/Pipeline/OperationResolverMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/OperationResolverMiddleware.cs
@@ -32,11 +32,11 @@ internal sealed class OperationResolverMiddleware
             throw new ArgumentNullException(nameof(optimizers));
         }
 
-        _next = next ?? 
+        _next = next ??
             throw new ArgumentNullException(nameof(next));
-        _operationCompilerPool = operationCompilerPool ?? 
+        _operationCompilerPool = operationCompilerPool ??
             throw new ArgumentNullException(nameof(operationCompilerPool));
-        _coercionHelper = coercionHelper ?? 
+        _coercionHelper = coercionHelper ??
             throw new ArgumentNullException(nameof(coercionHelper));
         _optimizers = optimizers.ToArray();
     }
@@ -103,7 +103,7 @@ internal sealed class OperationResolverMiddleware
             OperationType.Query => schema.QueryType,
             OperationType.Mutation => schema.MutationType,
             OperationType.Subscription => schema.SubscriptionType,
-            _ => throw ThrowHelper.RootTypeNotSupported(operationType)
+            _ => throw ThrowHelper.RootTypeNotSupported(operationType),
         };
 
     private bool IsNullBubblingEnabled(IRequestContext context, OperationDefinitionNode operationDefinition)
@@ -113,7 +113,7 @@ internal sealed class OperationResolverMiddleware
         {
             return true;
         }
-        
+
         var enabled = true;
 
         for (var i = 0; i < operationDefinition.Directives.Count; i++)
@@ -136,7 +136,7 @@ internal sealed class OperationResolverMiddleware
                         enabled = b.Value;
                         break;
                     }
-                        
+
                     if (argument.Value is VariableNode v)
                     {
                         enabled = CoerceVariable(context, operationDefinition, v);
@@ -154,11 +154,11 @@ internal sealed class OperationResolverMiddleware
     }
 
     private bool CoerceVariable(
-        IRequestContext context, 
-        OperationDefinitionNode operationDefinition, 
+        IRequestContext context,
+        OperationDefinitionNode operationDefinition,
         VariableNode variable)
     {
         var variables = CoerceVariables(context, _coercionHelper, operationDefinition.VariableDefinitions);
         return variables.GetVariable<bool>(variable.Name.Value);
-    } 
+    }
 }

--- a/src/HotChocolate/Core/src/Execution/Pipeline/PersistedQueryNotFoundMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/PersistedQueryNotFoundMiddleware.cs
@@ -22,7 +22,7 @@ internal sealed class PersistedQueryNotFoundMiddleware
             ?? throw new ArgumentNullException(nameof(diagnosticEvents));
         _statusCode = new Dictionary<string, object?>
         {
-            { HttpStatusCode, 400 }
+            { HttpStatusCode, 400 },
         };
     }
 

--- a/src/HotChocolate/Core/src/Execution/Pipeline/RequestClassMiddlewareFactory.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/RequestClassMiddlewareFactory.cs
@@ -93,7 +93,7 @@ internal static class RequestClassMiddlewareFactory
 
         var list = new List<IParameterHandler>
         {
-            new TypeParameterHandler(typeof(IDocumentValidator), getValidator)
+            new TypeParameterHandler(typeof(IDocumentValidator), getValidator),
         };
 
         var constructor = middleware.GetConstructors().SingleOrDefault(t => t.IsPublic);

--- a/src/HotChocolate/Core/src/Execution/Pipeline/WritePersistedQueryMiddleware.cs
+++ b/src/HotChocolate/Core/src/Execution/Pipeline/WritePersistedQueryMiddleware.cs
@@ -58,7 +58,7 @@ internal sealed class WritePersistedQueryMiddleware
                     new Dictionary<string, object>
                     {
                         { _hashProvider.Name, userHash },
-                        { _persisted, true }
+                        { _persisted, true },
                     });
 
                 context.ContextData[WellKnownContextData.DocumentSaved] = true;
@@ -73,7 +73,7 @@ internal sealed class WritePersistedQueryMiddleware
                         { _expectedValue, context.DocumentId },
                         { _expectedType, _hashProvider.Name },
                         { _expectedFormat, _hashProvider.Format.ToString() },
-                        { _persisted, false }
+                        { _persisted, false },
                     });
             }
 

--- a/src/HotChocolate/Core/src/Execution/Processing/DefaultTransactionScopeHandler.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DefaultTransactionScopeHandler.cs
@@ -25,7 +25,7 @@ public class DefaultTransactionScopeHandler : ITransactionScopeHandler
                 TransactionScopeOption.Required,
                 new TransactionOptions
                 {
-                    IsolationLevel = IsolationLevel.ReadCommitted
+                    IsolationLevel = IsolationLevel.ReadCommitted,
                 },
                 TransactionScopeAsyncFlowOption.Enabled));
     }

--- a/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Pure.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Pure.cs
@@ -91,7 +91,7 @@ internal partial class MiddlewareContext
                     Selection.Field.Coordinate,
                     Path,
                     typeof(T),
-                    _parent.GetType())
+                    _parent.GetType()),
             };
 
         public T ArgumentValue<T>(string name)
@@ -163,7 +163,7 @@ internal partial class MiddlewareContext
         }
 
         public T Service<T>() where T: notnull => _parentContext.Service<T>();
-        
+
 #if NET8_0_OR_GREATER
         public T? Service<T>(object key) where T : notnull => _parentContext.Service<T>(key);
 #endif

--- a/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/OperationCompiler.cs
@@ -646,7 +646,7 @@ public sealed partial class OperationCompiler
             TypeKind.Object => ReferenceEquals(typeCondition, current),
             TypeKind.Interface => current.IsImplementing((InterfaceType) typeCondition),
             TypeKind.Union => ((UnionType) typeCondition).Types.ContainsKey(current.Name),
-            _ => false
+            _ => false,
         };
 
     private FragmentDefinitionNode GetFragmentDefinition(

--- a/src/HotChocolate/Core/src/Execution/Processing/PathHelper.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/PathHelper.cs
@@ -13,7 +13,7 @@ internal static class PathHelper
         {
             ObjectResult => CreatePath(parent, selection.ResponseName),
             ListResult => CreatePath(parent, index),
-            _ => throw new NotSupportedException($"{parent.GetType().FullName} is not a supported parent type.")
+            _ => throw new NotSupportedException($"{parent.GetType().FullName} is not a supported parent type."),
         };
 
     private static Path CreatePath(ResultData parent, object segmentValue)
@@ -23,16 +23,16 @@ internal static class PathHelper
         var length = Build(segments, parent);
         var path = CreatePath(parent.PatchPath, segments, length);
         ArrayPool<object>.Shared.Return(segments);
-        return path;   
+        return path;
     }
-    
+
     private static Path CreatePath(ResultData parent)
     {
         var segments = ArrayPool<object>.Shared.Rent(64);
         var length = Build(segments, parent, 0);
         var path = CreatePath(parent.PatchPath, segments, length);
         ArrayPool<object>.Shared.Return(segments);
-        return path;   
+        return path;
     }
 
     private static Path CreatePath(Path? patchPath, object[] segments, int length)
@@ -48,14 +48,14 @@ internal static class PathHelper
                 {
                     string s => path.Append(s),
                     int n => path.Append(n),
-                    _ => path
+                    _ => path,
                 };
             }
         }
 
         return path;
     }
-    
+
     private static int Build(object[] segments, ResultData parent, int start = 1)
     {
         var segment = start;

--- a/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectFieldResult.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectFieldResult.cs
@@ -26,7 +26,7 @@ public sealed class ObjectFieldResult
     internal bool TrySetNull()
     {
         _value = null;
-        
+
         if ((_flags & Flags.InitializedAndNullable) == Flags.InitializedAndNullable)
         {
             return true;
@@ -47,6 +47,6 @@ public sealed class ObjectFieldResult
     {
         Initialized = 1,
         Nullable = 2,
-        InitializedAndNullable = Initialized | Nullable
+        InitializedAndNullable = Initialized | Nullable,
     }
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Selection.cs
@@ -387,7 +387,7 @@ public class Selection : ISelection
         Sealed = 2,
         List = 4,
         Stream = 8,
-        StreamResult = 16
+        StreamResult = 16,
     }
 
     [Flags]
@@ -400,7 +400,7 @@ public class Selection : ISelection
         Option4 = 8,
         Option5 = 16,
         Option6 = 32,
-        Option7 = 64
+        Option7 = 64,
     }
 
     internal sealed class Sealed : Selection

--- a/src/HotChocolate/Core/src/Execution/Processing/SelectionInclusionKind.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/SelectionInclusionKind.cs
@@ -25,5 +25,5 @@ public enum SelectionInclusionKind
     /// The selection is included for internal processing when certain
     /// conditions are met and will not appear in the result set.
     /// </summary>
-    InternalConditional
+    InternalConditional,
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/SelectionSet.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/SelectionSet.cs
@@ -99,6 +99,6 @@ internal sealed class SelectionSet : ISelectionSet
     {
         None = 0,
         Conditional = 1,
-        Sealed = 2
+        Sealed = 2,
     }
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/SelectionVariants.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/SelectionVariants.cs
@@ -31,17 +31,17 @@ internal sealed class SelectionVariants : ISelectionVariants
         {
             return _map.ContainsKey(typeContext);
         }
-        
+
         if (ReferenceEquals(_firstType, typeContext))
         {
             return true;
         }
-        
+
         if (ReferenceEquals(_secondType, typeContext))
         {
             return true;
         }
-        
+
         return false;
     }
 
@@ -138,7 +138,7 @@ internal sealed class SelectionVariants : ISelectionVariants
                 {
                     { _firstType, _firstSelectionSet! },
                     { _secondType, _secondSelectionSet! },
-                    { typeContext, selectionSet }
+                    { typeContext, selectionSet },
                 };
 
                 _firstType = null;

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.cs
@@ -46,7 +46,7 @@ internal sealed partial class ResolverTask : IExecutionTask
             SelectionExecutionStrategy.Default => ExecutionTaskKind.Parallel,
             SelectionExecutionStrategy.Serial => ExecutionTaskKind.Serial,
             SelectionExecutionStrategy.Pure => ExecutionTaskKind.Pure,
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Execution/RequestContext.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestContext.cs
@@ -99,7 +99,7 @@ internal sealed class RequestContext : IRequestContext
             Operation = Operation,
             Variables = Variables,
             Result = Result,
-            Exception = Exception
+            Exception = Exception,
         };
 
         foreach (var item in _contextData)

--- a/src/HotChocolate/Core/src/Execution/RequestExecutorEventType.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutorEventType.cs
@@ -13,5 +13,5 @@ public enum RequestExecutorEventType
     /// <summary>
     /// A request executor was evicted.
     /// </summary>
-    Evicted
+    Evicted,
 }

--- a/src/HotChocolate/Core/src/Execution/Serialization/JsonNullIgnoreCondition.cs
+++ b/src/HotChocolate/Core/src/Execution/Serialization/JsonNullIgnoreCondition.cs
@@ -23,5 +23,5 @@ public enum JsonNullIgnoreCondition
     /// <summary>
     /// Fields that have a null value and null elements in lists are ignored.
     /// </summary>
-    All = 4
+    All = 4,
 }

--- a/src/HotChocolate/Core/src/Execution/Serialization/JsonResultFormatterOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Serialization/JsonResultFormatterOptions.cs
@@ -34,7 +34,7 @@ public struct JsonResultFormatterOptions
         => new()
         {
             Indented = Indented,
-            Encoder = Encoder ?? JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            Encoder = Encoder ?? JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         };
 
     internal JsonSerializerOptions CreateSerializerOptions()
@@ -45,6 +45,6 @@ public struct JsonResultFormatterOptions
             DefaultIgnoreCondition =
                 NullIgnoreCondition is Fields or All
                     ? WhenWritingNull
-                    : default
+                    : default,
         };
 }

--- a/src/HotChocolate/Core/src/Execution/Serialization/MultiPartResultFormatter.Constants.cs
+++ b/src/HotChocolate/Core/src/Execution/Serialization/MultiPartResultFormatter.Constants.cs
@@ -10,21 +10,21 @@ public sealed partial class MultiPartResultFormatter
         (byte)'t', (byte)'i', (byte)'o', (byte)'n', (byte)'/', (byte)'j', (byte)'s',
         (byte)'o', (byte)'n', (byte)';', (byte)' ', (byte)'c', (byte)'h', (byte)'a',
         (byte)'r', (byte)'s', (byte)'e', (byte)'t', (byte)'=', (byte)'u', (byte)'t',
-        (byte)'f', (byte)'-', (byte)'8'
+        (byte)'f', (byte)'-', (byte)'8',
     };
 
     private static byte[] Start { get; } =
     {
-        (byte)'-', (byte)'-', (byte)'-'
+        (byte)'-', (byte)'-', (byte)'-',
     };
 
     private static byte[] End { get; } =
     {
-        (byte)'-', (byte)'-', (byte)'-', (byte)'-', (byte)'-'
+        (byte)'-', (byte)'-', (byte)'-', (byte)'-', (byte)'-',
     };
 
     private static byte[] CrLf { get; } =
     {
-        (byte)'\r', (byte)'\n'
+        (byte)'\r', (byte)'\n',
     };
 }

--- a/src/HotChocolate/Core/src/Execution/Serialization/MultiPartResultFormatter.cs
+++ b/src/HotChocolate/Core/src/Execution/Serialization/MultiPartResultFormatter.cs
@@ -71,7 +71,7 @@ public sealed partial class MultiPartResultFormatter : IExecutionResultFormatter
                     outputStream,
                     cancellationToken),
             _ => throw MultiPartFormatter_ResultNotSupported(
-                nameof(MultiPartResultFormatter))
+                nameof(MultiPartResultFormatter)),
         };
     }
 

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
@@ -103,11 +103,11 @@ internal sealed class PostgresChannelWriter : IAsyncDisposable
 
                 var channel = new NpgsqlParameter("channel", DbType.String)
                 {
-                    Value = _channelName
+                    Value = _channelName,
                 };
                 var msg = new NpgsqlParameter("message", DbType.String)
                 {
-                    Value = message.FormattedPayload
+                    Value = message.FormattedPayload,
                 };
                 command.Parameters.Add(channel);
                 command.Parameters.Add(msg);

--- a/src/HotChocolate/Core/src/Subscriptions.Serializers.Newtonsoft/NewtonsoftJsonMessageSerializer.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Serializers.Newtonsoft/NewtonsoftJsonMessageSerializer.cs
@@ -10,7 +10,7 @@ internal sealed class NewtonsoftJsonMessageSerializer : IMessageSerializer
     {
         TypeNameHandling = TypeNameHandling.All,
         TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
-        Formatting = Formatting.None
+        Formatting = Formatting.None,
     };
 
     public string CompleteMessage => _completed;

--- a/src/HotChocolate/Core/src/Subscriptions/DefaultJsonMessageSerializer.cs
+++ b/src/HotChocolate/Core/src/Subscriptions/DefaultJsonMessageSerializer.cs
@@ -16,7 +16,7 @@ public sealed class DefaultJsonMessageSerializer : IMessageSerializer
     private readonly JsonSerializerOptions _options =
         new(JsonSerializerDefaults.Web)
         {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Subscriptions/DefaultTopic.cs
+++ b/src/HotChocolate/Core/src/Subscriptions/DefaultTopic.cs
@@ -37,7 +37,7 @@ public abstract class DefaultTopic<TMessage> : ITopic
         Name = name ?? throw new ArgumentNullException(nameof(name));
         _channelOptions = new BoundedChannelOptions(capacity)
         {
-            FullMode = (BoundedChannelFullMode) (int) fullMode
+            FullMode = (BoundedChannelFullMode) (int) fullMode,
         };
         _incoming = CreateUnbounded<TMessage>();
         _diagnosticEvents = diagnosticEvents;
@@ -53,7 +53,7 @@ public abstract class DefaultTopic<TMessage> : ITopic
         Name = name ?? throw new ArgumentNullException(nameof(name));
         _channelOptions = new BoundedChannelOptions(capacity)
         {
-            FullMode = (BoundedChannelFullMode) (int) fullMode
+            FullMode = (BoundedChannelFullMode) (int) fullMode,
         };
         _incoming = incomingMessages;
         _diagnosticEvents = diagnosticEvents;

--- a/src/HotChocolate/Core/src/Subscriptions/MessageKind.cs
+++ b/src/HotChocolate/Core/src/Subscriptions/MessageKind.cs
@@ -15,5 +15,5 @@ public enum MessageKind
     /// A completed message, which signals that the topic is now
     /// completed and no more messages will arrive.
     /// </summary>
-    Completed = 1
+    Completed = 1,
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/DataLoaderKind.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/DataLoaderKind.cs
@@ -4,5 +4,5 @@ public enum DataLoaderKind
 {
     Batch,
     Group,
-    Cache
+    Cache,
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/ModuleOptions.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/ModuleOptions.cs
@@ -5,5 +5,5 @@ public enum ModuleOptions
 {
     Default = RegisterDataLoader | RegisterTypes,
     RegisterTypes = 1,
-    RegisterDataLoader = 2
+    RegisterDataLoader = 2,
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/OperationType.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/OperationType.cs
@@ -6,5 +6,5 @@ public enum OperationType
     No = 0,
     Query = 1,
     Mutation = 2,
-    Subscription = 4
+    Subscription = 4,
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/TypeModuleGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/TypeModuleGenerator.cs
@@ -16,13 +16,13 @@ public class TypeModuleGenerator : IIncrementalGenerator
         new ClassBaseClassInspector(),
         new ModuleInspector(),
         new DataLoaderInspector(),
-        new DataLoaderDefaultsInspector()
+        new DataLoaderDefaultsInspector(),
     };
 
     private static readonly ISyntaxGenerator[] _generators =
     {
         new ModuleGenerator(),
-        new DataLoaderGenerator()
+        new DataLoaderGenerator(),
     };
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -94,22 +94,22 @@ public class TypeModuleGenerator : IIncrementalGenerator
         {
             return;
         }
-        
+
         var buffer = ArrayPool<ISyntaxInfo>.Shared.Rent(syntaxInfos.Length * 2);
-        
+
         // prepare context
         for (var i = syntaxInfos.Length - 1; i >= 0; i--)
         {
             buffer[i] = syntaxInfos[i];
         }
-        
+
         var nodes = buffer.AsSpan().Slice(0, syntaxInfos.Length);
         var batch = buffer.AsSpan().Slice(syntaxInfos.Length, syntaxInfos.Length);
-        
+
         foreach (var generator in _generators)
         {
-            var next = 0; 
-            
+            var next = 0;
+
             // gather infos for current generator
             foreach (var node in nodes)
             {
@@ -125,7 +125,7 @@ public class TypeModuleGenerator : IIncrementalGenerator
                 generator.Generate(context, compilation, batch.Slice(0, next));
             }
         }
-        
+
         ArrayPool<ISyntaxInfo>.Shared.Return(buffer);
     }
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/WellKnownAttributes.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/WellKnownAttributes.cs
@@ -24,6 +24,6 @@ public static class WellKnownAttributes
             InputObjectTypeAttribute,
             QueryTypeAttribute,
             MutationTypeAttribute,
-            SubscriptionTypeAttribute
+            SubscriptionTypeAttribute,
         };
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
@@ -42,6 +42,6 @@ public static class WellKnownTypes
             InterfaceTypeExtension,
             UnionTypeExtension,
             InputObjectTypeExtension,
-            EnumTypeExtension
+            EnumTypeExtension,
         };
 }

--- a/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionType.cs
@@ -152,7 +152,7 @@ internal class ConnectionType
         var definition = new ObjectTypeDefinition
         {
             Description = ConnectionType_Description,
-            RuntimeType = typeof(Connection)
+            RuntimeType = typeof(Connection),
         };
 
         definition.Fields.Add(new(

--- a/src/HotChocolate/Core/src/Types.CursorPagination/EdgeType.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/EdgeType.cs
@@ -110,8 +110,8 @@ internal sealed class EdgeType : ObjectType, IEdgeType
                 new(Names.Node,
                     EdgeType_Node_Description,
                     nodeType,
-                    pureResolver: GetNode)
-            }
+                    pureResolver: GetNode),
+            },
         };
 
     private static string GetCursor(IPureResolverContext context)

--- a/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/UsePagingAttribute.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/UsePagingAttribute.cs
@@ -132,7 +132,7 @@ public sealed class UsePagingAttribute : DescriptorAttribute
                         AllowBackwardPagination = _allowBackwardPagination,
                         RequirePagingBoundaries = _requirePagingBoundaries,
                         InferConnectionNameFromField = _inferConnectionNameFromField,
-                        ProviderName = ProviderName
+                        ProviderName = ProviderName,
                     });
             }
             else if (descriptor is IInterfaceFieldDescriptor ifd)
@@ -150,7 +150,7 @@ public sealed class UsePagingAttribute : DescriptorAttribute
                         AllowBackwardPagination = _allowBackwardPagination,
                         RequirePagingBoundaries = _requirePagingBoundaries,
                         InferConnectionNameFromField = _inferConnectionNameFromField,
-                        ProviderName = ProviderName
+                        ProviderName = ProviderName,
                     });
             }
         }

--- a/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/QueryableCursorPagingHandler.cs
@@ -27,7 +27,7 @@ internal class QueryableCursorPagingHandler<TEntity> : CursorPagingHandler
             IQueryable<TEntity> q => ResolveAsync(context, q, arguments, ct),
             IEnumerable<TEntity> e => ResolveAsync(context, e.AsQueryable(), arguments, ct),
             IExecutable<TEntity> ex => SliceAsync(context, ex.Source, arguments),
-            _ => throw new GraphQLException("Cannot handle the specified data source.")
+            _ => throw new GraphQLException("Cannot handle the specified data source."),
         };
     }
 

--- a/src/HotChocolate/Core/src/Types.Mutations/DependencyInjection/MutationRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/DependencyInjection/MutationRequestExecutorBuilderExtensions.cs
@@ -31,7 +31,7 @@ public static class MutationRequestExecutorBuilderExtensions
             builder,
             new MutationConventionOptions
             {
-                ApplyToAllMutations = applyToAllMutations
+                ApplyToAllMutations = applyToAllMutations,
             });
 
     /// <summary>
@@ -109,7 +109,7 @@ public static class MutationRequestExecutorBuilderExtensions
         this IRequestExecutorBuilder builder,
         Type type) =>
         builder.ConfigureSchema(x => x.AddErrorInterfaceType(type));
-    
+
     /// <summary>
     /// Adds a new error registrar.
     /// </summary>
@@ -122,7 +122,7 @@ public static class MutationRequestExecutorBuilderExtensions
     /// <returns>
     /// The request executor builder
     /// </returns>
-    public static IRequestExecutorBuilder AddMutationErrorConfiguration<T>(this IRequestExecutorBuilder builder) 
+    public static IRequestExecutorBuilder AddMutationErrorConfiguration<T>(this IRequestExecutorBuilder builder)
         where T : MutationErrorConfiguration, new()
         => builder.TryAddTypeInterceptor(new MutationErrorTypeInterceptor<T>(new T()));
 
@@ -143,7 +143,7 @@ public static class MutationRequestExecutorBuilderExtensions
     /// </returns>
     public static IRequestExecutorBuilder AddMutationErrorConfiguration<T>(
         this IRequestExecutorBuilder builder,
-        T configuration) 
+        T configuration)
         where T : MutationErrorConfiguration
         => builder.TryAddTypeInterceptor(new MutationErrorTypeInterceptor<T>(configuration));
 }

--- a/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorFactoryCompiler.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/Errors/ErrorFactoryCompiler.cs
@@ -23,7 +23,7 @@ internal static class ErrorFactoryCompiler
         {
             return new[]
             {
-                definition
+                definition,
             };
         }
 
@@ -31,7 +31,7 @@ internal static class ErrorFactoryCompiler
         {
             return new[]
             {
-                definition
+                definition,
             };
         }
 
@@ -42,7 +42,7 @@ internal static class ErrorFactoryCompiler
         {
             return new[] { new ErrorDefinition(errorType.GetGenericArguments()[0], errorType) };
         }
-        
+
         // else we will create a schema type.
         var schemaType = typeof(ErrorObjectType<>).MakeGenericType(errorType);
         return new[] { new ErrorDefinition(errorType, schemaType) };
@@ -188,7 +188,7 @@ internal static class ErrorFactoryCompiler
                     Expression.Block(
                         new[]
                         {
-                            variable
+                            variable,
                         },
                         new List<Expression> { previous, variable }),
                     exception)

--- a/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
@@ -235,7 +235,7 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
                 {
                     0 => null,
                     1 => argument.Formatters[0],
-                    _ => new AggregateInputValueFormatter(argument.Formatters)
+                    _ => new AggregateInputValueFormatter(argument.Formatters),
                 };
 
             resolverArguments.Add(
@@ -721,7 +721,7 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
         var registeredType = _typeInitializer.InitializeType(type);
         _typeInitializer.CompleteTypeName(registeredType);
 
-        if (registeredType.Type is ObjectType errorObject && 
+        if (registeredType.Type is ObjectType errorObject &&
             errorObject.RuntimeType != typeof(object))
         {
             foreach (var possibleInterface in _typeRegistry.Types)
@@ -744,7 +744,7 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
                 }
             }
         }
-        else if (registeredType.Type is ObjectType errorInterface && 
+        else if (registeredType.Type is ObjectType errorInterface &&
             errorInterface.RuntimeType != typeof(object))
         {
             foreach (var possibleInterface in _typeRegistry.Types)
@@ -819,7 +819,7 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
             NonNullType nnt => new NonNullTypeNode((INullableTypeNode) CreateTypeNode(nnt.Type)),
             ListType lt => new ListTypeNode(CreateTypeNode(lt.ElementType)),
             INamedType nt => new NamedTypeNode(nt.Name),
-            _ => throw new NotSupportedException("Type is not supported.")
+            _ => throw new NotSupportedException("Type is not supported."),
         };
 
     private readonly ref struct Options

--- a/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentType~1.cs
+++ b/src/HotChocolate/Core/src/Types.OffsetPagination/CollectionSegmentType~1.cs
@@ -83,7 +83,7 @@ internal class CollectionSegmentType
         var definition = new ObjectTypeDefinition
         {
             Description = CollectionSegmentType_Description,
-            RuntimeType = typeof(CollectionSegment)
+            RuntimeType = typeof(CollectionSegment),
         };
 
         definition.Fields.Add(new(

--- a/src/HotChocolate/Core/src/Types.OffsetPagination/Extensions/UseOffsetPagingAttribute.cs
+++ b/src/HotChocolate/Core/src/Types.OffsetPagination/Extensions/UseOffsetPagingAttribute.cs
@@ -121,7 +121,7 @@ public class UseOffsetPagingAttribute : DescriptorAttribute
                     IncludeTotalCount = _includeTotalCount,
                     RequirePagingBoundaries = _requirePagingBoundaries,
                     ProviderName = ProviderName,
-                    InferCollectionSegmentNameFromField = _inferCollectionSegmentNameFromField
+                    InferCollectionSegmentNameFromField = _inferCollectionSegmentNameFromField,
                 });
         }
 
@@ -139,7 +139,7 @@ public class UseOffsetPagingAttribute : DescriptorAttribute
                     IncludeTotalCount = _includeTotalCount,
                     RequirePagingBoundaries = _requirePagingBoundaries,
                     ProviderName = ProviderName,
-                    InferCollectionSegmentNameFromField = _inferCollectionSegmentNameFromField
+                    InferCollectionSegmentNameFromField = _inferCollectionSegmentNameFromField,
                 });
         }
     }

--- a/src/HotChocolate/Core/src/Types.OffsetPagination/QueryableOffsetPagingHandler.cs
+++ b/src/HotChocolate/Core/src/Types.OffsetPagination/QueryableOffsetPagingHandler.cs
@@ -31,7 +31,7 @@ public class QueryableOffsetPagingHandler<TEntity>
             IQueryable<TEntity> q => ResolveAsync(context, q, arguments, ct),
             IEnumerable<TEntity> e => ResolveAsync(context, e.AsQueryable(), arguments, ct),
             IExecutable<TEntity> ex => SliceAsync(context, ex.Source, arguments),
-            _ => throw new GraphQLException("Cannot handle the specified data source.")
+            _ => throw new GraphQLException("Cannot handle the specified data source."),
         };
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/LatitudeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LatitudeType.cs
@@ -52,7 +52,7 @@ public class LatitudeType : ScalarType<double, StringValueNode>
 
             double d => ParseValue(d),
 
-            _ => throw ThrowHelper.LatitudeType_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.LatitudeType_ParseValue_IsInvalid(this),
         };
     }
 
@@ -177,7 +177,7 @@ public class LatitudeType : ScalarType<double, StringValueNode>
                 {
                     >= 0 and < _max => $"{degree}° {minutes}' {seconds}\" N",
                     < 0 and > _min => $"{Abs(degree)}° {Abs(minutes)}' {Abs(seconds)}\" S",
-                    _ => $"{degree}° {minutes}' {seconds}\""
+                    _ => $"{degree}° {minutes}' {seconds}\"",
                 };
 
                 resultValue = serializedLatitude;

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalCurrencyType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalCurrencyType.cs
@@ -46,7 +46,7 @@ public class LocalCurrencyType : ScalarType<decimal, StringValueNode>
             null => NullValueNode.Default,
             string s => new StringValueNode(s),
             decimal d => ParseValue(d),
-            _ => throw ThrowHelper.LocalCurrencyType_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.LocalCurrencyType_ParseValue_IsInvalid(this),
         };
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalDateType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalDateType.cs
@@ -44,7 +44,7 @@ public class LocalDateType : ScalarType<DateTime, StringValueNode>
             string s => new StringValueNode(s),
             DateTimeOffset o => ParseValue(o.DateTime),
             DateTime dt => ParseValue(dt),
-            _ => throw ThrowHelper.LocalDateType_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.LocalDateType_ParseValue_IsInvalid(this),
         };
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalTimeType.cs
@@ -43,7 +43,7 @@ public class LocalTimeType : ScalarType<DateTime, StringValueNode>
             string s => new StringValueNode(s),
             DateTimeOffset d => ParseValue(d),
             DateTime dt => ParseValue(dt),
-            _ => throw ThrowHelper.LocalTimeType_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.LocalTimeType_ParseValue_IsInvalid(this),
         };
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/LongitudeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LongitudeType.cs
@@ -52,7 +52,7 @@ public class LongitudeType : ScalarType<double, StringValueNode>
 
             double d => ParseValue(d),
 
-            _ => throw ThrowHelper.LongitudeType_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.LongitudeType_ParseValue_IsInvalid(this),
         };
     }
 
@@ -176,7 +176,7 @@ public class LongitudeType : ScalarType<double, StringValueNode>
                 {
                     >= 0 and < _max => $"{degree}° {minutes}' {seconds}\" E",
                     < 0 and > _min => $"{Abs(degree)}° {Abs(minutes)}' {Abs(seconds)}\" W",
-                    _ => $"{degree}° {minutes}' {seconds}\""
+                    _ => $"{degree}° {minutes}' {seconds}\"",
                 };
 
                 resultValue = serializedLatitude;

--- a/src/HotChocolate/Core/src/Types.Scalars/UtcOffsetType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/UtcOffsetType.cs
@@ -45,7 +45,7 @@ public class UtcOffsetType : ScalarType<TimeSpan, StringValueNode>
 
             TimeSpan ts => ParseValue(ts),
 
-            _ => throw ThrowHelper.UtcOffset_ParseValue_IsInvalid(this)
+            _ => throw ThrowHelper.UtcOffset_ParseValue_IsInvalid(this),
         };
     }
 
@@ -154,7 +154,7 @@ public class UtcOffsetType : ScalarType<TimeSpan, StringValueNode>
                     { new TimeSpan(12, 0, 0), "+12:00" },
                     { new TimeSpan(12, 45, 0), "+12:45" },
                     { new TimeSpan(13, 0, 0), "+13:00" },
-                    { new TimeSpan(14, 0, 0), "+14:00" }
+                    { new TimeSpan(14, 0, 0), "+14:00" },
                 };
 
             var offsetToTimeSpan = _timeSpanToOffset

--- a/src/HotChocolate/Core/src/Types.Shared/BuiltInTypes.cs
+++ b/src/HotChocolate/Core/src/Types.Shared/BuiltInTypes.cs
@@ -30,7 +30,7 @@ public static class BuiltInTypes
             WellKnownDirectives.Deprecated,
             WellKnownDirectives.Defer,
             WellKnownDirectives.Stream,
-            WellKnownDirectives.SpecifiedBy
+            WellKnownDirectives.SpecifiedBy,
         };
 
     public static bool IsBuiltInType(string name)

--- a/src/HotChocolate/Core/src/Types/Configuration/Contracts/DirectiveVisibility.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Contracts/DirectiveVisibility.cs
@@ -13,5 +13,5 @@ public enum DirectiveVisibility
     /// <summary>
     /// Directive is internal and only visible within the type system.
     /// </summary>
-    Internal
+    Internal,
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/Contracts/FieldMiddlewareApplication.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Contracts/FieldMiddlewareApplication.cs
@@ -16,5 +16,5 @@ public enum FieldMiddlewareApplication : byte
     /// Custom field middleware is applied to all fields
     /// (user-defined fields and introspection fields).
     /// </summary>
-    AllFields = 1
+    AllFields = 1,
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/RootTypeKind.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/RootTypeKind.cs
@@ -7,5 +7,5 @@ internal enum RootTypeKind
     Query = 0,
     Mutation = 1,
     Subscription = 2,
-    None = 3
+    None = 3,
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeDiscoverer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeDiscoverer.cs
@@ -75,7 +75,7 @@ internal sealed class TypeDiscoverer
             new SyntaxTypeReferenceHandler(context.TypeInspector),
             new FactoryTypeReferenceHandler(context),
             new DependantFactoryTypeReferenceHandler(context),
-            new ExtendedTypeDirectiveReferenceHandler(context.TypeInspector)
+            new ExtendedTypeDirectiveReferenceHandler(context.TypeInspector),
         };
 
         _interceptor = interceptor;

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -341,7 +341,7 @@ internal sealed class TypeInitializer
             {
                 if (extension.Type is INamedTypeExtension
                     {
-                        ExtendsType: { } extendsType
+                        ExtendsType: { } extendsType,
                     } namedTypeExtension)
                 {
                     var isSchemaType = typeof(INamedType).IsAssignableFrom(extendsType);

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
@@ -13,7 +13,7 @@ internal static class SchemaValidator
         new InterfaceTypeValidationRule(),
         new InputObjectTypeValidationRule(),
         new DirectiveValidationRule(),
-        new InterfaceHasAtLeastOneImplementationRule()
+        new InterfaceHasAtLeastOneImplementationRule(),
     };
 
     public static IReadOnlyCollection<ISchemaError> Validate(

--- a/src/HotChocolate/Core/src/Types/Extensions/SchemaExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Extensions/SchemaExtensions.cs
@@ -27,7 +27,7 @@ public static class SchemaExtensions
             OperationType.Query => schema.QueryType,
             OperationType.Mutation => schema.MutationType,
             OperationType.Subscription => schema.SubscriptionType,
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
 
     /// <summary>

--- a/src/HotChocolate/Core/src/Types/Internal/ArgumentKind.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ArgumentKind.cs
@@ -22,5 +22,5 @@ public enum ArgumentKind
     ScopedState,
     LocalState,
     EventMessage,
-    Custom
+    Custom,
 }

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.BaseTypes.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.BaseTypes.cs
@@ -30,7 +30,7 @@ internal sealed partial class ExtendedType
             typeof(UnionTypeExtension),
             typeof(UnionType<>),
             typeof(DirectiveType),
-            typeof(DirectiveType<>)
+            typeof(DirectiveType<>),
         };
 
         /// <summary>

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedType.Members.cs
@@ -27,7 +27,7 @@ internal sealed partial class ExtendedType
                 PropertyInfo p => CreateExtendedType(context, flags, p.PropertyType),
                 MethodInfo m => CreateExtendedType(context, flags, m.ReturnType),
                 _ => throw new NotSupportedException(
-                    "Only PropertyInfo and MethodInfo are supported.")
+                    "Only PropertyInfo and MethodInfo are supported."),
             };
         }
 

--- a/src/HotChocolate/Core/src/Types/Internal/ExtendedTypeKind.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/ExtendedTypeKind.cs
@@ -4,5 +4,5 @@ public enum ExtendedTypeKind
 {
     Runtime,
     Extended,
-    Schema
+    Schema,
 }

--- a/src/HotChocolate/Core/src/Types/Internal/TypeComponentKind.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/TypeComponentKind.cs
@@ -4,5 +4,5 @@ public enum TypeComponentKind
 {
     NonNull,
     List,
-    Named
+    Named,
 }

--- a/src/HotChocolate/Core/src/Types/Internal/TypeDiscoveryInfo.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/TypeDiscoveryInfo.cs
@@ -148,7 +148,7 @@ public readonly ref struct TypeDiscoveryInfo
                 IsValueType: true,
                 IsPrimitive: false,
                 IsEnum: false,
-                IsByRefLike: false
+                IsByRefLike: false,
             };
 
         if (isComplexValueType && unresolvedType.IsGeneric)

--- a/src/HotChocolate/Core/src/Types/Resolvers/CleanAfter.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/CleanAfter.cs
@@ -15,5 +15,5 @@ public enum CleanAfter
     /// <summary>
     /// The cleanup task shall be applied when the query result is being disposed.
     /// </summary>
-    Request
+    Request,
 }

--- a/src/HotChocolate/Core/src/Types/Resolvers/DefaultResolverCompiler.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/DefaultResolverCompiler.cs
@@ -65,7 +65,7 @@ internal sealed class DefaultResolverCompiler : IResolverCompiler
             new LocalStateParameterExpressionBuilder(),
             new EventMessageParameterExpressionBuilder(),
             new ScopedServiceParameterExpressionBuilder(),
-            new LegacyScopedServiceParameterExpressionBuilder()
+            new LegacyScopedServiceParameterExpressionBuilder(),
         };
 
         if (customParameterExpressionBuilders is not null)

--- a/src/HotChocolate/Core/src/Types/Resolvers/DirectiveClassMiddlewareFactory.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/DirectiveClassMiddlewareFactory.cs
@@ -50,7 +50,7 @@ internal static class DirectiveClassMiddlewareFactory
                                 .CompileFactory<IServiceProvider, FieldDelegate>(
                                     (services, _) => new IParameterHandler[]
                                     {
-                                        directiveHandler, new ServiceParameterHandler(services)
+                                        directiveHandler, new ServiceParameterHandler(services),
                                     });
 
                         invoke =
@@ -60,12 +60,12 @@ internal static class DirectiveClassMiddlewareFactory
                                     {
                                         directiveHandler,
                                         new ServiceParameterHandler(
-                                            Expression.Property(context, _services))
+                                            Expression.Property(context, _services)),
                                     });
                     }
                 }
             }
-            
+
             TMiddleware? instance = null;
 
             return context =>
@@ -105,12 +105,12 @@ internal static class DirectiveClassMiddlewareFactory
                                     {
                                         directiveHandler,
                                         new ServiceParameterHandler(
-                                            Expression.Property(context, _services))
+                                            Expression.Property(context, _services)),
                                     });
                     }
                 }
             }
-            
+
             TMiddleware? instance = null;
 
             return context =>

--- a/src/HotChocolate/Core/src/Types/Resolvers/DirectiveScope.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/DirectiveScope.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Resolvers;
 public enum DirectiveScope
 {
     All,
-    FieldSelection
+    FieldSelection,
 }

--- a/src/HotChocolate/Core/src/Types/Resolvers/FieldClassMiddlewareFactory.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/FieldClassMiddlewareFactory.cs
@@ -83,7 +83,7 @@ public static class FieldClassMiddlewareFactory
             MiddlewareCompiler<TMiddleware>.CompileDelegate<IMiddlewareContext>(
                 (context, _) => new List<IParameterHandler>
                 {
-                    new ServiceParameterHandler(Expression.Property(context, _services))
+                    new ServiceParameterHandler(Expression.Property(context, _services)),
                 });
 
         return context =>

--- a/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
@@ -36,7 +36,7 @@ public partial class SchemaBuilder : ISchemaBuilder
         typeof(InterfaceCompletionTypeInterceptor),
         typeof(CostTypeInterceptor),
         typeof(MiddlewareValidationTypeInterceptor),
-        typeof(EnableTrueNullabilityTypeInterceptor)
+        typeof(EnableTrueNullabilityTypeInterceptor),
     };
 
     private SchemaOptions _options = new();

--- a/src/HotChocolate/Core/src/Types/SchemaErrorBuilder.Error.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaErrorBuilder.Error.cs
@@ -20,7 +20,7 @@ public partial class SchemaErrorBuilder
         private static readonly JsonWriterOptions _serializationOptions = new()
         {
             Indented = true,
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         };
 
         public string Message { get; set; } = default!;

--- a/src/HotChocolate/Core/src/Types/SchemaOptions.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaOptions.cs
@@ -255,7 +255,7 @@ public class SchemaOptions : IReadOnlySchemaOptions
             MaxAllowedNodeBatchSize = options.MaxAllowedNodeBatchSize,
             StripLeadingIFromInterface = options.StripLeadingIFromInterface,
             EnableTrueNullability = options.EnableTrueNullability,
-            EnableTag = options.EnableTag
+            EnableTag = options.EnableTag,
         };
     }
 }

--- a/src/HotChocolate/Core/src/Types/SchemaPrinter.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaPrinter.cs
@@ -242,7 +242,7 @@ public static class SchemaPrinter
             InputObjectType type => PrintInputObjectType(type),
             UnionType type => PrintUnionType(type),
             EnumType type => PrintEnumType(type),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
 
     private static ObjectTypeDefinitionNode PrintObjectType(

--- a/src/HotChocolate/Core/src/Types/Types/Contracts/MemberKind.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Contracts/MemberKind.cs
@@ -7,5 +7,5 @@ public enum MemberKind
     ObjectField,
     InputObjectField,
     Argument,
-    DirectiveArgument
+    DirectiveArgument,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/BindingBehavior.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/BindingBehavior.cs
@@ -13,5 +13,5 @@ public enum BindingBehavior
     /// <summary>
     /// Type system members need to be explicitly bound.
     /// </summary>
-    Explicit = 1
+    Explicit = 1,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/ConfigurationKind.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/ConfigurationKind.cs
@@ -29,5 +29,5 @@ public enum ApplyConfigurationOn
     /// <summary>
     /// After the type is completed.
     /// </summary>
-    AfterCompletion
+    AfterCompletion,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/FieldBindingFlags.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Contracts/FieldBindingFlags.cs
@@ -28,5 +28,5 @@ public enum FieldBindingFlags
     /// <summary>
     /// Specifies that instance and static members shall be inferred as GraphQL fields.
     /// </summary>
-    InstanceAndStatic = Instance | Static
+    InstanceAndStatic = Instance | Static,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ConventionStatus.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/ConventionStatus.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Types.Descriptors;
 internal enum ConventionStatus
 {
     Uninitialized,
-    Initialized
+    Initialized,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/FieldFlags.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/FieldFlags.cs
@@ -13,5 +13,5 @@ internal enum FieldFlags
     ParallelExecutable = 16,
     Stream = 32,
     Sealed = 64,
-    TypeNameField = 128
+    TypeNameField = 128,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectFieldBindingType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectFieldBindingType.cs
@@ -13,5 +13,5 @@ public enum ObjectFieldBindingType
     /// <summary>
     /// Binds to a GraphQL field
     /// </summary>
-    Field
+    Field,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectTypeDefinition.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/ObjectTypeDefinition.cs
@@ -244,7 +244,7 @@ public class ObjectTypeDefinition
                     target.Fields.FirstOrDefault(t => bindTo.Name.EqualsOrdinal(t.Member?.Name!)),
                 { BindToField: { Type: ObjectFieldBindingType.Field } bindTo } =>
                     target.Fields.FirstOrDefault(t => bindTo.Name.EqualsOrdinal(t.Name)),
-                _ => target.Fields.FirstOrDefault(t => field.Name.EqualsOrdinal(t.Name))
+                _ => target.Fields.FirstOrDefault(t => field.Name.EqualsOrdinal(t.Name)),
             };
 
             var replaceField = field.BindToField?.Replace ?? false;

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/TypeDependencyFulfilled.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/TypeDependencyFulfilled.cs
@@ -18,5 +18,5 @@ public enum TypeDependencyFulfilled
     /// <summary>
     /// The dependency instance needs to be fully completed.
     /// </summary>
-    Completed
+    Completed,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/TypeReferences/TypeReferenceExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/TypeReferences/TypeReferenceExtensions.cs
@@ -15,6 +15,6 @@ public static class TypeReferenceExtensions
         SchemaTypeReference schema => schema.With(context: context, scope: scope),
         SyntaxTypeReference syntax => syntax.With(context: context, scope: scope),
         DependantFactoryTypeReference d => d.With(context: context, scope: scope),
-        _ => throw new NotSupportedException()
+        _ => throw new NotSupportedException(),
     };
 }

--- a/src/HotChocolate/Core/src/Types/Types/Directives/Directives.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/Directives.cs
@@ -17,7 +17,7 @@ public static class Directives
             WellKnownDirectives.Deprecated,
             WellKnownDirectives.Stream,
             WellKnownDirectives.Defer,
-            WellKnownDirectives.OneOf
+            WellKnownDirectives.OneOf,
         };
 
     internal static IReadOnlyList<TypeReference> CreateReferences(
@@ -40,7 +40,7 @@ public static class Directives
         {
             directiveTypes.Add(typeInspector.GetTypeRef(typeof(StreamDirectiveType)));
         }
-        
+
         if (descriptorContext.Options.EnableTrueNullability)
         {
             directiveTypes.Add(typeInspector.GetTypeRef(typeof(NullBubblingDirective)));

--- a/src/HotChocolate/Core/src/Types/Types/Directives/TagMode.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/TagMode.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Types;
 internal enum TagMode
 {
     GraphQLFusion,
-    ApolloFederation
+    ApolloFederation,
 }

--- a/src/HotChocolate/Core/src/Types/Types/Extensions/DirectiveCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Extensions/DirectiveCollectionExtensions.cs
@@ -137,7 +137,7 @@ public static class DirectiveCollectionExtensions
                             VariableNode variable
                                 => variables.GetVariable<bool>(variable.Name.Value),
                             BooleanValueNode b => b.Value,
-                            _ => @if
+                            _ => @if,
                         };
                         break;
 
@@ -147,7 +147,7 @@ public static class DirectiveCollectionExtensions
                             VariableNode variable
                                 => variables.GetVariable<string?>(variable.Name.Value),
                             StringValueNode b => b.Value,
-                            _ => label
+                            _ => label,
                         };
                         break;
                 }
@@ -186,7 +186,7 @@ public static class DirectiveCollectionExtensions
                             VariableNode variable
                                 => variables.GetVariable<bool>(variable.Name.Value),
                             BooleanValueNode b => b.Value,
-                            _ => @if
+                            _ => @if,
                         };
                         break;
 
@@ -196,7 +196,7 @@ public static class DirectiveCollectionExtensions
                             VariableNode variable
                                 => variables.GetVariable<string?>(variable.Name.Value),
                             StringValueNode b => b.Value,
-                            _ => label
+                            _ => label,
                         };
                         break;
 
@@ -206,7 +206,7 @@ public static class DirectiveCollectionExtensions
                             VariableNode variable
                                 => variables.GetVariable<int>(variable.Name.Value),
                             IntValueNode b => b.ToInt32(),
-                            _ => initialCount
+                            _ => initialCount,
                         };
                         break;
                 }

--- a/src/HotChocolate/Core/src/Types/Types/Extensions/TypeExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Extensions/TypeExtensions.cs
@@ -521,7 +521,7 @@ public static class TypeExtensions
             NonNullType xnn when y is NonNullType ynn => xnn.Type.IsEqualTo(ynn.Type),
             ListType xl when y is ListType yl => xl.ElementType.IsEqualTo(yl.ElementType),
             INamedType xnt when y is INamedType ynt => xnt.Name.EqualsOrdinal(ynt.Name),
-            _ => false
+            _ => false,
         };
     }
 
@@ -656,7 +656,7 @@ public static class TypeExtensions
             NonNullTypeNode nonNull => new NonNullTypeNode((INullableTypeNode)RenameName(nonNull.Type, name)),
             ListTypeNode list => new ListTypeNode(RenameName(list.Type, name)),
             NamedTypeNode named => named.WithName(named.Name.WithValue(name)),
-            _ => throw new NotSupportedException(TypeResources.TypeExtensions_KindIsNotSupported)
+            _ => throw new NotSupportedException(TypeResources.TypeExtensions_KindIsNotSupported),
         };
 
     public static bool IsInstanceOfType(this IInputType type, IValueNode literal)
@@ -763,7 +763,7 @@ public static class TypeExtensions
                 throw RewriteNullability_InvalidNullabilityStructure();
         }
     }
-    
+
     public static IType RewriteToNullableType(this IType type)
         => type.Kind is TypeKind.NonNull
             ? type.InnerType()

--- a/src/HotChocolate/Core/src/Types/Types/Helpers/DirectiveHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Helpers/DirectiveHelper.cs
@@ -19,7 +19,7 @@ internal static class DirectiveHelper
             IOutputField => DirectiveLocation.FieldDefinition,
             InputField => DirectiveLocation.InputFieldDefinition,
             Argument => DirectiveLocation.ArgumentDefinition,
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
     }
 }

--- a/src/HotChocolate/Core/src/Types/Types/InputField.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputField.cs
@@ -24,7 +24,7 @@ public class InputField : FieldBase<InputFieldDefinition>, IInputField, IHasProp
         {
             0 => null,
             1 => formatters[0],
-            _ => new AggregateInputValueFormatter(formatters)
+            _ => new AggregateInputValueFormatter(formatters),
         };
 
         IsDeprecated = !string.IsNullOrEmpty(definition.DeprecationReason);

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/FlagEnumTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/FlagEnumTypeInterceptor.cs
@@ -117,7 +117,7 @@ public class FlagsEnumInterceptor : TypeInterceptor
         var desc = _namingConventions.GetTypeDescription(type, TypeKind.Enum);
         var objectTypeDefinition = new ObjectTypeDefinition(typeName, desc)
         {
-            RuntimeType = typeof(Dictionary<string, object>)
+            RuntimeType = typeof(Dictionary<string, object>),
         };
 
         foreach (var value in Enum.GetValues(type))
@@ -148,7 +148,7 @@ public class FlagsEnumInterceptor : TypeInterceptor
         var desc = _namingConventions.GetTypeDescription(type, TypeKind.Enum);
         var objectTypeDefinition = new InputObjectTypeDefinition(typeName, desc)
         {
-            RuntimeType = typeof(Dictionary<string, object>)
+            RuntimeType = typeof(Dictionary<string, object>),
         };
 
         var metadata = new Dictionary<string, object>();

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/IntrospectionTypes.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/IntrospectionTypes.cs
@@ -20,7 +20,7 @@ public static class IntrospectionTypes
             __Type.Names.__Type,
             __TypeKind.Names.__TypeKind,
             __AppliedDirective.Names.__AppliedDirective,
-            __DirectiveArgument.Names.__DirectiveArgument
+            __DirectiveArgument.Names.__DirectiveArgument,
         };
 
     internal static IReadOnlyList<TypeReference> CreateReferences(
@@ -35,7 +35,7 @@ public static class IntrospectionTypes
                 context.TypeInspector.GetTypeRef(typeof(__InputValue)),
                 context.TypeInspector.GetTypeRef(typeof(__Schema)),
                 context.TypeInspector.GetTypeRef(typeof(__Type)),
-                context.TypeInspector.GetTypeRef(typeof(__TypeKind))
+                context.TypeInspector.GetTypeRef(typeof(__TypeKind)),
             };
 
         if (context.Options.EnableDirectiveIntrospection)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__AppliedDirective.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__AppliedDirective.cs
@@ -31,8 +31,8 @@ internal sealed class __AppliedDirective : ObjectType<DirectiveNode>
             Fields =
             {
                 new(Names.Name, type: nonNullStringType, pureResolver: Resolvers.Name),
-                new(Names.Args, type: locationListType, pureResolver: Resolvers.Arguments)
-            }
+                new(Names.Args, type: locationListType, pureResolver: Resolvers.Arguments),
+            },
         };
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Directive.cs
@@ -42,9 +42,9 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                         new(Names.IncludeDeprecated, type: booleanType)
                         {
                             DefaultValue = BooleanValueNode.False,
-                            RuntimeDefaultValue = false
-                        }
-                    }
+                            RuntimeDefaultValue = false,
+                        },
+                    },
                 },
                 new(Names.IsRepeatable,
                     type: nonNullBooleanType,
@@ -53,21 +53,21 @@ internal sealed class __Directive : ObjectType<DirectiveType>
                     type: nonNullBooleanType,
                     pureResolver: Resolvers.OnOperation)
                 {
-                    DeprecationReason = TypeResources.Directive_UseLocation
+                    DeprecationReason = TypeResources.Directive_UseLocation,
                 },
                 new(Names.OnFragment,
                     type: nonNullBooleanType,
                     pureResolver: Resolvers.OnFragment)
                 {
-                    DeprecationReason = TypeResources.Directive_UseLocation
+                    DeprecationReason = TypeResources.Directive_UseLocation,
                 },
                 new(Names.OnField,
                     type: nonNullBooleanType,
                     pureResolver: Resolvers.OnField)
                 {
-                    DeprecationReason = TypeResources.Directive_UseLocation
-                }
-            }
+                    DeprecationReason = TypeResources.Directive_UseLocation,
+                },
+            },
         };
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveArgument.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveArgument.cs
@@ -32,8 +32,8 @@ internal sealed class __DirectiveArgument : ObjectType<ArgumentNode>
             Fields =
             {
                 new(Names.Name, type: nonNullStringType, pureResolver: Resolvers.Name),
-                new(Names.Value, type: nonNullStringType, pureResolver: Resolvers.Value)
-            }
+                new(Names.Value, type: nonNullStringType, pureResolver: Resolvers.Value),
+            },
         };
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveLocation.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__DirectiveLocation.cs
@@ -95,7 +95,7 @@ internal sealed class __DirectiveLocation : EnumType<DirectiveLocation>
                     Lang.InputFieldDefinition.Value,
                     DirectiveLocation_InputFieldDefinition,
                     DirectiveLocation.InputFieldDefinition),
-            }
+            },
         };
 
     public static class Names

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__EnumValue.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__EnumValue.cs
@@ -34,7 +34,7 @@ internal sealed class __EnumValue : ObjectType<IEnumValue>
                         pureResolver: Resolvers.IsDeprecated),
                     new(Names.DeprecationReason, type: stringType,
                         pureResolver: Resolvers.DeprecationReason),
-                }
+                },
         };
 
         if (context.DescriptorContext.Options.EnableDirectiveIntrospection)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Field.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Field.cs
@@ -41,9 +41,9 @@ internal sealed class __Field : ObjectType<IOutputField>
                         new(Names.IncludeDeprecated, type: booleanType)
                         {
                             DefaultValue = BooleanValueNode.False,
-                            RuntimeDefaultValue = false
-                        }
-                    }
+                            RuntimeDefaultValue = false,
+                        },
+                    },
                 },
                 new(Names.Type, type: nonNullTypeType, pureResolver: Resolvers.Type),
                 new(Names.IsDeprecated,
@@ -52,7 +52,7 @@ internal sealed class __Field : ObjectType<IOutputField>
                 new(Names.DeprecationReason,
                     type: stringType,
                     pureResolver: Resolvers.DeprecationReason),
-            }
+            },
         };
 
         if (context.DescriptorContext.Options.EnableDirectiveIntrospection)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__InputValue.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__InputValue.cs
@@ -44,7 +44,7 @@ internal sealed class __InputValue : ObjectType
                 new(Names.DeprecationReason,
                     type: stringType,
                     pureResolver: Resolvers.DeprecationReason),
-            }
+            },
         };
 
         if (context.DescriptorContext.Options.EnableDirectiveIntrospection)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Schema.cs
@@ -45,7 +45,7 @@ internal sealed class __Schema : ObjectType
                         Schema_Directives,
                         directiveListType,
                         pureResolver: Resolvers.Directives),
-                }
+                },
         };
 
         if (context.DescriptorContext.Options.EnableDirectiveIntrospection)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__Type.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__Type.cs
@@ -45,8 +45,8 @@ internal sealed class __Type : ObjectType
                         {
                             DefaultValue = BooleanValueNode.False,
                             RuntimeDefaultValue = false,
-                        }
-                    }
+                        },
+                    },
                 },
                 new(Names.Interfaces, type: typeListType, pureResolver: Resolvers.Interfaces),
                 new(Names.PossibleTypes, type: typeListType, pureResolver: Resolvers.PossibleTypes),
@@ -60,8 +60,8 @@ internal sealed class __Type : ObjectType
                             Type = booleanType,
                             DefaultValue = BooleanValueNode.False,
                             RuntimeDefaultValue = false,
-                        }
-                    }
+                        },
+                    },
                 },
                 new(Names.InputFields,
                     type: inputValueListType,
@@ -75,15 +75,15 @@ internal sealed class __Type : ObjectType
                             Type = booleanType,
                             DefaultValue = BooleanValueNode.False,
                             RuntimeDefaultValue = false,
-                        }
-                    }
+                        },
+                    },
                 },
                 new(Names.OfType, type: typeType, pureResolver: Resolvers.OfType),
                 new(Names.SpecifiedByUrl,
                     TypeResources.Type_SpecifiedByUrl_Description,
                     stringType,
-                    pureResolver: Resolvers.SpecifiedBy)
-            }
+                    pureResolver: Resolvers.SpecifiedBy),
+            },
         };
 
         if (context.DescriptorContext.Options.EnableOneOf)
@@ -160,7 +160,7 @@ internal sealed class __Type : ObjectType
             {
                 ListType lt => lt.ElementType,
                 NonNullType nnt => nnt.Type,
-                _ => null
+                _ => null,
             };
 
         public static object? OneOf(IPureResolverContext context)

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__TypeKind.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__TypeKind.cs
@@ -24,7 +24,7 @@ internal sealed class __TypeKind : EnumType
                 new(Names.InputObject, TypeKind_InputObject, TypeKind.InputObject),
                 new(Names.List, TypeKind_List, TypeKind.List),
                 new(Names.NonNull, TypeKind_NonNull, TypeKind.NonNull),
-            }
+            },
         };
 
     public static class Names

--- a/src/HotChocolate/Core/src/Types/Types/Pagination/PagingOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Pagination/PagingOptions.cs
@@ -91,6 +91,6 @@ public struct PagingOptions
             InferConnectionNameFromField = InferConnectionNameFromField,
             InferCollectionSegmentNameFromField = InferCollectionSegmentNameFromField,
             ProviderName = ProviderName,
-            LegacySupport = LegacySupport
+            LegacySupport = LegacySupport,
         };
 }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/NodeFieldTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/NodeFieldTypeInterceptor.cs
@@ -92,8 +92,8 @@ internal sealed class NodeFieldTypeInterceptor : TypeInterceptor
                     _ => async context =>
                     {
                         await ResolveSingleNodeAsync(context, serializer).ConfigureAwait(false);
-                    })
-            }
+                    }),
+            },
         };
 
         // In the projection interceptor we want to change the context data that is on this field
@@ -127,8 +127,8 @@ internal sealed class NodeFieldTypeInterceptor : TypeInterceptor
                     {
                         await ResolveManyNodeAsync(context, serializer, maxAllowedNodes)
                             .ConfigureAwait(false);
-                    })
-            }
+                    }),
+            },
         };
 
         // In the projection interceptor we want to change the context data that is on this field

--- a/src/HotChocolate/Core/src/Types/Types/Relay/NodeResolverCompilerHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/NodeResolverCompilerHelper.cs
@@ -6,6 +6,6 @@ internal static class NodeResolverCompilerHelper
 {
     public static readonly IParameterExpressionBuilder[] ParameterExpressionBuilders =
     {
-        NodeIdParameterExpressionBuilder.Instance
+        NodeIdParameterExpressionBuilder.Instance,
     };
 }

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/Scalars.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/Scalars.cs
@@ -95,7 +95,7 @@ public static class Scalars
         { typeof(double?), ValueKind.Float },
         { typeof(decimal?), ValueKind.Float },
         { typeof(bool), ValueKind.Float },
-        { typeof(bool?), ValueKind.Float }
+        { typeof(bool?), ValueKind.Float },
     };
 
     internal static bool TryGetScalar(

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/TimeSpanFormat.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/TimeSpanFormat.cs
@@ -11,5 +11,5 @@ public enum TimeSpanFormat
     /// TimeSpan .NET Constant ("c") Format
     /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings#the-constant-c-format-specifier
     /// </summary>
-    DotNet
+    DotNet,
 }

--- a/src/HotChocolate/Core/src/Types/Types/TypeContext.cs
+++ b/src/HotChocolate/Core/src/Types/Types/TypeContext.cs
@@ -4,5 +4,5 @@ public enum TypeContext
 {
     None = 0,
     Output = 2,
-    Input = 4
+    Input = 4,
 }

--- a/src/HotChocolate/Core/src/Types/Types/TypeStatus.cs
+++ b/src/HotChocolate/Core/src/Types/Types/TypeStatus.cs
@@ -6,5 +6,5 @@ internal enum TypeStatus
     Initialized,
     Named,
     Completed,
-    Finalized
+    Finalized,
 }

--- a/src/HotChocolate/Core/src/Types/Utilities/Nullable.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/Nullable.cs
@@ -7,5 +7,5 @@ internal enum Nullable : byte
     Skip = 0,
     Yes = 2,
     No = 1,
-    Undefined = 3
+    Undefined = 3,
 }

--- a/src/HotChocolate/Core/src/Types/Utilities/NullableHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/NullableHelper.cs
@@ -64,7 +64,7 @@ internal readonly struct NullableHelper
             {
                 Nullable.Yes => true,
                 Nullable.No => false,
-                _ => null
+                _ => null,
             };
         }
         return parent;
@@ -96,7 +96,7 @@ internal readonly struct NullableHelper
                 {
                     Nullable.Yes => true,
                     Nullable.No => false,
-                    _ => null
+                    _ => null,
                 };
             }
 

--- a/src/HotChocolate/Core/src/Validation/Rules/ArgumentVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ArgumentVisitor.cs
@@ -36,7 +36,7 @@ internal sealed class ArgumentVisitor : TypeDocumentValidatorVisitor
     public ArgumentVisitor()
         : base(new SyntaxVisitorOptions
         {
-            VisitDirectives = true
+            VisitDirectives = true,
         })
     {
     }

--- a/src/HotChocolate/Core/src/Validation/Rules/DirectiveVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/DirectiveVisitor.cs
@@ -50,7 +50,7 @@ internal sealed class DirectiveVisitor : DocumentValidatorVisitor
     public DirectiveVisitor()
         : base(new SyntaxVisitorOptions
         {
-            VisitDirectives = true
+            VisitDirectives = true,
         })
     {
     }

--- a/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
@@ -52,7 +52,7 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         : base(new SyntaxVisitorOptions
         {
             VisitDirectives = true,
-            VisitArguments = true
+            VisitArguments = true,
         })
     {
     }
@@ -367,7 +367,7 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
             SyntaxKind.Argument =>
                 context.ArgumentValueIsNotCompatible(
                     (ArgumentNode)node, locationType, valueNode),
-            _ => null
+            _ => null,
         };
         return error != null;
     }

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableVisitor.cs
@@ -55,7 +55,7 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         : base(new SyntaxVisitorOptions
         {
             VisitDirectives = true,
-            VisitArguments = true
+            VisitArguments = true,
         })
     {
     }
@@ -248,7 +248,7 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         {
             SyntaxKind.Argument => context.InputFields.Peek().DefaultValue,
             SyntaxKind.ObjectField => context.InputFields.Peek().DefaultValue,
-            _ => null
+            _ => null,
         };
 
         if (context.Variables.TryGetValue(

--- a/src/HotChocolate/Core/test/Abstractions.Tests/ErrorBuilderTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/ErrorBuilderTests.cs
@@ -31,7 +31,7 @@ public class ErrorBuilderTests
             "123",
             extensions: new OrderedDictionary<string, object>
             {
-                {"foo", "bar"}
+                {"foo", "bar"},
             });
 
         // act
@@ -53,7 +53,7 @@ public class ErrorBuilderTests
             "123",
             extensions: new OrderedDictionary<string, object>
             {
-                {"foo", "bar"}
+                {"foo", "bar"},
             }
         );
 
@@ -75,7 +75,7 @@ public class ErrorBuilderTests
             extensions: new OrderedDictionary<string, object>
             {
                 {"foo", "bar"},
-                {"bar", "foo"}
+                {"bar", "foo"},
             }
         );
 

--- a/src/HotChocolate/Core/test/Abstractions.Tests/ErrorTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/ErrorTests.cs
@@ -123,7 +123,7 @@ public class ErrorTests
             new Dictionary<string, object>
             {
                 { "a", "b" },
-                { "c", "d" }
+                { "c", "d" },
             });
 
         // act

--- a/src/HotChocolate/Core/test/Abstractions.Tests/Execution/QueryRequestBuilderTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/Execution/QueryRequestBuilderTests.cs
@@ -98,7 +98,7 @@ public class QueryRequestBuilderTests
                 .AddVariableValue("two", "bar")
                 .SetVariableValues(new Dictionary<string, object>
                 {
-                    { "three", "baz" }
+                    { "three", "baz" },
                 })
                 .Create();
 
@@ -186,7 +186,7 @@ public class QueryRequestBuilderTests
                 .AddGlobalState("two", "bar")
                 .InitializeGlobalState(new Dictionary<string, object>
                 {
-                    { "three", "baz" }
+                    { "three", "baz" },
                 })
                 .Create();
 
@@ -453,7 +453,7 @@ public class QueryRequestBuilderTests
                 .AddExtension("two", "bar")
                 .SetExtensions(new Dictionary<string, object>
                 {
-                    { "three", "baz" }
+                    { "three", "baz" },
                 })
                 .Create();
 
@@ -469,7 +469,7 @@ public class QueryRequestBuilderTests
         IReadOnlyDictionary<string, object> ext =
             new Dictionary<string, object>
             {
-                { "three", "baz" }
+                { "three", "baz" },
             };
 
         // act
@@ -493,7 +493,7 @@ public class QueryRequestBuilderTests
         IReadOnlyDictionary<string, object> ext =
             new Dictionary<string, object>
             {
-                { "three", "baz" }
+                { "three", "baz" },
             };
 
         // act
@@ -518,7 +518,7 @@ public class QueryRequestBuilderTests
         IDictionary<string, object> ext =
             new Dictionary<string, object>
             {
-                { "three", "baz" }
+                { "three", "baz" },
             };
 
         // act
@@ -542,7 +542,7 @@ public class QueryRequestBuilderTests
         IDictionary<string, object> ext =
             new Dictionary<string, object>
             {
-                { "three", "baz" }
+                { "three", "baz" },
             };
 
         // act

--- a/src/HotChocolate/Core/test/Execution.Tests/Batching/BatchQueryExecutorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Batching/BatchQueryExecutorTests.cs
@@ -42,7 +42,7 @@ public class BatchQueryExecutorTests
                                 name
                             }
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -87,7 +87,7 @@ public class BatchQueryExecutorTests
                                 name
                             }
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -132,7 +132,7 @@ public class BatchQueryExecutorTests
                                 name
                             }
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -180,7 +180,7 @@ public class BatchQueryExecutorTests
                                 stars
                             }
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -209,7 +209,7 @@ public class BatchQueryExecutorTests
                         return new List<string>
                         {
                             "123",
-                            "456"
+                            "456",
                         };
                     }
 
@@ -232,7 +232,7 @@ public class BatchQueryExecutorTests
                     @"{
                             foo(bar: $b)
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -271,14 +271,14 @@ public class BatchQueryExecutorTests
                     {
                         new Dictionary<string, object>
                         {
-                            { "bar" , "123" }
-                        }
+                            { "bar" , "123" },
+                        },
                     };
                 }
 
                 list.Add(new Dictionary<string, object>
                 {
-                    { "bar" , "456" }
+                    { "bar" , "456" },
                 });
                 return list;
             })
@@ -314,7 +314,7 @@ public class BatchQueryExecutorTests
                                 bar
                             }
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -357,7 +357,7 @@ public class BatchQueryExecutorTests
                     @"query foo2($b: [String]) {
                             foo(bar: $b)
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);
@@ -408,7 +408,7 @@ public class BatchQueryExecutorTests
                     @"query foo2($b2: String) {
                             baz(bar: $b2)
                         }")
-                .Create()
+                .Create(),
         };
 
         var batchResult = await executor.ExecuteBatchAsync(batch);

--- a/src/HotChocolate/Core/test/Execution.Tests/Batching/CollectVariablesVisitorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Batching/CollectVariablesVisitorTests.cs
@@ -47,7 +47,7 @@ public class CollectVariablesVisitorTests
         new DocumentNode(
             new IDefinitionNode[]
             {
-                operation
+                operation,
             }).Print().MatchSnapshot();
     }
 
@@ -90,7 +90,7 @@ public class CollectVariablesVisitorTests
         new DocumentNode(
             new IDefinitionNode[]
             {
-                operation
+                operation,
             }).Print().MatchSnapshot();
     }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/ClientControlledNullabilityTests.cs
@@ -65,7 +65,7 @@ public class ClientControlledNullabilityTests
         public List<Person> Persons { get; } = new()
         {
             new Person {Name = "Abc", Bio = "Def"},
-            new Person {Name = "Ghi", Bio = null}
+            new Person {Name = "Ghi", Bio = null},
         };
     }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/CodeFirstTests.cs
@@ -505,7 +505,7 @@ public class CodeFirstTests
     public enum DrinkKind
     {
         BlackTea,
-        Water
+        Water,
     }
 
     public class FooBarUnionType : UnionType

--- a/src/HotChocolate/Core/test/Execution.Tests/DependencyInjectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/DependencyInjectionTests.cs
@@ -30,7 +30,7 @@ public class DependencyInjectionTests
                 .ToJsonAsync(),
             result2 = await executor
                 .ExecuteAsync("{ hello }")
-                .ToJsonAsync()
+                .ToJsonAsync(),
         }.MatchSnapshot();
     }
 
@@ -97,7 +97,7 @@ public class DependencyInjectionTests
                 .ToJsonAsync(),
             result2 = await executor
                 .ExecuteAsync("{ hello }")
-                .ToJsonAsync()
+                .ToJsonAsync(),
         }.MatchSnapshot();
     }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/DataLoader/DataLoaderTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/DataLoader/DataLoaderTests.cs
@@ -201,7 +201,7 @@ public class DataLoaderTests
                         @"{
                             c: withDataLoader(key: ""c"")
                         }")
-                    .Create())
+                    .Create()),
         };
 
         // assert
@@ -298,7 +298,7 @@ public class DataLoaderTests
                         @"{
                             c: dataLoaderWithInterface(key: ""c"")
                         }")
-                    .Create())
+                    .Create()),
         };
 
         // assert

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/StarWarsCodeFirstTests.cs
@@ -999,13 +999,13 @@ public class StarWarsCodeFirstTests
             ConfigureRequest = r =>
             {
                 r.SkipExecutionDepthAnalysis();
-            }
+            },
         };
         var configurationB = new TestConfiguration
         {
             ConfigureRequest = _ =>
             {
-            }
+            },
         };
         var executor = await CreateExecutorAsync(
             c =>

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/TypeConverterTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/TypeConverterTests.cs
@@ -28,7 +28,7 @@ public class TypeConverterTests
                     {
                         { "id", "934b987bc0d842bbabfd8a3b3f8b476e" },
                         { "time", "2018-05-29T01:00Z" },
-                        { "number", (byte)123 }
+                        { "number", (byte)123 },
                     }),
                 configure: c => c.AddQueryType<Query>())
             .MatchSnapshotAsync();
@@ -82,7 +82,7 @@ public class TypeConverterTests
                     {
                         { "id", "934b987bc0d842bbabfd8a3b3f8b476e" },
                         { "time", "2018-05-29T01:00Z" },
-                        { "number", (byte)123 }
+                        { "number", (byte)123 },
                     }),
                 configure: c => c.AddQueryType<QueryType>())
             .MatchSnapshotAsync();

--- a/src/HotChocolate/Core/test/Execution.Tests/Processing/VariableCoercionHelperTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Processing/VariableCoercionHelperTests.cs
@@ -24,7 +24,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>();
@@ -70,7 +70,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -97,7 +97,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>();
@@ -125,7 +125,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>();
@@ -160,7 +160,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>();
@@ -188,12 +188,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", new StringValueNode("xyz")}
+            {"abc", new StringValueNode("xyz")},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -227,12 +227,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", "xyz"}
+            {"abc", "xyz"},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -266,12 +266,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", NullValueNode.Default}
+            {"abc", NullValueNode.Default},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -304,12 +304,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", null}
+            {"abc", null},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -342,12 +342,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("ReviewInput"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", new ObjectValueNode(new ObjectFieldNode("stars", 5))}
+            {"abc", new ObjectValueNode(new ObjectFieldNode("stars", 5))},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -380,12 +380,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("ReviewInput"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", new Dictionary<string, object> { {"stars", 5} }}
+            {"abc", new Dictionary<string, object> { {"stars", 5} }},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -418,12 +418,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("ReviewInput"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            { "abc", new Review { Stars = 5 } }
+            { "abc", new Review { Stars = 5 } },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -456,12 +456,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NonNullTypeNode(new NamedTypeNode("String")),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", NullValueNode.Default}
+            {"abc", NullValueNode.Default},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -488,12 +488,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NonNullTypeNode(new NamedTypeNode("String")),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", null}
+            {"abc", null},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -520,12 +520,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            {"abc", new IntValueNode(1)}
+            {"abc", new IntValueNode(1)},
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -554,12 +554,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            { "abc", 1 }
+            { "abc", 1 },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -585,12 +585,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("Human"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            { "abc", 1 }
+            { "abc", 1 },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -616,12 +616,12 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("ReviewInput"),
                 new StringValueNode("def"),
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
         {
-            { "abc", new ObjectValueNode(new ObjectFieldNode("abc", "def")) }
+            { "abc", new ObjectValueNode(new ObjectFieldNode("abc", "def")) },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -666,7 +666,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new ListTypeNode(new NamedTypeNode("FooInput")),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
@@ -678,7 +678,7 @@ public class VariableCoercionHelperTests
                         new ObjectFieldNode("enum", "Foo")),
                     new ObjectValueNode(
                         new ObjectFieldNode("enum", "Bar")))
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -727,7 +727,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new ListTypeNode(new NamedTypeNode("FooInput")),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
@@ -739,7 +739,7 @@ public class VariableCoercionHelperTests
                         new ObjectFieldNode("enum", "Foo")),
                     new ObjectValueNode(
                         new ObjectFieldNode("enum", "Bar")))
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -789,7 +789,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("FooInput"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
@@ -799,7 +799,7 @@ public class VariableCoercionHelperTests
                 new ObjectValueNode(
                     new ObjectFieldNode("enum", "Foo"),
                     new ObjectFieldNode("enum2", "Bar"))
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -847,7 +847,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("FooInput"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>
@@ -857,7 +857,7 @@ public class VariableCoercionHelperTests
                 new ObjectValueNode(
                     new ObjectFieldNode("enum", "Foo"),
                     new ObjectFieldNode("enum2", "Bar"))
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -905,7 +905,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("FooInput"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var expectToBeUnchanged = new ObjectFieldNode("value_a", "Foo");
@@ -918,7 +918,7 @@ public class VariableCoercionHelperTests
                 new ObjectValueNode(
                     expectToBeUnchanged,
                     expectToBeRewritten)
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -972,7 +972,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new ListTypeNode(new NamedTypeNode("FooInput")),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var expectToBeUnchanged = new ObjectValueNode(new ObjectFieldNode("value_a", "Foo"));
@@ -983,7 +983,7 @@ public class VariableCoercionHelperTests
             {
                 "abc",
                 new ListValueNode(expectToBeUnchanged, expectToBeRewritten)
-            }
+            },
         };
 
         var coercedValues = new Dictionary<string, VariableValueOrLiteral>();
@@ -1020,7 +1020,7 @@ public class VariableCoercionHelperTests
                 new VariableNode("abc"),
                 new NamedTypeNode("String"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var variableValues = new Dictionary<string, object>();

--- a/src/HotChocolate/Core/test/Execution.Tests/ScalarExecutionErrorTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/ScalarExecutionErrorTests.cs
@@ -81,7 +81,7 @@ public class ScalarExecutionErrorTests
             "query a($a: Foo) { fooToString(name: $a) }",
             new Dictionary<string, object?>
             {
-                {"a", " "}
+                {"a", " "},
             });
 
         // assert

--- a/src/HotChocolate/Core/test/Execution.Tests/SchemaFirstTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/SchemaFirstTests.cs
@@ -269,7 +269,7 @@ public class SchemaFirstTests
     {
         Bar,
         Baz,
-        BazBar
+        BazBar,
     }
 
     public class Query5730

--- a/src/HotChocolate/Core/test/StarWars/Data/CharacterRepository.cs
+++ b/src/HotChocolate/Core/test/StarWars/Data/CharacterRepository.cs
@@ -87,7 +87,7 @@ public class CharacterRepository
             Friends = new[] { "1002", "1003", "2000", "2001" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
             HomePlanet = "Tatooine",
-            Traits = JsonSerializer.SerializeToElement(new { lastJedi = true })
+            Traits = JsonSerializer.SerializeToElement(new { lastJedi = true }),
         };
 
         yield return new Human
@@ -97,7 +97,7 @@ public class CharacterRepository
             Friends = new[] { "1004" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
             HomePlanet = "Tatooine",
-            Traits = JsonSerializer.SerializeToElement(new { theChosenOne = true })
+            Traits = JsonSerializer.SerializeToElement(new { theChosenOne = true }),
         };
 
         yield return new Human
@@ -106,7 +106,7 @@ public class CharacterRepository
             Name = "Han Solo",
             Friends = new[] { "1000", "1003", "2001" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
-            Traits = JsonSerializer.SerializeToElement(new { hanShot = "first" })
+            Traits = JsonSerializer.SerializeToElement(new { hanShot = "first" }),
         };
 
         yield return new Human
@@ -116,7 +116,7 @@ public class CharacterRepository
             Friends = new[] { "1000", "1002", "2000", "2001" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
             HomePlanet = "Alderaan",
-            Traits = JsonSerializer.SerializeToElement(new { brother = "luke" })
+            Traits = JsonSerializer.SerializeToElement(new { brother = "luke" }),
         };
 
         yield return new Human
@@ -124,7 +124,7 @@ public class CharacterRepository
             Id = "1004",
             Name = "Wilhuff Tarkin",
             Friends = new[] { "1001" },
-            AppearsIn = new[] { Episode.NewHope }
+            AppearsIn = new[] { Episode.NewHope },
         };
 
         yield return new Droid
@@ -134,7 +134,7 @@ public class CharacterRepository
             Friends = new[] { "1000", "1002", "1003", "2001" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
             PrimaryFunction = "Protocol",
-            Traits = JsonSerializer.SerializeToElement(new { annoying = true })
+            Traits = JsonSerializer.SerializeToElement(new { annoying = true }),
         };
 
         yield return new Droid
@@ -144,7 +144,7 @@ public class CharacterRepository
             Friends = new[] { "1000", "1002", "1003" },
             AppearsIn = new[] { Episode.NewHope, Episode.Empire, Episode.Jedi },
             PrimaryFunction = "Astromech",
-            Traits = JsonSerializer.SerializeToElement(new { rockets = true })
+            Traits = JsonSerializer.SerializeToElement(new { rockets = true }),
         };
     }
 
@@ -154,7 +154,7 @@ public class CharacterRepository
         {
             Id = "3000",
             Name = "TIE Advanced x1",
-            Length = 9.2
+            Length = 9.2,
         };
     }
 }

--- a/src/HotChocolate/Core/test/StarWars/Models/Episode.cs
+++ b/src/HotChocolate/Core/test/StarWars/Models/Episode.cs
@@ -16,5 +16,5 @@ public enum Episode
     /// <summary>
     /// Star Wars Episode VI: Return of the Jedi
     /// </summary>
-    Jedi
+    Jedi,
 }

--- a/src/HotChocolate/Core/test/StarWars/Models/Unit.cs
+++ b/src/HotChocolate/Core/test/StarWars/Models/Unit.cs
@@ -6,5 +6,5 @@ namespace HotChocolate.StarWars.Models;
 public enum Unit
 {
     Foot,
-    Meters
+    Meters,
 }

--- a/src/HotChocolate/Core/test/Subscriptions.Nats.Tests/NatsIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Nats.Tests/NatsIntegrationTests.cs
@@ -40,11 +40,11 @@ public class NatsIntegrationTests : SubscriptionIntegrationTestBase, IClassFixtu
     [Fact]
     public override Task Subscribe_Topic_With_2_Arguments()
         => base.Subscribe_Topic_With_2_Arguments();
-    
+
     [Fact]
     public override Task Subscribe_And_Complete_Topic()
         => base.Subscribe_And_Complete_Topic();
-    
+
     [Fact]
     public override Task Subscribe_And_Complete_Topic_With_ValueTypeMessage()
         => base.Subscribe_And_Complete_Topic_With_ValueTypeMessage();
@@ -55,7 +55,7 @@ public class NatsIntegrationTests : SubscriptionIntegrationTestBase, IClassFixtu
         graphqlBuilder.Services
             .AddNats(poolSize: 1, options => options with
             {
-                Url = _natsResource.NatsConnectionString
+                Url = _natsResource.NatsConnectionString,
             })
             .AddLogging();
 

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
@@ -27,7 +27,7 @@ public class PostgresChannelTests
         _channelName = $"channel_{Guid.NewGuid():N}";
         _options = new PostgresSubscriptionOptions
         {
-            ConnectionFactory = ConnectionFactory, ChannelName = _channelName
+            ConnectionFactory = ConnectionFactory, ChannelName = _channelName,
         };
     }
 
@@ -299,7 +299,7 @@ public class PostgresChannelTests
 
                 return await ConnectionFactory(ct);
             },
-            ChannelName = _channelName
+            ChannelName = _channelName,
         };
         var channel = new PostgresChannel(_events, options);
         await channel.EnsureInitialized(CancellationToken.None);
@@ -358,7 +358,7 @@ public class PostgresChannelTests
 
                 return await ConnectionFactory(ct);
             },
-            ChannelName = _channelName
+            ChannelName = _channelName,
         };
         var channel = new PostgresChannel(_events, options);
         await channel.EnsureInitialized(CancellationToken.None);

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
@@ -27,7 +27,7 @@ public class PostgresChannelWriterTests
         _channelName = $"channel_{Guid.NewGuid():N}";
         _options = new PostgresSubscriptionOptions
         {
-            ConnectionFactory = ConnectionFactory, ChannelName = _channelName
+            ConnectionFactory = ConnectionFactory, ChannelName = _channelName,
         };
     }
 
@@ -89,7 +89,7 @@ public class PostgresChannelWriterTests
                 connected = true;
                 return await ConnectionFactory(ct);
             },
-            ChannelName = _channelName
+            ChannelName = _channelName,
         };
         var postgresChannelWriter = new PostgresChannelWriter(_events, options);
 
@@ -121,7 +121,7 @@ public class PostgresChannelWriterTests
 
                 return await ConnectionFactory(ct);
             },
-            ChannelName = _channelName
+            ChannelName = _channelName,
         };
         var postgresChannelWriter = new PostgresChannelWriter(_events, options);
         await postgresChannelWriter.Initialize(CancellationToken.None);
@@ -146,7 +146,7 @@ public class PostgresChannelWriterTests
                 connection = await ConnectionFactory(ct);
                 return connection;
             },
-            ChannelName = _channelName
+            ChannelName = _channelName,
         };
         var postgresChannelWriter = new PostgresChannelWriter(_events, options);
         await postgresChannelWriter.Initialize(CancellationToken.None);

--- a/src/HotChocolate/Core/test/Subscriptions.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.RabbitMQ.Tests/RabbitMQIntegrationTests.cs
@@ -38,11 +38,11 @@ public class RabbitMQIntegrationTests : SubscriptionIntegrationTestBase, IClassF
     [Fact]
     public override Task Subscribe_Topic_With_2_Arguments()
         => base.Subscribe_Topic_With_2_Arguments();
-    
+
     [Fact]
     public override Task Subscribe_And_Complete_Topic()
         => base.Subscribe_And_Complete_Topic();
-    
+
     [Fact]
     public override Task Subscribe_And_Complete_Topic_With_ValueTypeMessage()
         => base.Subscribe_And_Complete_Topic_With_ValueTypeMessage();
@@ -56,7 +56,7 @@ public class RabbitMQIntegrationTests : SubscriptionIntegrationTestBase, IClassF
         graphqlBuilder.AddRabbitMQSubscriptions(new()
         {
             HostName = _rabbitMQResource.Instance.Address,
-            Port = _rabbitMQResource.Instance.HostPort
+            Port = _rabbitMQResource.Instance.HostPort,
         });
     }
 }

--- a/src/HotChocolate/Core/test/Subscriptions.Tests/DefaultJsonMessageSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Tests/DefaultJsonMessageSerializerTests.cs
@@ -32,7 +32,7 @@ public class DefaultJsonMessageSerializerTests
         // assert
         Assert.Equal(MessageKind.Completed, messageEnvelope.Kind);
     }
-    
+
     [Fact]
     public void DeserializeCompleteMessage_With_Enum_Body()
     {
@@ -46,7 +46,7 @@ public class DefaultJsonMessageSerializerTests
         // assert
         Assert.Equal(MessageKind.Completed, messageEnvelope.Kind);
     }
-    
+
     [Fact]
     public void DeserializeCompleteMessage_With_Int_Body()
     {
@@ -77,9 +77,9 @@ public class DefaultJsonMessageSerializerTests
             .Add(serializedMessage)
             .MatchInline("{\"body\":\"abc\",\"kind\":0}");
     }
-    
+
     public enum Foo
     {
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Core/test/Subscriptions.Tests/SubscriptionIntegrationTestBase.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Tests/SubscriptionIntegrationTestBase.cs
@@ -298,7 +298,7 @@ public abstract class SubscriptionIntegrationTestBase
               }
             }");
     }
-    
+
     [Fact]
     public virtual async Task Subscribe_And_Complete_Topic()
     {
@@ -326,7 +326,7 @@ public abstract class SubscriptionIntegrationTestBase
             Assert.False(true, "Should not have any messages.");
         }
     }
-    
+
     [Fact]
     public virtual async Task Subscribe_And_Complete_Topic_With_ValueTypeMessage()
     {
@@ -402,7 +402,7 @@ public abstract class SubscriptionIntegrationTestBase
         [Subscribe]
         public string OnMessage2(string arg1, string arg2, [EventMessage] string message)
             => message;
-        
+
         [Topic("OnMessage3")]
         [Subscribe]
         public FooEnum OnMessage3([EventMessage] FooEnum message)
@@ -413,9 +413,9 @@ public abstract class SubscriptionIntegrationTestBase
     {
         public string? Bar { get; set; }
     }
-    
+
     public enum FooEnum
     {
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/CustomEnum.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/CustomEnum.cs
@@ -4,5 +4,5 @@ namespace HotChocolate.Types;
 public enum MyEnum
 {
     Abc,
-    Def
+    Def,
 }

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/CursorPagingQueryableExtensionsTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/CursorPagingQueryableExtensionsTests.cs
@@ -119,7 +119,7 @@ public class CursorPagingQueryableExtensionsTests
                 new() { Name = "Foo" },
                 new() { Name = "Bar" },
                 new() { Name = "Baz" },
-                new() { Name = "Qux" }
+                new() { Name = "Qux" },
             };
 
             return await list.AsQueryable().ApplyCursorPaginationAsync(
@@ -142,7 +142,7 @@ public class CursorPagingQueryableExtensionsTests
                 new() { Name = "Foo" },
                 new() { Name = "Bar" },
                 new() { Name = "Baz" },
-                new() { Name = "Qux" }
+                new() { Name = "Qux" },
             };
 
             return await list.ApplyCursorPaginationAsync(

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
@@ -966,7 +966,7 @@ public class IntegrationTests
                     options: new PagingOptions
                     {
                         MaxPageSize = 2,
-                        IncludeTotalCount = true
+                        IncludeTotalCount = true,
                     });
         }
     }
@@ -982,7 +982,7 @@ public class IntegrationTests
                     options: new PagingOptions
                     {
                         MaxPageSize = 2,
-                        IncludeTotalCount = true
+                        IncludeTotalCount = true,
                     });
         }
     }
@@ -1002,7 +1002,7 @@ public class IntegrationTests
             "i",
             "j",
             "k",
-            "l"
+            "l",
         };
 
         public List<List<Foo>> Foos() => new()
@@ -1011,7 +1011,7 @@ public class IntegrationTests
             new List<Foo> { new() { Bar = "b" }, new() { Bar = "c" } },
             new List<Foo> { new() { Bar = "d" } },
             new List<Foo> { new() { Bar = "e" } },
-            new List<Foo> { new() { Bar = "f" } }
+            new List<Foo> { new() { Bar = "f" } },
         };
     }
 
@@ -1025,7 +1025,7 @@ public class IntegrationTests
                 new() { Bar = "c" } ,
                 new() { Bar = "d" },
                 new() { Bar = "e" },
-                new() { Bar = "f" }
+                new() { Bar = "f" },
             }.AsQueryable());
     }
 
@@ -1050,7 +1050,7 @@ public class IntegrationTests
             "i",
             "j",
             "k",
-            "l"
+            "l",
         };
 
         [UsePaging(typeof(NonNullType<StringType>))]
@@ -1066,7 +1066,7 @@ public class IntegrationTests
             new List<Foo> { new() { Bar = "b" }, new() { Bar = "c" } },
             new List<Foo> { new() { Bar = "d" } },
             new List<Foo> { new() { Bar = "e" } },
-            new List<Foo> { new() { Bar = "f" } }
+            new List<Foo> { new() { Bar = "f" } },
         };
     }
 

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
@@ -332,7 +332,7 @@ public class QueryableCursorPagingProviderTests
             "d",
             "e",
             "f",
-            "g"
+            "g",
         });
 
         var pagingDetails = new CursorPagingArguments(2);
@@ -381,7 +381,7 @@ public class QueryableCursorPagingProviderTests
             "d",
             "e",
             "f",
-            "g"
+            "g",
         }.AsQueryable());
 
         var pagingDetails = new CursorPagingArguments(2);

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/UsePagingAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/UsePagingAttributeTests.cs
@@ -129,7 +129,7 @@ public class UsePagingAttributeTests
             new
             {
                 ex.Errors[0].Message,
-                ex.Errors[0].Code
+                ex.Errors[0].Code,
             }.MatchSnapshot();
         }
     }

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -372,7 +372,7 @@ public class AnnotationBasedMutations
                         InputTypeNamePattern = "{MutationName}In",
                         PayloadTypeNamePattern = "{MutationName}Out",
                         PayloadErrorTypeNamePattern = "{MutationName}Fault",
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -1359,7 +1359,7 @@ public class AnnotationBasedMutations
     {
         public User? DoSomething([ID("Foo")] Guid id)
         {
-            return new User { Name = "Foo", Id = id, };
+            return new User { Name = "Foo", Id = id };
         }
     }
 
@@ -1367,7 +1367,7 @@ public class AnnotationBasedMutations
     {
         public User? DoSomething([ID<Foo>] Guid id)
         {
-            return new User { Name = "Foo", Id = id, };
+            return new User { Name = "Foo", Id = id };
         }
     }
 

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/CodeFirstMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/CodeFirstMutations.cs
@@ -47,7 +47,7 @@ public class CodeFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .ExecuteRequestAsync("mutation { doSomething(input: { a: \"abc\" }) { string } }");

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/SchemaFirstMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/SchemaFirstMutations.cs
@@ -23,7 +23,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -46,7 +46,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -69,7 +69,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -93,7 +93,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -117,7 +117,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();
@@ -140,7 +140,7 @@ public class SchemaFirstMutations
                 .AddMutationConventions(
                     new MutationConventionOptions
                     {
-                        ApplyToAllMutations = true
+                        ApplyToAllMutations = true,
                     })
                 .ModifyOptions(o => o.StrictValidation = false)
                 .BuildSchemaAsync();

--- a/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.OffsetPagination.Tests/IntegrationTests.cs
@@ -563,7 +563,7 @@ namespace HotChocolate.Types.Pagination
                         .UseOffsetPaging(
                             options: new PagingOptions
                             {
-                                InferCollectionSegmentNameFromField = false
+                                InferCollectionSegmentNameFromField = false,
                             }))
                     .ModifyOptions(o =>
                     {
@@ -685,7 +685,7 @@ namespace HotChocolate.Types.Pagination
         {
             public string[] Letters => new[]
             {
-                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
             };
 
             public List<List<Foo>> Foos() => new()
@@ -694,7 +694,7 @@ namespace HotChocolate.Types.Pagination
                 new List<Foo> { new Foo { Bar = "b" }, new Foo { Bar = "c" } },
                 new List<Foo> { new Foo { Bar = "d" } },
                 new List<Foo> { new Foo { Bar = "e" } },
-                new List<Foo> { new Foo { Bar = "f" } }
+                new List<Foo> { new Foo { Bar = "f" } },
             };
         }
 
@@ -708,7 +708,7 @@ namespace HotChocolate.Types.Pagination
                     new Foo { Bar = "c" },
                     new Foo { Bar = "d" },
                     new Foo { Bar = "e" },
-                    new Foo { Bar = "f" }
+                    new Foo { Bar = "f" },
                 }.AsQueryable());
         }
 
@@ -734,7 +734,7 @@ namespace HotChocolate.Types.Pagination
             [UseOffsetPaging]
             public string[] Letters => new[]
             {
-                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
             };
 
             [UseOffsetPaging(typeof(NonNullType<StringType>))]
@@ -750,7 +750,7 @@ namespace HotChocolate.Types.Pagination
                 new List<Foo> { new Foo { Bar = "b" }, new Foo { Bar = "c" } },
                 new List<Foo> { new Foo { Bar = "d" } },
                 new List<Foo> { new Foo { Bar = "e" } },
-                new List<Foo> { new Foo { Bar = "f" } }
+                new List<Foo> { new Foo { Bar = "f" } },
             };
         }
 

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/ScalarTypeTestBase.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/ScalarTypeTestBase.cs
@@ -246,6 +246,6 @@ public class ScalarTypeTestBase
 
     public enum TestEnum
     {
-        Foo
+        Foo,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests.Documentation/EnumWithDocu.cs
+++ b/src/HotChocolate/Core/test/Types.Tests.Documentation/EnumWithDocu.cs
@@ -13,6 +13,6 @@ namespace HotChocolate.Types.Descriptors
         /// <summary>
         /// Value2 Documentation
         /// </summary>
-        Value2
+        Value2,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeDiscoveryTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeDiscoveryTests.cs
@@ -177,7 +177,7 @@ public class SchemaTypeDiscoveryTests
     public enum FooBar
     {
         Foo,
-        Bar
+        Bar,
     }
 
     public class ByteArrayType : ScalarType

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeResolverTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeResolverTests.cs
@@ -166,6 +166,6 @@ public class SchemaTypeResolverTests
     public enum Foo
     {
         Bar,
-        Baz
+        Baz,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeDiscovererTests.cs
@@ -26,7 +26,7 @@ public class TypeDiscovererTests
             typeLookup,
             new HashSet<TypeReference>
             {
-                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output)
+                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output),
             },
             new AggregateTypeInterceptor(),
             false);
@@ -46,12 +46,12 @@ public class TypeDiscovererTests
                     runtimeType = t.Type is IHasRuntimeType hr
                         ? hr.RuntimeType.GetTypeName()
                         : null,
-                    references = t.References.Select(r => r.ToString()).ToList()
+                    references = t.References.Select(r => r.ToString()).ToList(),
                 }).ToList(),
 
             runtimeTypeRefs = typeRegistry.RuntimeTypeRefs.ToDictionary(
                 t => t.Key.ToString(),
-                t => t.Value.ToString())
+                t => t.Value.ToString()),
 
         }.MatchSnapshot();
     }
@@ -70,7 +70,7 @@ public class TypeDiscovererTests
             typeLookup,
             new HashSet<TypeReference>
             {
-                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output)
+                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output),
             },
             new AggregateTypeInterceptor());
 
@@ -89,12 +89,12 @@ public class TypeDiscovererTests
                     runtimeType = t.Type is IHasRuntimeType hr
                         ? hr.RuntimeType.GetTypeName()
                         : null,
-                    references = t.References.Select(r => r.ToString()).ToList()
+                    references = t.References.Select(r => r.ToString()).ToList(),
                 }).ToList(),
 
             runtimeTypeRefs = typeRegistry.RuntimeTypeRefs.ToDictionary(
                 t => t.Key.ToString(),
-                t => t.Value.ToString())
+                t => t.Value.ToString()),
 
         }.MatchSnapshot();
     }
@@ -114,7 +114,7 @@ public class TypeDiscovererTests
             typeLookup,
             new HashSet<TypeReference>
             {
-                _typeInspector.GetTypeRef(typeof(Foo), TypeContext.Output)
+                _typeInspector.GetTypeRef(typeof(Foo), TypeContext.Output),
             },
             new AggregateTypeInterceptor());
 
@@ -133,12 +133,12 @@ public class TypeDiscovererTests
                     runtimeType = t.Type is IHasRuntimeType hr
                         ? hr.RuntimeType.GetTypeName()
                         : null,
-                    references = t.References.Select(r => r.ToString()).ToList()
+                    references = t.References.Select(r => r.ToString()).ToList(),
                 }).ToList(),
 
             runtimeTypeRefs = typeRegistry.RuntimeTypeRefs.ToDictionary(
                 t => t.Key.ToString(),
-                t => t.Value.ToString())
+                t => t.Value.ToString()),
 
         }.MatchSnapshot();
     }
@@ -159,7 +159,7 @@ public class TypeDiscovererTests
             new HashSet<TypeReference>
             {
                 _typeInspector.GetTypeRef(typeof(ObjectType<Foo>), TypeContext.Output),
-                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output)
+                _typeInspector.GetTypeRef(typeof(FooType), TypeContext.Output),
             },
             new AggregateTypeInterceptor());
 
@@ -178,12 +178,12 @@ public class TypeDiscovererTests
                     runtimeType = t.Type is IHasRuntimeType hr
                         ? hr.RuntimeType.GetTypeName()
                         : null,
-                    references = t.References.Select(r => r.ToString()).ToList()
+                    references = t.References.Select(r => r.ToString()).ToList(),
                 }).ToList(),
 
             runtimeTypeRefs = typeRegistry.RuntimeTypeRefs.ToDictionary(
                 t => t.Key.ToString(),
-                t => t.Value.ToString())
+                t => t.Value.ToString()),
 
         }.MatchSnapshot();
     }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeInitializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/TypeInitializerTests.cs
@@ -26,7 +26,7 @@ public class TypeInitializerTests
             typeRegistry,
             new List<TypeReference>
             {
-                context.TypeInspector.GetTypeRef(typeof(FooType), TypeContext.Output)
+                context.TypeInspector.GetTypeRef(typeof(FooType), TypeContext.Output),
             },
             null,
             t => t is FooType ? RootTypeKind.Query : RootTypeKind.None,
@@ -74,7 +74,7 @@ public class TypeInitializerTests
             typeRegistry,
             new List<TypeReference>
             {
-                context.TypeInspector.GetTypeRef(typeof(Foo), TypeContext.Output)
+                context.TypeInspector.GetTypeRef(typeof(Foo), TypeContext.Output),
             },
             null,
             t =>
@@ -82,7 +82,7 @@ public class TypeInitializerTests
                 return t switch
                 {
                     ObjectType<Foo> => RootTypeKind.Query,
-                    _ => RootTypeKind.None
+                    _ => RootTypeKind.None,
                 };
             },
             new SchemaOptions());
@@ -130,7 +130,7 @@ public class TypeInitializerTests
             typeRegistry,
             new List<TypeReference>
             {
-                context.TypeInspector.GetTypeRef(typeof(Foo), TypeContext.Output)
+                context.TypeInspector.GetTypeRef(typeof(Foo), TypeContext.Output),
             },
             null!,
             t =>
@@ -138,7 +138,7 @@ public class TypeInitializerTests
                 return t switch
                 {
                     ObjectType<Foo> => RootTypeKind.Query,
-                    _ => RootTypeKind.None
+                    _ => RootTypeKind.None,
                 };
             },
             null!);

--- a/src/HotChocolate/Core/test/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Extensions/SchemaBuilderExtensions.Types.Tests.cs
@@ -1161,6 +1161,6 @@ public class SchemaBuilderExtensionsTypeTests
     public enum MyEnum
     {
         A,
-        B
+        B,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Regressions/Issue_4811.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Regressions/Issue_4811.cs
@@ -26,31 +26,31 @@ public class Issue_4811
               query: Query
               mutation: Mutation
             }
-            
+
             type ADDBookResponse {
               title: String!
             }
-            
+
             type Book {
               title: String!
             }
-            
+
             type Mutation {
               addBook(input: CreateCnaeInput!): ADDBookResponse!
             }
-            
+
             type Query {
               book: Book!
             }
-            
+
             input CNAEMutationInput {
               title: String!
             }
-            
+
             input CreateCnaeInput {
               cnae: CNAEMutationInput!
             }
-            
+
             "The @tag directive is used to apply arbitrary string\nmetadata to a schema location. Custom tooling can use\nthis metadata during any step of the schema delivery flow,\nincluding composition, static analysis, and documentation.\n            \n\ninterface Book {\n  id: ID! @tag(name: \"your-value\")\n  title: String!\n  author: String!\n}"
             directive @tag("The name of the tag." name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             """);
@@ -66,7 +66,7 @@ public class Issue_4811
         public Book GetBook() =>
             new Book
             {
-                Title = "C# in depth."
+                Title = "C# in depth.",
             };
     }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Regressions/NestedOptionalInt_2114.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Regressions/NestedOptionalInt_2114.cs
@@ -75,7 +75,7 @@ public class NestedOptionalInt_2114
                             "complexAssigned",
                             new Dictionary<string, object?>
                             {
-                                { "value", 3 }
+                                { "value", 3 },
                             }
                         },
                         { "complexAssignedNull", null} ,
@@ -83,11 +83,11 @@ public class NestedOptionalInt_2114
                             "complexList",
                             new List<Dictionary<string, object?>>
                             {
-                                new() { { "value", 2 } }
+                                new() { { "value", 2 } },
                             }
-                        }
+                        },
                     }
-                }
+                },
             });
 
         // assert

--- a/src/HotChocolate/Core/test/Types.Tests/ResolverContextStateExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/ResolverContextStateExtensionTests.cs
@@ -26,7 +26,7 @@ public class ResolverContextStateExtensionTests
         var user = new ClaimsPrincipal(
             new ClaimsIdentity(new[]
             {
-                new Claim(ClaimTypes.Name, "abc")
+                new Claim(ClaimTypes.Name, "abc"),
             }));
 
         await new ServiceCollection()
@@ -168,7 +168,7 @@ public class ResolverContextStateExtensionTests
     {
         var dict = new Dictionary<string, object?>
         {
-            {"key", "value"}
+            {"key", "value"},
         };
 
         var mock = new Mock<IResolverContext>();
@@ -187,7 +187,7 @@ public class ResolverContextStateExtensionTests
     {
         var dict = new Dictionary<string, object?>
         {
-            {"key", 2}
+            {"key", 2},
         };
 
         var mock = new Mock<IResolverContext>();
@@ -237,7 +237,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            { "key", "value" }
+            { "key", "value" },
         }.ToImmutableDictionary();
 
         var state = context.GetScopedStateOrDefault<int>("key");
@@ -254,7 +254,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            { "key", "value" }
+            { "key", "value" },
         }.ToImmutableDictionary();
 
         Assert.Throws<ArgumentException>(() =>
@@ -270,7 +270,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            { "key", 1 }
+            { "key", 1 },
         }.ToImmutableDictionary();
 
         var state = context.GetScopedStateOrDefault<int>("key");
@@ -287,7 +287,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            { "key", 1 }
+            { "key", 1 },
         }.ToImmutableDictionary();
 
         var state = context.GetScopedState<int>("key");
@@ -333,7 +333,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            {"key", "value"}
+            {"key", "value"},
         }.ToImmutableDictionary();
 
         var state = context.GetOrSetScopedState<int>("key", key => 1);
@@ -351,7 +351,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.ScopedContextData = new Dictionary<string, object?>
         {
-            {"key", 2}
+            {"key", 2},
         }.ToImmutableDictionary();
 
         var state = context.GetOrSetScopedState<int>("key", key => 1);
@@ -428,7 +428,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", "value" }
+            { "key", "value" },
         }.ToImmutableDictionary();
 
         var state = context.GetLocalStateOrDefault<int>("key");
@@ -445,7 +445,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", "value" }
+            { "key", "value" },
         }.ToImmutableDictionary();
 
         Assert.Throws<ArgumentException>(() =>
@@ -461,7 +461,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", 1 }
+            { "key", 1 },
         }.ToImmutableDictionary();
 
         var state = context.GetLocalStateOrDefault<int>("key");
@@ -478,7 +478,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", 1 }
+            { "key", 1 },
         }.ToImmutableDictionary();
 
         var state = context.GetLocalState<int>("key");
@@ -524,7 +524,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", "value" }
+            { "key", "value" },
         }.ToImmutableDictionary();
 
         var state = context.GetOrSetLocalState<int>("key", key => 1);
@@ -542,7 +542,7 @@ public class ResolverContextStateExtensionTests
         var context = mock.Object;
         context.LocalContextData = new Dictionary<string, object?>
         {
-            { "key", 2 }
+            { "key", 2 },
         }.ToImmutableDictionary();
 
         var state = context.GetOrSetLocalState<int>("key", key => 1);

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/ResolverCompilerTests.cs
@@ -1221,7 +1221,7 @@ public class ResolverCompilerTests
 
         var contextData = new Dictionary<string, object?>
         {
-            { nameof(ClaimsPrincipal), new ClaimsPrincipal() }
+            { nameof(ClaimsPrincipal), new ClaimsPrincipal() },
         };
 
         // act

--- a/src/HotChocolate/Core/test/Types.Tests/SchemaFirstTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/SchemaFirstTests.cs
@@ -635,12 +635,12 @@ public class QueryEnumExample
 
 public enum TestEnum
 {
-    FooBar
+    FooBar,
 }
 
 public enum TestEnumInput
 {
-    FooBarInput
+    FooBarInput,
 }
 
 public class QueryWithFooInput

--- a/src/HotChocolate/Core/test/Types.Tests/Types/BindingBehaviorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/BindingBehaviorTests.cs
@@ -23,22 +23,22 @@ public class BindingBehaviorTests
             schema {
               query: Query
             }
-            
+
             type Book1 {
               title: String
               category: BookCategory1!
             }
-            
+
             type Query {
               books: Book1
             }
-            
+
             enum BookCategory1 {
               A
               B
               C
             }
-            
+
             "The @tag directive is used to apply arbitrary string\nmetadata to a schema location. Custom tooling can use\nthis metadata during any step of the schema delivery flow,\nincluding composition, static analysis, and documentation.\n            \n\ninterface Book {\n  id: ID! @tag(name: \"your-value\")\n  title: String!\n  author: String!\n}"
             directive @tag("The name of the tag." name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             """);
@@ -58,7 +58,7 @@ public class BindingBehaviorTests
     {
         A,
         B,
-        C
+        C,
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class BindingBehaviorTests
     {
         A,
         B,
-        C
+        C,
     }
 
     [Fact]
@@ -116,20 +116,20 @@ public class BindingBehaviorTests
             schema {
               query: Query
             }
-            
+
             type Book3 {
               title: String
               category: BookCategory3!
             }
-            
+
             type Query {
               books: Book3
             }
-            
+
             enum BookCategory3 {
               A
             }
-            
+
             "The @tag directive is used to apply arbitrary string\nmetadata to a schema location. Custom tooling can use\nthis metadata during any step of the schema delivery flow,\nincluding composition, static analysis, and documentation.\n            \n\ninterface Book {\n  id: ID! @tag(name: \"your-value\")\n  title: String!\n  author: String!\n}"
             directive @tag("The name of the tag." name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             """);
@@ -148,7 +148,7 @@ public class BindingBehaviorTests
     {
         A,
         B,
-        C
+        C,
     }
 
     public class BookCategory3Type : EnumType<BookCategory3>

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultNamingConventionsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultNamingConventionsTests.cs
@@ -135,7 +135,7 @@ public class DefaultNamingConventionsTests
     {
         Bar,
 
-        [GraphQLDescription("Baz Desc")] Baz
+        [GraphQLDescription("Baz Desc")] Baz,
     }
 
     private sealed class MyInputType : InputObjectType

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/DefaultTypeInspectorTests.cs
@@ -763,7 +763,7 @@ public class DefaultTypeInspectorTests
     public enum BarEnum
     {
         Bar,
-        Baz
+        Baz,
     }
 
     public class DoNotInfer

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/DescriptorContextTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/DescriptorContextTests.cs
@@ -51,7 +51,7 @@ public class DescriptorContextTests
         {
             {
                 (typeof(INamingConventions), null), new List<CreateConvention>{_ => naming}
-            }
+            },
         };
 
         // act

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/EnumTypeDescriptorTests.cs
@@ -158,6 +158,6 @@ public class EnumTypeDescriptorTests : DescriptorTestBase
     private enum FooEnum
     {
         Bar1,
-        Bar2
+        Bar2,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveLocationTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveLocationTests.cs
@@ -16,7 +16,7 @@ public class DirectiveLocationTests
             (int)DirectiveLocation.Executable,
             (int)DirectiveLocation.TypeSystem,
             (int)DirectiveLocation.Operation,
-            (int)DirectiveLocation.Fragment
+            (int)DirectiveLocation.Fragment,
         };
 
         Enum.GetValues(typeof(DirectiveLocation))

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/TagDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/TagDirectiveTests.cs
@@ -18,7 +18,7 @@ public class TagDirectiveTests
                 .AddType<FooDirective>()
                 .SetSchema(d => d.Tag("OnSchema"))
                 .BuildSchemaAsync();
-        
+
         schema.MatchSnapshot();
     }
 
@@ -27,10 +27,10 @@ public class TagDirectiveTests
     {
         [Tag("OnObjectField")]
         public IFoo GetFoo([Tag("OnObjectFieldArg")] string a) => new Foo();
-        
+
         public FooEnum GetFooEnum(FooInput input) => FooEnum.Foo;
     }
-    
+
     [Tag("OnInterface")]
     public interface IFoo
     {
@@ -42,15 +42,15 @@ public class TagDirectiveTests
     {
         public string Bar(string baz) => "Bar" + baz;
     }
-    
+
     [Tag("OnEnum")]
     public enum FooEnum
     {
         [Tag("OnEnumValue")]
         Foo,
-        Bar
+        Bar,
     }
-    
+
     [Tag("OnInputObjectType")]
     public class FooInput
     {

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumFlagsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumFlagsTests.cs
@@ -61,23 +61,23 @@ public class EnumFlagsTests
             schema {
               query: Query
             }
-            
+
             type FooBarBazFlags {
               isFoo: Boolean!
               isBar: Boolean!
               isBaz: Boolean!
             }
-            
+
             type Query {
               foo(input: FooBarBazFlagsInput!): FooBarBazFlags!
             }
-            
+
             input FooBarBazFlagsInput {
               isFoo: Boolean
               isBar: Boolean
               isBaz: Boolean
             }
-            
+
             "The @tag directive is used to apply arbitrary string\nmetadata to a schema location. Custom tooling can use\nthis metadata during any step of the schema delivery flow,\nincluding composition, static analysis, and documentation.\n            \n\ninterface Book {\n  id: ID! @tag(name: \"your-value\")\n  title: String!\n  author: String!\n}"
             directive @tag("The name of the tag." name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             """);
@@ -94,6 +94,6 @@ public class EnumFlagsTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeDescriptorAttributeTests.cs
@@ -53,7 +53,7 @@ public class EnumTypeDescriptorAttributeTests
 
         [RenameValue]
         Value1,
-        Value2
+        Value2,
     }
 
     public class RenameValueAttribute
@@ -73,7 +73,7 @@ public class EnumTypeDescriptorAttributeTests
     {
 
         Value1,
-        Value2
+        Value2,
     }
 
     [EnumType(Name = "Foo")]
@@ -81,7 +81,7 @@ public class EnumTypeDescriptorAttributeTests
     {
 
         Value1,
-        Value2
+        Value2,
     }
 
     public class RenameTypeAttribute

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeExtensionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeExtensionTests.cs
@@ -178,7 +178,7 @@ public class EnumTypeExtensionTests
     {
         Bar,
         Baz,
-        Quox
+        Quox,
     }
 
     public class DummyDirective

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
@@ -662,7 +662,7 @@ public class EnumTypeTests : TypeTestBase
     public enum Foo
     {
         Bar1,
-        Bar2
+        Bar2,
     }
 
     public class Bar;
@@ -672,14 +672,14 @@ public class EnumTypeTests : TypeTestBase
         Bar1,
 
         [Obsolete]
-        Bar2
+        Bar2,
     }
 
     public enum FooIgnore
     {
         Bar1,
         [GraphQLIgnore]
-        Bar2
+        Bar2,
     }
 
     public class FooIgnoredType : EnumType<Foo>
@@ -702,7 +702,7 @@ public class EnumTypeTests : TypeTestBase
     {
         Bar1,
         [GraphQLDeprecated("Baz.")]
-        Bar2
+        Bar2,
     }
 
     [GraphQLName("Foo")]
@@ -710,12 +710,12 @@ public class EnumTypeTests : TypeTestBase
     {
         Bar1,
         [GraphQLName("BAR_2")]
-        Bar2
+        Bar2,
     }
 
     public enum FooUnderline
     {
-        Creating_Instance = 1
+        Creating_Instance = 1,
     }
 
     public class SomeQueryType : ObjectType
@@ -742,7 +742,7 @@ public class EnumTypeTests : TypeTestBase
     public enum DescriptionTestEnum
     {
         Foo,
-        Bar
+        Bar,
     }
 
     public class ValueComparer : IEqualityComparer<object>

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeUnsafeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeUnsafeTests.cs
@@ -21,8 +21,8 @@ public class EnumTypeUnsafeTests
                 Values =
                 {
                     new("ONE", runtimeValue: "One"),
-                    new("TWO", runtimeValue: "Two")
-                }
+                    new("TWO", runtimeValue: "Two"),
+                },
             });
 
         var queryType = ObjectType.CreateUnsafe(
@@ -30,8 +30,8 @@ public class EnumTypeUnsafeTests
             {
                 Fields =
                 {
-                    new("foo", type: TypeReference.Create(enumType), pureResolver: _ => "One")
-                }
+                    new("foo", type: TypeReference.Create(enumType), pureResolver: _ => "One"),
+                },
             });
 
         // assert
@@ -53,8 +53,8 @@ public class EnumTypeUnsafeTests
                 Values =
                 {
                     new("ONE", runtimeValue: "One"),
-                    new("TWO", runtimeValue: "Two")
-                }
+                    new("TWO", runtimeValue: "Two"),
+                },
             });
 
         var queryType = ObjectType.CreateUnsafe(
@@ -62,8 +62,8 @@ public class EnumTypeUnsafeTests
             {
                 Fields =
                 {
-                    new("foo", type: TypeReference.Create(enumType), pureResolver: _ => "One")
-                }
+                    new("foo", type: TypeReference.Create(enumType), pureResolver: _ => "One"),
+                },
             });
 
         // assert

--- a/src/HotChocolate/Core/test/Types.Tests/Types/InputObjectTypeAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/InputObjectTypeAttributeTests.cs
@@ -187,6 +187,6 @@ public class InputObjectTypeAttributeTests
     public enum Quux
     {
         Corge,
-        Grault
+        Grault,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/InputObjectTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/InputObjectTypeTests.cs
@@ -895,7 +895,7 @@ public class InputObjectTypeTests : TypeTestBase
             {
                 IsBarSet = input.Bar.HasValue,
                 Bar = input.Bar,
-                Baz = input.Baz
+                Baz = input.Baz,
             };
         }
     }
@@ -982,6 +982,6 @@ public class InputObjectTypeTests : TypeTestBase
     public enum FooEnum
     {
         Bar,
-        Baz
+        Baz,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/InputParserTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/InputParserTests.cs
@@ -28,7 +28,7 @@ public class InputParserTests
         var fieldData = new Dictionary<string, object?>
         {
             { "field1", "abc" },
-            { "field2", 123 }
+            { "field2", 123 },
         };
 
         // act
@@ -76,7 +76,7 @@ public class InputParserTests
         var fieldData = new Dictionary<string, object?>
         {
             { "field1", "abc" },
-            { "field2", 123 }
+            { "field2", 123 },
         };
 
         // act
@@ -123,7 +123,7 @@ public class InputParserTests
 
         var fieldData = new Dictionary<string, object?>
         {
-            { "field2", 123 }
+            { "field2", 123 },
         };
 
         // act
@@ -170,7 +170,7 @@ public class InputParserTests
         var fieldData = new Dictionary<string, object?>
         {
             { "field2", 123 },
-            { "field3", 123 }
+            { "field3", 123 },
         };
 
         // act
@@ -223,7 +223,7 @@ public class InputParserTests
         {
             { "field2", 123 },
             { "field3", 123 },
-            { "field4", 123 }
+            { "field4", 123 },
         };
 
         // act
@@ -283,7 +283,7 @@ public class InputParserTests
 
         var options = new InputParserOptions
         {
-            IgnoreAdditionalInputFields = true
+            IgnoreAdditionalInputFields = true,
         };
 
         // act
@@ -485,7 +485,7 @@ public class InputParserTests
 
         var fieldData = new Dictionary<string, object?>
         {
-            { "field1", "abc" }
+            { "field1", "abc" },
         };
 
         // act
@@ -548,7 +548,7 @@ public class InputParserTests
 
     public enum Bar
     {
-        Baz
+        Baz,
     }
 
     [OneOf]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Interceptors/FlagEnumInterceptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Interceptors/FlagEnumInterceptorTests.cs
@@ -455,7 +455,7 @@ public class FlagEnumInterceptorTests
     {
         [GraphQLDescription("Foo has a desc")] Foo = 1,
         [GraphQLDescription("Bar has a desc")] Bar = 2,
-        [GraphQLDescription("Baz has a desc")] Baz = 3
+        [GraphQLDescription("Baz has a desc")] Baz = 3,
     }
 
     [InterfaceType()]
@@ -504,7 +504,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -512,7 +512,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 0x1,
         Bar = 0x2,
-        Baz = 0x4
+        Baz = 0x4,
     }
 
     [Flags]
@@ -520,7 +520,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 0x1,
         Bar = 0x2,
-        Baz = 0x4
+        Baz = 0x4,
     }
 
     [Flags]
@@ -528,7 +528,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -536,7 +536,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -544,7 +544,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -552,7 +552,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -560,7 +560,7 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 
     [Flags]
@@ -568,6 +568,6 @@ public class FlagEnumInterceptorTests
     {
         Foo = 1,
         Bar = 2,
-        Baz = 4
+        Baz = 4,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/PaginationTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/PaginationTests.cs
@@ -109,7 +109,7 @@ public class PaginationTests
                 .Resolve(() => new[]
                 {
                     new User { FirstName = "Mother" },
-                    new User { FirstName = "Father" }
+                    new User { FirstName = "Father" },
                 });
 
             descriptor
@@ -117,7 +117,7 @@ public class PaginationTests
                 .UseOffsetPaging<GroupType>()
                 .Resolve(() => new[]
                 {
-                    new Group { FirstName = "Admin" }
+                    new Group { FirstName = "Admin" },
                 });
         }
     }
@@ -132,7 +132,7 @@ public class PaginationTests
                 .Resolve(() => new[]
                 {
                     new User { FirstName = "Mother" },
-                    new User { FirstName = "Father" }
+                    new User { FirstName = "Father" },
                 });
         }
     }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdAttributeTests.cs
@@ -139,7 +139,7 @@ public class IdAttributeTests
         {
             result = result.ToJson(),
             someId,
-            someIntId
+            someIntId,
         }.MatchSnapshot();
     }
 
@@ -190,7 +190,7 @@ public class IdAttributeTests
         {
             result = result.ToJson(),
             someId,
-            someIntId
+            someIntId,
         }.MatchSnapshot();
     }
 
@@ -268,7 +268,7 @@ public class IdAttributeTests
         new
         {
             result = result.ToJson(),
-            someId
+            someId,
         }.MatchSnapshot();
     }
 
@@ -304,7 +304,7 @@ public class IdAttributeTests
         new
         {
             result = result.ToJson(),
-            someId
+            someId,
         }.MatchSnapshot();
     }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdDescriptorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/IdDescriptorTests.cs
@@ -72,7 +72,7 @@ public class IdDescriptorTests
         new
         {
             result = result.ToJson(),
-            someId
+            someId,
         }.MatchSnapshot();
     }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Types/SDL/EnumTypeSchemaFirstTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/SDL/EnumTypeSchemaFirstTests.cs
@@ -205,6 +205,6 @@ public class EnumTypeSchemaFirstTests
     public enum Greetings
     {
         GoodMorning,
-        GoodEvening
+        GoodEvening,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/AnyTypeTests.cs
@@ -419,8 +419,8 @@ public class AnyTypeTests
                 {
                     new Dictionary<string, object>
                     {
-                        { "abc", "def" }
-                    }
+                        { "abc", "def" },
+                    },
                 })
                 .Create());
 
@@ -1036,7 +1036,7 @@ public class AnyTypeTests
 
         var toDeserialize = new Dictionary<string, object>
         {
-            {"Foo", new StringValueNode("Bar")}
+            {"Foo", new StringValueNode("Bar")},
         };
 
         // act
@@ -1063,7 +1063,7 @@ public class AnyTypeTests
 
         var toDeserialize = new Dictionary<string, object>
         {
-            {"Foo",new Dictionary<string, object>{{"Bar",new StringValueNode("Baz")}}}
+            {"Foo",new Dictionary<string, object>{{"Bar",new StringValueNode("Baz")}}},
         };
 
         // act
@@ -1120,7 +1120,7 @@ public class AnyTypeTests
                 configure: c => c.AddQueryType<SomeQuery>())
             .MatchSnapshotAsync();
     }
-    
+
     [Fact]
     public async Task UseImmutableDictWithAny()
     {
@@ -1140,7 +1140,7 @@ public class AnyTypeTests
             obj.a = "Foo";
             return obj;
         }
-        
+
         [GraphQLType<AnyType>]
         public ImmutableDictionary<string, object> GetSomethingImmutable()
         {

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/ScalarsTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/ScalarsTests.cs
@@ -143,6 +143,6 @@ public class ScalarsTests
 
     public enum Foo
     {
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/TypeFactoryTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/TypeFactoryTests.cs
@@ -19,7 +19,7 @@ public class TypeFactoryTests : TypeTestBase
 
         var resolvers = new
         {
-            Simple = new { A = "hello", B = new[] { "hello" } }
+            Simple = new { A = "hello", B = new[] { "hello" } },
         };
 
         // act

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/BaseTypesTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/BaseTypesTests.cs
@@ -64,6 +64,6 @@ public class BaseTypesTests
 
     public enum FooEnum
     {
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/DictionaryToObjectConverterTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/DictionaryToObjectConverterTests.cs
@@ -115,6 +115,6 @@ public class DictionaryToObjectConverterTests
     public enum State
     {
         On,
-        Off
+        Off,
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/InputObjectToDictionaryConverterTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/InputObjectToDictionaryConverterTests.cs
@@ -24,7 +24,7 @@ public class InputObjectToDictionaryConverterTests
         var foo = new Foo
         {
             Bar = bar1,
-            Bars = new List<Bar> { bar2, bar3 }
+            Bars = new List<Bar> { bar2, bar3 },
         };
 
         // act
@@ -52,7 +52,7 @@ public class InputObjectToDictionaryConverterTests
         var foo = new Foo
         {
             Bar = null,
-            Bars = new List<Bar> { bar2, bar3 }
+            Bars = new List<Bar> { bar2, bar3 },
         };
 
         // act
@@ -80,7 +80,7 @@ public class InputObjectToDictionaryConverterTests
         var foo = new Foo
         {
             Bar = bar1,
-            Bars = new List<Bar> { bar2, null }
+            Bars = new List<Bar> { bar2, null },
         };
 
         // act
@@ -109,7 +109,7 @@ public class InputObjectToDictionaryConverterTests
     public enum Baz
     {
         Foo,
-        Bar
+        Bar,
     }
 
     public class DummyQuery

--- a/src/HotChocolate/Core/test/Types.Tests/Utilities/TypeConversionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Utilities/TypeConversionTests.cs
@@ -476,6 +476,6 @@ public class TypeConverterTests
     public enum FooOrBar
     {
         Foo,
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Core/test/Utilities/SubscriptionTestDiagnostics.cs
+++ b/src/HotChocolate/Core/test/Utilities/SubscriptionTestDiagnostics.cs
@@ -12,7 +12,7 @@ public sealed class SubscriptionTestDiagnostics : SubscriptionDiagnosticEventsLi
 
     private readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
     public SubscriptionTestDiagnostics(ITestOutputHelper output)

--- a/src/HotChocolate/Core/test/Utilities/TestHelper.cs
+++ b/src/HotChocolate/Core/test/Utilities/TestHelper.cs
@@ -74,7 +74,7 @@ public static class TestHelper
             query,
             new TestConfiguration
             {
-                Configure = configure, ConfigureRequest = request, Services = requestServices
+                Configure = configure, ConfigureRequest = request, Services = requestServices,
             },
             elementInspectors);
     }
@@ -148,7 +148,7 @@ public static class TestHelper
         Action<IRequestExecutorBuilder>? configure = null,
         ITestOutputHelper? output = null)
     {
-        var configuration = new TestConfiguration { Configure = configure, };
+        var configuration = new TestConfiguration { Configure = configure };
 
         return await CreateExecutorAsync(configuration, output);
     }

--- a/src/HotChocolate/Core/test/Validation.Tests/DocumentValidatorTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/DocumentValidatorTests.cs
@@ -727,7 +727,7 @@ public class DocumentValidatorTests
                 new List<ISelectionNode>
                 {
                     originalOperation.SelectionSet.Selections[0],
-                    originalOperation.SelectionSet.Selections[0]
+                    originalOperation.SelectionSet.Selections[0],
                 }));
 
         document = document.WithDefinitions(

--- a/src/HotChocolate/Core/test/Validation.Tests/IntrospectionRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/IntrospectionRuleTests.cs
@@ -32,7 +32,7 @@ public class IntrospectionRuleTests
                 }",
             new KeyValuePair<string, object>[]
             {
-                new(WellKnownContextData.IntrospectionMessage, new Func<string>(() => "Bar"))
+                new(WellKnownContextData.IntrospectionMessage, new Func<string>(() => "Bar")),
             });
     }
 
@@ -48,7 +48,7 @@ public class IntrospectionRuleTests
                 }",
             new KeyValuePair<string, object>[]
             {
-                new(WellKnownContextData.IntrospectionMessage, "Baz")
+                new(WellKnownContextData.IntrospectionMessage, "Baz"),
             });
     }
 
@@ -89,7 +89,7 @@ public class IntrospectionRuleTests
             }",
             new KeyValuePair<string, object>[]
             {
-                new(WellKnownContextData.IntrospectionAllowed, null)
+                new(WellKnownContextData.IntrospectionAllowed, null),
             });
     }
 
@@ -105,7 +105,7 @@ public class IntrospectionRuleTests
                 }",
             new KeyValuePair<string, object>[]
             {
-                new(WellKnownContextData.IntrospectionAllowed, null)
+                new(WellKnownContextData.IntrospectionAllowed, null),
             });
     }
 

--- a/src/HotChocolate/Core/test/Validation.Tests/Models/CatCommand.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Models/CatCommand.cs
@@ -2,5 +2,5 @@
 
 public enum CatCommand
 {
-    JUMP
+    JUMP,
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/Models/DogCommand.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/Models/DogCommand.cs
@@ -4,5 +4,5 @@ public enum DogCommand
 {
     Sit,
     Down,
-    Heel
+    Heel,
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/ValidationUtils.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ValidationUtils.cs
@@ -15,7 +15,7 @@ public static class ValidationUtils
         => new()
         {
             Schema = schema ?? CreateSchema(),
-            ContextData = new Dictionary<string, object?>()
+            ContextData = new Dictionary<string, object?>(),
         };
 
     public static void Prepare(this IDocumentValidatorContext context, DocumentNode document)

--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableDefaultFieldHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableDefaultFieldHandler.cs
@@ -94,7 +94,7 @@ public class QueryableDefaultFieldHandler
 
                 null => throw ThrowHelper.QueryableFiltering_NoMemberDeclared(field),
 
-                _ => throw ThrowHelper.QueryableFiltering_MemberInvalid(field.Member, field)
+                _ => throw ThrowHelper.QueryableFiltering_MemberInvalid(field.Member, field),
             };
         }
 

--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableCombinator.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableCombinator.cs
@@ -28,7 +28,7 @@ public class QueryableCombinator
                 FilterCombinator.And => Expression.AndAlso(combined, operations.Dequeue()),
                 FilterCombinator.Or => Expression.OrElse(combined, operations.Dequeue()),
                 _ => throw ThrowHelper
-                    .Filtering_QueryableCombinator_InvalidCombinator(this, combinator)
+                    .Filtering_QueryableCombinator_InvalidCombinator(this, combinator),
             };
         }
 

--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/QueryableFilterProvider.cs
@@ -188,7 +188,7 @@ public class QueryableFilterProvider : FilterProvider<QueryableFilterContext>
             IQueryable<TEntityType> q => q.Where(where),
             IEnumerable<TEntityType> q => q.AsQueryable().Where(where),
             QueryableExecutable<TEntityType> q => q.WithSource(q.Source.Where(where)),
-            _ => input
+            _ => input,
         };
 
     private ApplyFiltering CreateApplicator<TEntityType>(string argumentName)

--- a/src/HotChocolate/Data/src/Data/Filters/Extensions/FilterObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Extensions/FilterObjectFieldDescriptorExtensions.cs
@@ -172,7 +172,7 @@ public static class FilterObjectFieldDescriptorExtensions
                     var argumentDefinition = new ArgumentDefinition
                     {
                         Name = argumentPlaceholder,
-                        Type = argumentTypeReference
+                        Type = argumentTypeReference,
                     };
 
                     definition.Arguments.Add(argumentDefinition);
@@ -220,7 +220,7 @@ public static class FilterObjectFieldDescriptorExtensions
         var middleware = (FieldMiddleware)factory.Invoke(null,
             new object[]
             {
-                    convention
+                    convention,
             })!;
         var index = definition.MiddlewareDefinitions.IndexOf(placeholder);
         definition.MiddlewareDefinitions[index] =

--- a/src/HotChocolate/Data/src/Data/Filters/Visitor/FilterCombinator.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Visitor/FilterCombinator.cs
@@ -6,5 +6,5 @@ namespace HotChocolate.Data.Filters;
 public enum FilterCombinator
 {
     And,
-    Or
+    Or,
 }

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/Extensions/ExpressionExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/Extensions/ExpressionExtensions.cs
@@ -14,7 +14,7 @@ internal static class ExpressionExtensions
             PropertyInfo propertyInfo => Expression.Property(expression, propertyInfo),
             MethodInfo methodInfo => Expression.Call(expression, methodInfo),
             { } info => throw ThrowHelper.ProjectionVisitor_MemberInvalid(info),
-            null => throw ThrowHelper.ProjectionVisitor_NoMemberFound()
+            null => throw ThrowHelper.ProjectionVisitor_NoMemberFound(),
         };
 
     public static Type GetReturnType(
@@ -24,6 +24,6 @@ internal static class ExpressionExtensions
             PropertyInfo propertyInfo => propertyInfo.PropertyType,
             MethodInfo methodInfo => methodInfo.ReturnType,
             { } info => throw ThrowHelper.ProjectionVisitor_MemberInvalid(info),
-            null => throw ThrowHelper.ProjectionVisitor_NoMemberFound()
+            null => throw ThrowHelper.ProjectionVisitor_NoMemberFound(),
         };
 }

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionProvider.cs
@@ -101,7 +101,7 @@ public class QueryableProjectionProvider : ProjectionProvider
             IQueryable<TEntityType> q => q.Select(projection),
             IEnumerable<TEntityType> q => q.AsQueryable().Select(projection),
             QueryableExecutable<TEntityType> q => q.WithSource(q.Source.Select(projection)),
-            _ => input
+            _ => input,
         };
 
     private ApplyProjection CreateApplicator<TEntityType>()

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
@@ -79,7 +79,7 @@ public static class QueryableProjectionScopeExtensions
             new[]
             {
                 scope.RuntimeType,
-                scope.RuntimeType
+                scope.RuntimeType,
             },
             source,
             scope.CreateMemberInitLambda());
@@ -104,7 +104,7 @@ public static class QueryableProjectionScopeExtensions
             nameof(Enumerable.ToArray),
             new[]
             {
-                scope.RuntimeType
+                scope.RuntimeType,
             },
             source);
     }
@@ -116,7 +116,7 @@ public static class QueryableProjectionScopeExtensions
             nameof(Enumerable.ToList),
             new[]
             {
-                scope.RuntimeType
+                scope.RuntimeType,
             },
             source);
     }
@@ -131,7 +131,7 @@ public static class QueryableProjectionScopeExtensions
         var ctor =
             typedGeneric.GetConstructor(new[]
             {
-                source.Type
+                source.Type,
             });
 
         if (ctor is null)

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/TypeExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/TypeExtensions.cs
@@ -14,6 +14,6 @@ public static class TypeExtensions
             IEdgeType t => t.NodeType.UnwrapRuntimeType(),
             NonNullType t => t.InnerType().UnwrapRuntimeType(),
             INamedType t => t.ToRuntimeType(),
-            _ => throw ThrowHelper.ProjectionVisitor_CouldNotUnwrapType(type)
+            _ => throw ThrowHelper.ProjectionVisitor_CouldNotUnwrapType(type),
         };
 }

--- a/src/HotChocolate/Data/src/Data/Projections/Visitor/SelectionVisitorActionKind.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Visitor/SelectionVisitorActionKind.cs
@@ -5,5 +5,5 @@ public enum SelectionVisitorActionKind
     Continue,
     Skip,
     Break,
-    SkipAndLeave
+    SkipAndLeave,
 }

--- a/src/HotChocolate/Data/src/Data/Sorting/Expressions/QueryableSortProvider.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/Expressions/QueryableSortProvider.cs
@@ -184,7 +184,7 @@ public class QueryableSortProvider : SortProvider<QueryableSortContext>
             IQueryable<TEntityType> q => sort(q),
             IEnumerable<TEntityType> q => sort(q.AsQueryable()),
             QueryableExecutable<TEntityType> q => q.WithSource(sort(q.Source)),
-            _ => input
+            _ => input,
         };
 
     private ApplySorting CreateApplicatorAsync<TEntityType>(string argumentName)

--- a/src/HotChocolate/Data/src/Data/Sorting/Extensions/SortObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/Extensions/SortObjectFieldDescriptorExtensions.cs
@@ -174,7 +174,7 @@ public static class SortObjectFieldDescriptorExtensions
                     var argumentDefinition = new ArgumentDefinition
                     {
                         Name = argumentPlaceholder,
-                        Type = argumentTypeReference
+                        Type = argumentTypeReference,
                     };
 
                     argumentDefinition.Configurations.Add(

--- a/src/HotChocolate/Data/src/EntityFramework/DbContextKind.cs
+++ b/src/HotChocolate/Data/src/EntityFramework/DbContextKind.cs
@@ -30,5 +30,5 @@ public enum DbContextKind
     /// <see cref="IServiceScope"/> when executing. The <see cref="DbContext"/> is retrieved from
     /// the service scope and the scope is disposed at the end of the resolver execution.
     /// </summary>
-    Resolver
+    Resolver,
 }

--- a/src/HotChocolate/Data/src/EntityFramework/DbContextParameterExpressionBuilder.cs
+++ b/src/HotChocolate/Data/src/EntityFramework/DbContextParameterExpressionBuilder.cs
@@ -25,7 +25,7 @@ internal sealed class DbContextParameterExpressionBuilder<TDbContext>
         {
             DbContextKind.Pooled => ServiceKind.Pooled,
             DbContextKind.Resolver => ServiceKind.Resolver,
-            _ => ServiceKind.Synchronized
+            _ => ServiceKind.Synchronized,
         };
     }
 

--- a/src/HotChocolate/Data/src/EntityFramework/ToListMiddleware.cs
+++ b/src/HotChocolate/Data/src/EntityFramework/ToListMiddleware.cs
@@ -26,7 +26,7 @@ internal sealed class ToListMiddleware<TEntity>
                 await queryable
                     .ToListAsync(context.RequestAborted)
                     .ConfigureAwait(false),
-            _ => context.Result
+            _ => context.Result,
         };
     }
 }

--- a/src/HotChocolate/Data/test/Data.AutoMapper.Tests/ProjectToTests.cs
+++ b/src/HotChocolate/Data/test/Data.AutoMapper.Tests/ProjectToTests.cs
@@ -23,7 +23,7 @@ public class ProjectToTests
                 new Author()
                 {
                     Name = "Phil",
-                    Membership = new PremiumMember { Name = "foo", Premium = "A" }
+                    Membership = new PremiumMember { Name = "foo", Premium = "A" },
                 },
             TitleImage = new Image() { Url = "https://testa.com/image.png" },
             Posts = new[]
@@ -36,8 +36,8 @@ public class ProjectToTests
                     {
                         Name = "Anna",
                         Membership =
-                            new StandardMember() { Name = "foo", Standard = "FLAT" }
-                    }
+                            new StandardMember() { Name = "foo", Standard = "FLAT" },
+                    },
                 },
                 new Post
                 {
@@ -47,10 +47,10 @@ public class ProjectToTests
                     {
                         Name = "Max",
                         Membership =
-                            new StandardMember() { Name = "foo", Standard = "FLAT" }
-                    }
-                }
-            }
+                            new StandardMember() { Name = "foo", Standard = "FLAT" },
+                    },
+                },
+            },
         },
         new()
         {
@@ -61,7 +61,7 @@ public class ProjectToTests
             {
                 Name = "Kurt",
                 Membership =
-                    new StandardMember() { Name = "foo", Standard = "FLAT" }
+                    new StandardMember() { Name = "foo", Standard = "FLAT" },
             },
             Posts = new[]
             {
@@ -73,8 +73,8 @@ public class ProjectToTests
                     {
                         Name = "Charles",
                         Membership =
-                            new PremiumMember { Name = "foo", Premium = "FLAT" }
-                    }
+                            new PremiumMember { Name = "foo", Premium = "FLAT" },
+                    },
                 },
                 new Post
                 {
@@ -84,10 +84,10 @@ public class ProjectToTests
                     {
                         Name = "Simone",
                         Membership =
-                            new PremiumMember { Name = "foo", Premium = "FLAT" }
-                    }
-                }
-            }
+                            new PremiumMember { Name = "foo", Premium = "FLAT" },
+                    },
+                },
+            },
         },
     };
 

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/AuthorFixture.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/AuthorFixture.cs
@@ -13,18 +13,18 @@ public class AuthorFixture : IDisposable
     {
         new Author
         {
-            Id = 1, Name = "Foo", Books = { new Book { Id = 1, Title = "Foo1" } }
+            Id = 1, Name = "Foo", Books = { new Book { Id = 1, Title = "Foo1" } },
         },
         new Author
         {
-            Id = 2, Name = "Bar", Books = { new Book { Id = 2, Title = "Bar1" } }
+            Id = 2, Name = "Bar", Books = { new Book { Id = 2, Title = "Bar1" } },
         },
-        new Author { Id = 3, Name = "Baz", Books = { new Book { Id = 3, Title = "Baz1" } } }
+        new Author { Id = 3, Name = "Baz", Books = { new Book { Id = 3, Title = "Baz1" } } },
     };
 
     private static readonly SingleOrDefaultAuthor[] _singleOrDefaultAuthors =
     {
-        new SingleOrDefaultAuthor { Id = 1, Name = "Foo" }
+        new SingleOrDefaultAuthor { Id = 1, Name = "Foo" },
     };
 
     public AuthorFixture()

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlCursorCursorPagingIntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlCursorCursorPagingIntegrationTests.cs
@@ -12,7 +12,7 @@ public class SqlCursorPagingIntegrationTests : SqlLiteCursorTestBase
         new TestData(Guid.NewGuid(), "A"),
         new TestData(Guid.NewGuid(), "B"),
         new TestData(Guid.NewGuid(), "C"),
-        new TestData(Guid.NewGuid(), "D")
+        new TestData(Guid.NewGuid(), "D"),
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlLiteCursorTestBase.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlLiteCursorTestBase.cs
@@ -65,7 +65,7 @@ public class SqlLiteCursorTestBase
                         })
                     .UsePaging<ObjectType<TEntity>>(options: new()
                     {
-                        IncludeTotalCount = true
+                        IncludeTotalCount = true,
                     }));
 
         var schema = builder.Create();

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlLiteOffsetTestBase.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlLiteOffsetTestBase.cs
@@ -65,7 +65,7 @@ public class SqlLiteOffsetTestBase
                         })
                     .UseOffsetPaging<ObjectType<TEntity>>(options: new()
                     {
-                        IncludeTotalCount = true
+                        IncludeTotalCount = true,
                     }));
 
         var schema = builder.Create();

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlOffsetPagingIntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/SqlOffsetPagingIntegrationTests.cs
@@ -12,7 +12,7 @@ public class SqlOffsetPagingIntegrationTests : SqlLiteOffsetTestBase
         new TestData(Guid.NewGuid(), "A"),
         new TestData(Guid.NewGuid(), "B"),
         new TestData(Guid.NewGuid(), "C"),
-        new TestData(Guid.NewGuid(), "D")
+        new TestData(Guid.NewGuid(), "D"),
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/FilteringAndPaging.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/FilteringAndPaging.cs
@@ -9,7 +9,7 @@ public class FilteringAndPaging
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterCombinatorTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterCombinatorTests.cs
@@ -9,7 +9,7 @@ public class QueryableFilterCombinatorTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorBooleanTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorBooleanTests.cs
@@ -9,14 +9,14 @@ public class QueryableFilterVisitorBooleanTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorComparableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorComparableTests.cs
@@ -10,7 +10,7 @@ public class QueryableFilterVisitorComparableTests : IClassFixture<SchemaCache>
     {
         new() { BarShort = 12 },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -18,7 +18,7 @@ public class QueryableFilterVisitorComparableTests : IClassFixture<SchemaCache>
         new() { BarShort = 12 },
         new() { BarShort = null },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorEnumTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorEnumTests.cs
@@ -12,7 +12,7 @@ public class QueryableFilterVisitorEnumTests
         new() { BarEnum = FooEnum.BAR },
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -21,7 +21,7 @@ public class QueryableFilterVisitorEnumTests
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
         new() { BarEnum = null },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private readonly SchemaCache _cache;
@@ -299,7 +299,7 @@ public class QueryableFilterVisitorEnumTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 
     public class FooFilterInput : FilterInputType<Foo>

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorExecutableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorExecutableTests.cs
@@ -9,14 +9,14 @@ public class QueryableFilterVisitorExecutableTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorExpressionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorExpressionTests.cs
@@ -14,7 +14,7 @@ public class QueryableFilterVisitorExpressionTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Name = "Foo", LastName = "Galoo", Bars = new[] { new Bar { Value="A"} } },
-        new() { Name = "Sam", LastName = "Sampleman", Bars = Array.Empty<Bar>() }
+        new() { Name = "Sam", LastName = "Sampleman", Bars = Array.Empty<Bar>() },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorIdTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorIdTests.cs
@@ -10,21 +10,21 @@ public class QueryableFilterVisitorIdTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = "testatest" },
-        new() { Bar = "testbtest" }
+        new() { Bar = "testbtest" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = "testatest" },
         new() { Bar = "testbtest" },
-        new() { Bar = null }
+        new() { Bar = null },
     };
 
     private static readonly FooShort[] _fooShortEntities =
     {
         new() { BarShort = 12 },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private static readonly FooShortNullable[] _fooShortNullableEntities =
@@ -32,7 +32,7 @@ public class QueryableFilterVisitorIdTests : IClassFixture<SchemaCache>
         new() { BarShort = 12 },
         new() { BarShort = null },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorInterfacesTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorInterfacesTests.cs
@@ -10,7 +10,7 @@ public class QueryableFilterVisitorInterfacesTests
     private static readonly BarInterface[] _barEntities =
     {
         new() { Test = new InterfaceImpl1 { Prop = "a" } },
-        new() { Test = new InterfaceImpl1 { Prop = "b" } }
+        new() { Test = new InterfaceImpl1 { Prop = "b" } },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorListTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorListTests.cs
@@ -16,8 +16,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         },
         new()
         {
@@ -25,8 +25,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         },
         new()
         {
@@ -34,8 +34,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         },
         new()
         {
@@ -43,8 +43,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         },
         new()
         {
@@ -52,9 +52,9 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = null },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
-        }
+                new FooNested { Bar = "b" },
+            },
+        },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorObjectTests.cs
@@ -24,12 +24,12 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             BarShort = 12,
-                            BarString = "a"
-                        }
-                    }
-                }
-            }
-         },
+                            BarString = "a",
+                        },
+                    },
+                },
+            },
+        },
         new()
         {
             Foo = new Foo
@@ -45,11 +45,11 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             BarShort = 14,
-                            BarString = "d"
-                        }
-                    }
-                }
-            }
+                            BarString = "d",
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -59,9 +59,9 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testctest",
-                ObjectArray = null
-            }
-        }
+                ObjectArray = null,
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -81,10 +81,10 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new FooNullable
                         {
                             BarShort = 12,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -101,10 +101,10 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new FooNullable
                         {
                             BarShort = null,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -121,10 +121,10 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new FooNullable
                         {
                             BarShort = 14,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -134,13 +134,13 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null
-            }
+                ObjectArray = null,
+            },
         },
         new()
         {
-            Foo = null
-        }
+            Foo = null,
+        },
     };
 
     private readonly SchemaCache _cache;
@@ -752,6 +752,6 @@ public class QueryableFilterVisitorObjectTests : IClassFixture<SchemaCache>
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorStringTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorStringTests.cs
@@ -9,14 +9,14 @@ public class QueryableFilterVisitorStringTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = "testatest" },
-        new() { Bar = "testbtest" }
+        new() { Bar = "testbtest" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = "testatest" },
         new() { Bar = "testbtest" },
-        new() { Bar = null }
+        new() { Bar = null },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorStructTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorStructTests.cs
@@ -11,39 +11,39 @@ public class QueryableFilterVisitorStructTests : IClassFixture<SchemaCache>
 {
     private static readonly Bar[] _barEntities =
     {
-        new() { Foo = new Foo { BarShort = 12, } },
-        new() { Foo = new Foo { BarShort = 14, } },
-        new() { Foo = new Foo { BarShort = 13, } }
+        new() { Foo = new Foo { BarShort = 12 } },
+        new() { Foo = new Foo { BarShort = 14 } },
+        new() { Foo = new Foo { BarShort = 13 } },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
     {
         new()
         {
-            Foo = new FooNullable { BarShort = 12, },
-            FooList = new[] { new FooNullable { BarShort = 13, } },
-            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = 13, } }
+            Foo = new FooNullable { BarShort = 12 },
+            FooList = new[] { new FooNullable { BarShort = 13 } },
+            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = 13 } },
         },
         new()
         {
-            Foo = new FooNullable { BarShort = null, },
-            FooList = new[] { new FooNullable { BarShort = null, } },
-            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = null, } }
+            Foo = new FooNullable { BarShort = null },
+            FooList = new[] { new FooNullable { BarShort = null } },
+            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = null } },
         },
         new()
         {
-            Foo = new FooNullable { BarShort = 14, },
-            FooList = new[] { new FooNullable { BarShort = 14, } },
-            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = 14, } }
+            Foo = new FooNullable { BarShort = 14 },
+            FooList = new[] { new FooNullable { BarShort = 14 } },
+            FooNullableList = new FooNullable?[] { new FooNullable { BarShort = 14 } },
         },
         new()
         {
-            Foo = new FooNullable { BarShort = 13, },
-            FooList = new[] { new FooNullable { BarShort = 13, } },
+            Foo = new FooNullable { BarShort = 13 },
+            FooList = new[] { new FooNullable { BarShort = 13 } },
             FooNullableList =
-                new FooNullable?[] { new FooNullable { BarShort = 13, }, null }
+                new FooNullable?[] { new FooNullable { BarShort = 13 }, null },
         },
-        new() { Foo = null, FooList = null, FooNullableList = null }
+        new() { Foo = null, FooList = null, FooNullableList = null },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorVariablesTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/QueryableFilterVisitorVariablesTests.cs
@@ -9,7 +9,7 @@ public class QueryableFilterVisitorVariablesTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/FilteringAndPaging.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/FilteringAndPaging.cs
@@ -9,7 +9,7 @@ public class FilteringAndPaging
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorBooleanTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorBooleanTests.cs
@@ -9,14 +9,14 @@ public class QueryableFilterVisitorBooleanTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorComparableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorComparableTests.cs
@@ -10,7 +10,7 @@ public class QueryableFilterVisitorComparableTests
     {
         new() { BarShort = 12 },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -18,7 +18,7 @@ public class QueryableFilterVisitorComparableTests
         new() { BarShort = 12 },
         new() { BarShort = null },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorEnumTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorEnumTests.cs
@@ -11,7 +11,7 @@ public class QueryableFilterVisitorEnumTests
         new() { BarEnum = FooEnum.BAR },
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -20,7 +20,7 @@ public class QueryableFilterVisitorEnumTests
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
         new() { BarEnum = null },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private readonly SchemaCache _cache = new();
@@ -293,7 +293,7 @@ public class QueryableFilterVisitorEnumTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 
     public class FooFilterInput : FilterInputType<Foo>

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorExecutableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorExecutableTests.cs
@@ -10,14 +10,14 @@ public class QueryableFilterVisitorExecutableTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorExpressionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorExpressionTests.cs
@@ -16,15 +16,15 @@ public class QueryableFilterVisitorExpressionTests : IClassFixture<SchemaCache>
             LastName = "Galoo",
             Bars = new[]
             {
-                new Bar { Value="A" }
-            }
+                new Bar { Value="A" },
+            },
         },
         new()
         {
             Name = "Sam",
             LastName = "Sampleman",
-            Bars = Array.Empty<Bar>()
-        }
+            Bars = Array.Empty<Bar>(),
+        },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorInterfacesTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorInterfacesTests.cs
@@ -12,7 +12,7 @@ public class QueryableFilterVisitorInterfacesTests : IClassFixture<SchemaCache>
     private static readonly BarInterface[] _barEntities =
     {
         new() { Test = new InterfaceImpl1 { Prop = "a" } },
-        new() { Test = new InterfaceImpl1 { Prop = "b" } }
+        new() { Test = new InterfaceImpl1 { Prop = "b" } },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorListTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorListTests.cs
@@ -16,8 +16,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         },
         new()
         {
@@ -25,8 +25,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         },
         new()
         {
@@ -34,8 +34,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         },
         new()
         {
@@ -43,8 +43,8 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         },
         new()
         {
@@ -52,9 +52,9 @@ public class QueryableFilterVisitorListTests
             {
                 new FooNested { Bar = null },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
-        }
+                new FooNested { Bar = "b" },
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorObjectTests.cs
@@ -19,9 +19,9 @@ public class QueryableFilterVisitorObjectTests
                 BarString = "testatest",
                 ObjectArray = new List<Bar>
                 {
-                    new() { Foo = new Foo { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new Foo { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -33,9 +33,9 @@ public class QueryableFilterVisitorObjectTests
                 BarString = "testbtest",
                 ObjectArray = new List<Bar>
                 {
-                    new() { Foo = new Foo { BarShort = 14, BarString = "d" } }
-                }
-            }
+                    new() { Foo = new Foo { BarShort = 14, BarString = "d" } },
+                },
+            },
         },
         new()
         {
@@ -46,8 +46,8 @@ public class QueryableFilterVisitorObjectTests
                 BarEnum = BarEnum.FOO,
                 BarString = "testctest",
                 ObjectArray = null,
-            }
-        }
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -62,9 +62,9 @@ public class QueryableFilterVisitorObjectTests
                 BarString = "testatest",
                 ObjectArray = new List<BarNullable>
                 {
-                    new() { Foo = new FooNullable { BarShort = 12 } }
-                }
-            }
+                    new() { Foo = new FooNullable { BarShort = 12 } },
+                },
+            },
         },
         new()
         {
@@ -76,9 +76,9 @@ public class QueryableFilterVisitorObjectTests
                 BarString = "testbtest",
                 ObjectArray = new List<BarNullable>
                 {
-                    new() { Foo = new FooNullable { BarShort = null } }
-                }
-            }
+                    new() { Foo = new FooNullable { BarShort = null } },
+                },
+            },
         },
         new()
         {
@@ -90,9 +90,9 @@ public class QueryableFilterVisitorObjectTests
                 BarString = "testctest",
                 ObjectArray = new List<BarNullable>
                 {
-                    new() { Foo = new FooNullable { BarShort = 14 } }
-                }
-            }
+                    new() { Foo = new FooNullable { BarShort = 14 } },
+                },
+            },
         },
         new()
         {
@@ -102,9 +102,9 @@ public class QueryableFilterVisitorObjectTests
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null
-            }
-        }
+                ObjectArray = null,
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -680,6 +680,6 @@ public class QueryableFilterVisitorObjectTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorStringTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/QueryableFilterVisitorStringTests.cs
@@ -9,14 +9,14 @@ public class QueryableFilterVisitorStringTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = "testatest" },
-        new() { Bar = "testbtest" }
+        new() { Bar = "testbtest" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = "testatest" },
         new() { Bar = "testbtest" },
-        new() { Bar = null }
+        new() { Bar = null },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorEnumTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorEnumTests.cs
@@ -242,7 +242,7 @@ public class QueryableFilterVisitorEnumTests : FilterVisitorTestBase
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 
     public class FooFilterInput : FilterInputType<Foo>
@@ -269,7 +269,7 @@ public class QueryableFilterVisitorEnumTests : FilterVisitorTestBase
         None,
         First,
         Second,
-        Third
+        Third,
     }
 
     public class AttributeTest

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorListTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorListTests.cs
@@ -89,8 +89,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 null,
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(a));
 
@@ -100,8 +100,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 null,
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(b));
     }
@@ -121,8 +121,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(a));
 
@@ -132,8 +132,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(b));
 
@@ -145,8 +145,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
                 new FooNested { Bar = null },
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(c));
     }
@@ -168,8 +168,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.False(func(a));
 
@@ -179,8 +179,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.True(func(b));
         var c = new Foo
@@ -190,8 +190,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
                 null,
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = null },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.True(func(c));
     }
@@ -214,8 +214,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(a));
 
@@ -225,8 +225,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.False(func(b));
 
@@ -236,8 +236,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(c));
 
@@ -247,8 +247,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(d));
 
@@ -259,8 +259,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
                 null,
                 new FooNested { Bar = null },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(e));
     }
@@ -283,8 +283,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(a));
 
@@ -314,8 +314,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.False(func(a));
 
@@ -423,8 +423,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(a));
 
@@ -434,8 +434,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.True(func(b));
 
@@ -445,8 +445,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "a" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.True(func(c));
 
@@ -456,8 +456,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(d));
 
@@ -468,8 +468,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
                 null,
                 new FooNested { Bar = null },
                 new FooNested { Bar = "d" },
-                new FooNested { Bar = "b" }
-            }
+                new FooNested { Bar = "b" },
+            },
         };
         Assert.False(func(e));
 
@@ -480,8 +480,8 @@ public class QueryableFilterVisitorListTests : FilterVisitorTestBase
             {
                 new FooNested { Bar = "c" },
                 new FooNested { Bar = "a" },
-                new FooNested { Bar = "a" }
-            }
+                new FooNested { Bar = "a" },
+            },
         };
         Assert.False(func(f));
     }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
@@ -307,11 +307,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                ScalarArray = new[] { "c", "d", "a" }
-                            }
-                        }
-                    }
-            }
+                                ScalarArray = new[] { "c", "d", "a" },
+                            },
+                        },
+                },
+            },
         };
         Assert.True(func(a));
 
@@ -322,11 +322,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                ScalarArray = new[] { "c", "d", "b" }
-                            }
-                        }
-                    }
-            }
+                                ScalarArray = new[] { "c", "d", "b" },
+                            },
+                        },
+                },
+            },
         };
         Assert.False(func(b));
     }
@@ -350,11 +350,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                ScalarArray = new[] { "c", "d", "a" }
-                            }
-                        }
-                    }
-            }
+                                ScalarArray = new[] { "c", "d", "a" },
+                            },
+                        },
+                },
+            },
         };
         Assert.True(func(a));
 
@@ -365,11 +365,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                ScalarArray = new string[0]
-                            }
-                        }
-                    }
-            }
+                                ScalarArray = new string[0],
+                            },
+                        },
+                },
+            },
         };
         Assert.False(func(b));
 
@@ -380,11 +380,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                ScalarArray = null
-                            }
-                        }
-                    }
-            }
+                                ScalarArray = null,
+                            },
+                        },
+                },
+            },
         };
         Assert.False(func(c));
     }
@@ -408,11 +408,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                BarString = "a"
-                            }
-                        }
-                    }
-            }
+                                BarString = "a",
+                            },
+                        },
+                },
+            },
         };
         Assert.True(func(a));
 
@@ -423,11 +423,11 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 ObjectArray = new Bar[] {
                         new Bar {
                             Foo = new Foo {
-                                BarString = "b"
-                            }
-                        }
-                    }
-            }
+                                BarString = "b",
+                            },
+                        },
+                },
+            },
         };
         Assert.False(func(b));
     }
@@ -448,8 +448,8 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
         {
             Test = new InterfaceImpl1
             {
-                Prop = "a"
-            }
+                Prop = "a",
+            },
         };
 
         Assert.True(func(a));
@@ -458,8 +458,8 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
         {
             Test = new InterfaceImpl1
             {
-                Prop = "b"
-            }
+                Prop = "b",
+            },
         };
         Assert.False(func(b));
     }
@@ -547,6 +547,6 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/FilterAttributeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/FilterAttributeTests.cs
@@ -61,7 +61,7 @@ public class FilterAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 #endif
@@ -77,7 +77,7 @@ public class FilterAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 
@@ -92,7 +92,7 @@ public class FilterAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 
@@ -107,7 +107,7 @@ public class FilterAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/QueryableFilteringExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/QueryableFilteringExtensionsTests.cs
@@ -16,7 +16,7 @@ public class QueryableFilteringExtensionsTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true, Baz = "a" },
-        new() { Bar = false, Baz = "b" }
+        new() { Bar = false, Baz = "b" },
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ComparableOperationInputTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ComparableOperationInputTests.cs
@@ -115,6 +115,6 @@ public class ComparableOperationInputTests
     public enum FooBar
     {
         Foo,
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Types/EnumOperationInputTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Types/EnumOperationInputTypeTests.cs
@@ -63,6 +63,6 @@ public class EnumOperationInputTests
     public enum FooBar
     {
         Foo,
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ListFilterInputTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ListFilterInputTests.cs
@@ -106,6 +106,6 @@ public class ListFilterInputTests
     public enum FooBar
     {
         Foo,
-        Bar
+        Bar,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableFirstOrDefaultTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableFirstOrDefaultTests.cs
@@ -22,9 +22,9 @@ public class QueryableFirstOrDefaultTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -38,10 +38,10 @@ public class QueryableFirstOrDefaultTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "d" } },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -56,9 +56,9 @@ public class QueryableFirstOrDefaultTests
                 BarString = "testatest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12 } },
+                },
+            },
         },
         new()
         {
@@ -70,9 +70,9 @@ public class QueryableFirstOrDefaultTests
                 BarString = "testbtest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 9 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 9 } },
+                },
+            },
         },
         new()
         {
@@ -84,9 +84,9 @@ public class QueryableFirstOrDefaultTests
                 BarString = "testctest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 14 } },
+                },
+            },
         },
         new()
         {
@@ -96,9 +96,9 @@ public class QueryableFirstOrDefaultTests
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null
-            }
-        }
+                ObjectArray = null,
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -345,6 +345,6 @@ public class QueryableFirstOrDefaultTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionExtensionsTests.cs
@@ -15,7 +15,7 @@ public class QueryableProjectionExtensionsTests
 {
     private static readonly Foo[] _fooEntities =
     {
-        new Foo { Bar = true, Baz = "a" }, new Foo { Bar = false, Baz = "b" }
+        new Foo { Bar = true, Baz = "a" }, new Foo { Bar = false, Baz = "b" },
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionFilterTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionFilterTests.cs
@@ -22,9 +22,9 @@ public class QueryableProjectionFilterTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -38,10 +38,10 @@ public class QueryableProjectionFilterTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "d" } },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -56,9 +56,9 @@ public class QueryableProjectionFilterTests
                 BarString = "testatest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12 } },
+                },
+            },
         },
         new()
         {
@@ -70,9 +70,9 @@ public class QueryableProjectionFilterTests
                 BarString = "testbtest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new BarNullableDeep { Foo = new FooDeep { BarShort = 9 } }
-                }
-            }
+                    new BarNullableDeep { Foo = new FooDeep { BarShort = 9 } },
+                },
+            },
         },
         new()
         {
@@ -84,9 +84,9 @@ public class QueryableProjectionFilterTests
                 BarString = "testctest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new BarNullableDeep { Foo = new FooDeep { BarShort = 14 } }
-                }
-            }
+                    new BarNullableDeep { Foo = new FooDeep { BarShort = 14 } },
+                },
+            },
         },
         new()
         {
@@ -96,9 +96,9 @@ public class QueryableProjectionFilterTests
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null
-            }
-        }
+                ObjectArray = null,
+            },
+        },
     };
 
     private static readonly BarNullable[] _barWithoutRelation =
@@ -111,12 +111,12 @@ public class QueryableProjectionFilterTests
                 BarShort = 15,
                 NestedObject = new BarNullableDeep
                 {
-                    Foo = new FooDeep { BarString = "Foo" }
-                }
-            }
+                    Foo = new FooDeep { BarString = "Foo" },
+                },
+            },
         },
         new() { Foo = new FooNullable { BarEnum = BarEnum.FOO, BarShort = 14 } },
-        new()
+        new(),
     };
 
     private readonly SchemaCache _cache = new();
@@ -449,6 +449,6 @@ public class QueryableProjectionFilterTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionHashSetTest.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionHashSetTest.cs
@@ -22,9 +22,9 @@ public class QueryableProjectionHashSetTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
                 ObjectSet = new HashSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -38,10 +38,10 @@ public class QueryableProjectionHashSetTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "d" } },
                 ObjectSet = new HashSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -196,6 +196,6 @@ public class QueryableProjectionHashSetTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionInterfaceTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionInterfaceTypeTests.cs
@@ -13,7 +13,7 @@ public class QueryableProjectionInterfaceTypeTests
     private static readonly AbstractType[] _barEntities =
     {
         new Bar { Name = "Bar", BarProp = "BarProp" },
-        new Foo { Name = "Foo", FooProp = "FooProp" }
+        new Foo { Name = "Foo", FooProp = "FooProp" },
     };
 
     private static readonly NestedObject[] _barNestedEntities =
@@ -29,16 +29,16 @@ public class QueryableProjectionInterfaceTypeTests
             List = new()
             {
                 new Foo { Name = "Foo", FooProp = "FooProp" },
-                new Bar { Name = "Bar", BarProp = "BarProp" }
-            }
+                new Bar { Name = "Bar", BarProp = "BarProp" },
+            },
         },
         new()
         {
             List = new()
             {
                 new Bar { Name = "Bar", BarProp = "BarProp" },
-                new Foo { Name = "Foo", FooProp = "FooProp" }
-            }
+                new Foo { Name = "Foo", FooProp = "FooProp" },
+            },
         },
     };
 

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionNestedTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionNestedTests.cs
@@ -9,8 +9,8 @@ public class QueryableProjectionNestedTests
 {
     private static readonly Bar[] _barEntities =
     {
-        new() { Foo = new Foo { BarString = "testatest", } },
-        new() { Foo = new Foo { BarString = "testbtest", } }
+        new() { Foo = new Foo { BarString = "testatest" } },
+        new() { Foo = new Foo { BarString = "testbtest" } },
     };
 
     private readonly SchemaCache _cache = new SchemaCache();

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSetTest.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSetTest.cs
@@ -21,13 +21,13 @@ public class QueryableProjectionISetTests
                 NestedObject =
                     new BarDeep
                     {
-                        Foo = new FooDeep { BarShort = 12, BarString = "a" }
+                        Foo = new FooDeep { BarShort = 12, BarString = "a" },
                     },
                 ObjectSet = new HashSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -40,14 +40,14 @@ public class QueryableProjectionISetTests
                 NestedObject =
                     new BarDeep
                     {
-                        Foo = new FooDeep { BarShort = 12, BarString = "d" }
+                        Foo = new FooDeep { BarShort = 12, BarString = "d" },
                     },
                 ObjectSet = new HashSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -202,6 +202,6 @@ public class QueryableProjectionISetTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSortedSetTest.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSortedSetTest.cs
@@ -22,9 +22,9 @@ public class QueryableProjectionSortedSetTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
                 ObjectSet = new SortedSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -38,10 +38,10 @@ public class QueryableProjectionSortedSetTests
                     new BarDeep { Foo = new FooDeep { BarShort = 12, BarString = "d" } },
                 ObjectSet = new SortedSet<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -196,6 +196,6 @@ public class QueryableProjectionSortedSetTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSortingTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionSortingTests.cs
@@ -24,9 +24,9 @@ public class QueryableProjectionSortingTests
                 {
                     new() { Foo = new FooDeep { BarShort = 1, BarString = "a" } },
                     new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
-                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -42,10 +42,10 @@ public class QueryableProjectionSortingTests
                 {
                     new() { Foo = new FooDeep { BarShort = 1, BarString = "a" } },
                     new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
-                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } },
+                },
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -64,9 +64,9 @@ public class QueryableProjectionSortingTests
                 {
                     new() { Foo = new FooDeep { BarShort = 1, BarString = "a" } },
                     new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
-                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -82,9 +82,9 @@ public class QueryableProjectionSortingTests
                 {
                     new() { Foo = new FooDeep { BarShort = 1, BarString = "a" } },
                     new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
-                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -100,9 +100,9 @@ public class QueryableProjectionSortingTests
                 {
                     new() { Foo = new FooDeep { BarShort = 1, BarString = "a" } },
                     new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
-                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 3, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -112,9 +112,9 @@ public class QueryableProjectionSortingTests
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null!
-            }
-        }
+                ObjectArray = null!,
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -375,6 +375,6 @@ public class QueryableProjectionSortingTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionUnionTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionUnionTypeTests.cs
@@ -13,7 +13,7 @@ public class QueryableProjectionUnionTypeTests
     private static readonly AbstractType[] _barEntities =
     {
         new Bar { Name = "Bar", BarProp = "BarProp" },
-        new Foo { Name = "Foo", FooProp = "FooProp" }
+        new Foo { Name = "Foo", FooProp = "FooProp" },
     };
 
     private static readonly NestedObject[] _barNestedEntities =
@@ -29,16 +29,16 @@ public class QueryableProjectionUnionTypeTests
             List = new()
             {
                 new Foo { Name = "Foo", FooProp = "FooProp" },
-                new Bar { Name = "Bar", BarProp = "BarProp" }
-            }
+                new Bar { Name = "Bar", BarProp = "BarProp" },
+            },
         },
         new()
         {
             List = new()
             {
                 new Bar { Name = "Bar", BarProp = "BarProp" },
-                new Foo { Name = "Foo", FooProp = "FooProp" }
-            }
+                new Foo { Name = "Foo", FooProp = "FooProp" },
+            },
         },
     };
 

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorExecutableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorExecutableTests.cs
@@ -9,7 +9,7 @@ public class QueryableProjectionVisitorExecutableTests
 {
     private static readonly Foo[] _fooEntities =
     {
-        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" }
+        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorIsProjectedTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorIsProjectedTests.cs
@@ -9,18 +9,18 @@ public class QueryableProjectionVisitorIsProjectedTests
     private static readonly Foo[] _fooEntities =
     {
         new() { IsProjectedTrue = true, IsProjectedFalse = false },
-        new() { IsProjectedTrue = true, IsProjectedFalse = false }
+        new() { IsProjectedTrue = true, IsProjectedFalse = false },
     };
 
     private static readonly MultipleFoo[] _fooMultipleEntities =
     {
         new() { IsProjectedTrue1 = true, IsProjectedFalse = false },
-        new() { IsProjectedTrue1 = true, IsProjectedFalse = false }
+        new() { IsProjectedTrue1 = true, IsProjectedFalse = false },
     };
 
     private static readonly Bar[] _barEntities =
     {
-        new() { IsProjectedFalse = false }, new() { IsProjectedFalse = false }
+        new() { IsProjectedFalse = false }, new() { IsProjectedFalse = false },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorPagingTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorPagingTests.cs
@@ -12,14 +12,14 @@ public class QueryableProjectionVisitorPagingTests
 {
     private static readonly Foo[] _fooEntities =
     {
-        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" }
+        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true, Baz = "a" },
         new() { Bar = null, Baz = null },
-        new() { Bar = false, Baz = "c" }
+        new() { Bar = false, Baz = "c" },
     };
 
     private readonly SchemaCache _cache = new SchemaCache();
@@ -535,7 +535,7 @@ public class QueryableProjectionVisitorPagingTests
                 new List<Bar>
                 {
                     new() { BarBaz = "a_a", BarQux = "a_c" },
-                    new() { BarBaz = "a_b", BarQux = "a_d" }
+                    new() { BarBaz = "a_b", BarQux = "a_d" },
                 });
         }
     }

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorScalarTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionVisitorScalarTests.cs
@@ -9,7 +9,7 @@ public class QueryableProjectionVisitorScalarTests
 {
     private static readonly Foo[] _fooEntities =
     {
-        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" }
+        new() { Bar = true, Baz = "a" }, new() { Bar = false, Baz = "b" },
     };
 
     private readonly SchemaCache _cache = new();

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableSingleOrDefaultTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableSingleOrDefaultTests.cs
@@ -21,13 +21,13 @@ public class QueryableSingleOrDefaultTests
                 NestedObject =
                     new BarDeep
                     {
-                        Foo = new FooDeep { BarShort = 12, BarString = "a" }
+                        Foo = new FooDeep { BarShort = 12, BarString = "a" },
                     },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12, BarString = "a" } },
+                },
+            },
         },
         new()
         {
@@ -40,14 +40,14 @@ public class QueryableSingleOrDefaultTests
                 NestedObject =
                     new BarDeep
                     {
-                        Foo = new FooDeep { BarShort = 12, BarString = "d" }
+                        Foo = new FooDeep { BarShort = 12, BarString = "d" },
                     },
                 ObjectArray = new List<BarDeep>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } }
-                }
-            }
-        }
+                    new() { Foo = new FooDeep { BarShort = 14, BarString = "d" } },
+                },
+            },
+        },
     };
 
     private static readonly BarNullable[] _barNullableEntities =
@@ -62,9 +62,9 @@ public class QueryableSingleOrDefaultTests
                 BarString = "testatest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 12 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 12 } },
+                },
+            },
         },
         new()
         {
@@ -76,9 +76,9 @@ public class QueryableSingleOrDefaultTests
                 BarString = "testbtest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 9 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 9 } },
+                },
+            },
         },
         new()
         {
@@ -90,9 +90,9 @@ public class QueryableSingleOrDefaultTests
                 BarString = "testctest",
                 ObjectArray = new List<BarNullableDeep?>
                 {
-                    new() { Foo = new FooDeep { BarShort = 14 } }
-                }
-            }
+                    new() { Foo = new FooDeep { BarShort = 14 } },
+                },
+            },
         },
         new()
         {
@@ -102,9 +102,9 @@ public class QueryableSingleOrDefaultTests
                 BarBool = false,
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
-                ObjectArray = null
-            }
-        }
+                ObjectArray = null,
+            },
+        },
     };
 
     private readonly SchemaCache _cache = new();
@@ -356,6 +356,6 @@ public class QueryableSingleOrDefaultTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.Tests/IntegrationTests.cs
@@ -535,19 +535,19 @@ public class QueryWithNodeResolvers
 {
     [UseProjection]
     public IQueryable<Foo> All()
-        => new Foo[] { new() { Bar = "A" }, }.AsQueryable();
+        => new Foo[] { new() { Bar = "A" } }.AsQueryable();
 
     [NodeResolver]
     [UseSingleOrDefault]
     [UseProjection]
     public IQueryable<Foo> GetById(string id)
-        => new Foo[] { new() { Bar = "A" }, }.AsQueryable();
+        => new Foo[] { new() { Bar = "A" } }.AsQueryable();
 
     [NodeResolver]
     [UseSingleOrDefault]
     [UseProjection]
     public IQueryable<Baz> GetBazById(string id)
-        => new Baz[] { new() { Bar2 = "A" }, }.AsQueryable();
+        => new Baz[] { new() { Bar2 = "A" } }.AsQueryable();
 
     [NodeResolver]
     public Bar GetBarById(string id) => new() { IdOfBar = "A" };

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableFilterVisitorInterfacesTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableFilterVisitorInterfacesTests.cs
@@ -10,7 +10,7 @@ public class QueryableFilterVisitorInterfacesTests : IClassFixture<SchemaCache>
     private static readonly BarInterface[] _barEntities =
     {
         new() { Test = new InterfaceImpl1 { Prop = "a" } },
-        new() { Test = new InterfaceImpl1 { Prop = "b" } }
+        new() { Test = new InterfaceImpl1 { Prop = "b" } },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorBooleanTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorBooleanTests.cs
@@ -9,14 +9,14 @@ public class QueryableSortVisitorBooleanTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorComparableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorComparableTests.cs
@@ -11,7 +11,7 @@ public class QueryableSortVisitorComparableTests
     {
         new() { BarShort = 12 },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -19,7 +19,7 @@ public class QueryableSortVisitorComparableTests
         new() { BarShort = 12 },
         new() { BarShort = null },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorEnumTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorEnumTests.cs
@@ -12,7 +12,7 @@ public class QueryableSortVisitorEnumTests
         new() { BarEnum = FooEnum.BAR },
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -21,7 +21,7 @@ public class QueryableSortVisitorEnumTests
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
         new() { BarEnum = null },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private readonly SchemaCache _cache;
@@ -101,7 +101,7 @@ public class QueryableSortVisitorEnumTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 
     public class FooSortType : SortInputType<Foo>

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorExecutableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorExecutableTests.cs
@@ -9,14 +9,14 @@ public class QueryableSortVisitorExecutableTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorExpressionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorExpressionTests.cs
@@ -17,15 +17,15 @@ public class QueryableSortVisitorExpressionTests : IClassFixture<SchemaCache>
          {
              Name = "Sam",
              LastName = "Sampleman",
-             Bars = Array.Empty<Bar>()
+             Bars = Array.Empty<Bar>(),
          },
          new()
          {
              Name = "Foo",
              LastName = "Galoo",
-             Bars = new Bar[] { new() { Value = "A" } }
-         }
-     };
+             Bars = new Bar[] { new() { Value = "A" } },
+         },
+    };
 
     private readonly SchemaCache _cache;
 

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorObjectTests.cs
@@ -25,11 +25,11 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             // ScalarArray = new[] { "c", "d", "a" }
-                            BarShort = 12, BarString = "a"
-                        }
-                    }
-                }
-            }
+                            BarShort = 12, BarString = "a",
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -47,11 +47,11 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
-                            BarShort = 14, BarString = "d"
-                        }
-                    }
-                }
-            }
+                            BarShort = 14, BarString = "d",
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -63,8 +63,8 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                 BarString = "testctest",
                 //ScalarArray = null,
                 ObjectArray = null,
-            }
-        }
+            },
+        },
     };
 
     private static readonly BarNullable?[] _barNullableEntities =
@@ -86,10 +86,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "a" }
                             BarShort = 12,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -108,10 +108,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
                             BarShort = null,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -130,10 +130,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
                             BarShort = 14,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -144,14 +144,14 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
                 //ScalarArray = null,
-                ObjectArray = null
-            }
+                ObjectArray = null,
+            },
         },
         new()
         {
-            Foo =null
+            Foo =null,
         },
-        null
+        null,
     };
 
     private readonly SchemaCache _cache;
@@ -520,6 +520,6 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorStringTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorStringTests.cs
@@ -9,14 +9,14 @@ public class QueryableSortVisitorStringTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = "testatest" },
-        new() { Bar = "testbtest" }
+        new() { Bar = "testbtest" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = "testatest" },
         new() { Bar = "testbtest" },
-        new() { Bar = null }
+        new() { Bar = null },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorVariablesTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.InMemory.Tests/QueryableSortVisitorVariablesTests.cs
@@ -15,7 +15,7 @@ public class QueryableSortVisitorVariablesTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorBooleanTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorBooleanTests.cs
@@ -9,14 +9,14 @@ public class QueryableSortVisitorBooleanTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorComparableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorComparableTests.cs
@@ -11,7 +11,7 @@ public class QueryableSortVisitorComparableTests
     {
         new() { BarShort = 12 },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -19,7 +19,7 @@ public class QueryableSortVisitorComparableTests
         new() { BarShort = 12 },
         new() { BarShort = null },
         new() { BarShort = 14 },
-        new() { BarShort = 13 }
+        new() { BarShort = 13 },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorEnumTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorEnumTests.cs
@@ -12,7 +12,7 @@ public class QueryableSortVisitorEnumTests
         new() { BarEnum = FooEnum.BAR },
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
@@ -21,7 +21,7 @@ public class QueryableSortVisitorEnumTests
         new() { BarEnum = FooEnum.BAZ },
         new() { BarEnum = FooEnum.FOO },
         new() { BarEnum = null },
-        new() { BarEnum = FooEnum.QUX }
+        new() { BarEnum = FooEnum.QUX },
     };
 
     private readonly SchemaCache _cache;
@@ -101,7 +101,7 @@ public class QueryableSortVisitorEnumTests
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 
     public class FooSortType : SortInputType<Foo>

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorExecutableTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorExecutableTests.cs
@@ -9,14 +9,14 @@ public class QueryableSortVisitorExecutableTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = true },
         new() { Bar = null },
-        new() { Bar = false }
+        new() { Bar = false },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorExpressionTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorExpressionTests.cs
@@ -14,8 +14,8 @@ public class QueryableSortVisitorExpressionTests : IClassFixture<SchemaCache>
     private static readonly Foo[] _fooEntities =
     {
          new Foo { Name = "Sam", LastName = "Sampleman", Bars = Array.Empty<Bar>() },
-         new Foo { Name = "Foo", LastName = "Galoo", Bars = new Bar[]{ new Bar { Value="A"} } }
-     };
+         new Foo { Name = "Foo", LastName = "Galoo", Bars = new Bar[]{ new Bar { Value="A"} } },
+    };
 
     private readonly SchemaCache _cache;
 

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorObjectTests.cs
@@ -25,11 +25,11 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             // ScalarArray = new[] { "c", "d", "a" }
-                            BarShort = 12, BarString = "a"
-                        }
-                    }
-                }
-            }
+                            BarShort = 12, BarString = "a",
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -47,11 +47,11 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         Foo = new Foo
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
-                            BarShort = 14, BarString = "d"
-                        }
-                    }
-                }
-            }
+                            BarShort = 14, BarString = "d",
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -63,8 +63,8 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                 BarString = "testctest",
                 //ScalarArray = null,
                 ObjectArray = null,
-            }
-        }
+            },
+        },
     };
 
     private static readonly BarNullable?[] _barNullableEntities =
@@ -86,10 +86,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "a" }
                             BarShort = 12,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -108,10 +108,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
                             BarShort = null,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -130,10 +130,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                         {
                             //ScalarArray = new[] { "c", "d", "b" }
                             BarShort = 14,
-                        }
-                    }
-                }
-            }
+                        },
+                    },
+                },
+            },
         },
         new()
         {
@@ -144,10 +144,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                 BarEnum = BarEnum.FOO,
                 BarString = "testdtest",
                 //ScalarArray = null,
-                ObjectArray = null
-            }
+                ObjectArray = null,
+            },
         },
-        new() { Foo = null }
+        new() { Foo = null },
     };
 
     private readonly SchemaCache _cache;
@@ -487,10 +487,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                                     "foo",
                                     new Dictionary<string,object>
                                     {
-                                         { "barShort", "ASC" },{ "barBool", "ASC" }
+                                         { "barShort", "ASC" },{ "barBool", "ASC" },
                                     }
-                                }
-                            }
+                                },
+                            },
                     })
                 .Create());
 
@@ -515,15 +515,15 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                                 {
                                     "foo",
                                     new Dictionary<string,object> { { "barShort", "ASC" } }
-                                }
+                                },
                             },
                             new()
                             {
                                 {
                                     "foo",
                                     new Dictionary<string,object> { { "barBool", "ASC" } }
-                                }
-                            }
+                                },
+                            },
                     })
                 .Create());
 
@@ -549,10 +549,10 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                                     "foo",
                                     new Dictionary<string,object>
                                     {
-                                        { "barShort", "DESC" },{ "barBool", "DESC" }
+                                        { "barShort", "DESC" },{ "barBool", "DESC" },
                                     }
-                                }
-                            }
+                                },
+                            },
                     })
                 .Create());
 
@@ -577,15 +577,15 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
                                 {
                                     "foo",
                                     new Dictionary<string, object> { { "barShort", "DESC" } }
-                                }
+                                },
                             },
                             new()
                             {
                                 {
                                     "foo",
                                     new Dictionary<string, object> { { "barBool", "DESC" } }
-                                }
-                            }
+                                },
+                            },
                     })
                 .Create());
 
@@ -664,6 +664,6 @@ public class QueryableSortVisitorObjectTests : IClassFixture<SchemaCache>
         FOO,
         BAR,
         BAZ,
-        QUX
+        QUX,
     }
 }

--- a/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorStringTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.SqlLite.Tests/QueryableSortVisitorStringTests.cs
@@ -10,14 +10,14 @@ public class QueryableSortVisitorStringTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = "testatest" },
-        new() { Bar = "testbtest" }
+        new() { Bar = "testbtest" },
     };
 
     private static readonly FooNullable[] _fooNullableEntities =
     {
         new() { Bar = "testatest" },
         new() { Bar = "testbtest" },
-        new() { Bar = null }
+        new() { Bar = null },
     };
 
     private readonly SchemaCache _cache;

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/Expression/QueryableSortVisitorAscObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/Expression/QueryableSortVisitorAscObjectTests.cs
@@ -246,7 +246,7 @@ public class QueryableSortVisitorAscObjectTests
     {
         Foo = 0,
         Bar = 1,
-        Baz = 2
+        Baz = 2,
     }
 
     public class FooNullableSortType<T>

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/Expression/QueryableSortVisitorDescObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/Expression/QueryableSortVisitorDescObjectTests.cs
@@ -203,7 +203,7 @@ public class QueryableSortVisitorDescObjectTests
     {
         Foo = 0,
         Bar = 1,
-        Baz = 2
+        Baz = 2,
     }
 
     public class FooNullableSortType<T>

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/IntegrationTests.cs
@@ -43,7 +43,7 @@ public class Query
     {
         new Foo { CreatedUtc = new DateTime(2000, 1, 1, 1, 1, 1) },
         new Foo { CreatedUtc = new DateTime(2010, 1, 1, 1, 1, 1) },
-        new Foo { CreatedUtc = new DateTime(2020, 1, 1, 1, 1, 1) }
+        new Foo { CreatedUtc = new DateTime(2020, 1, 1, 1, 1, 1) },
     };
 }
 

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/QueryableSortingExtensionsTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/QueryableSortingExtensionsTests.cs
@@ -16,7 +16,7 @@ public class QueryableSortingExtensionsTests
     private static readonly Foo[] _fooEntities =
     {
         new() { Bar = true, Baz = "a" },
-        new() { Bar = false, Baz = "b" }
+        new() { Bar = false, Baz = "b" },
     };
 
     [Fact]

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/SortAttributeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/SortAttributeTests.cs
@@ -92,7 +92,7 @@ public class SortAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 #endif
@@ -108,7 +108,7 @@ public class SortAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 
@@ -123,7 +123,7 @@ public class SortAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 
@@ -138,7 +138,7 @@ public class SortAttributeTests
             new Foo { Bar = "ab", Baz = 2 },
             new Foo { Bar = "ac", Baz = 2 },
             new Foo { Bar = "ad", Baz = 2 },
-            new Foo { Bar = null!, Baz = 0 }
+            new Foo { Bar = null!, Baz = 0 },
         };
     }
 

--- a/src/HotChocolate/Data/test/Data.Tests/AuthorFixture.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/AuthorFixture.cs
@@ -8,7 +8,7 @@ public class AuthorFixture : IDisposable
     {
         new() { Id = 1, Name = "Foo", Books = { new Book { Id = 1, Title = "Foo1" } } },
         new() { Id = 2, Name = "Bar", Books = { new Book { Id = 2, Title = "Bar1" } } },
-        new() { Id = 3, Name = "Baz", Books = { new Book { Id = 3, Title = "Baz1" } } }
+        new() { Id = 3, Name = "Baz", Books = { new Book { Id = 3, Title = "Baz1" } } },
     };
 
     public void Dispose() {  }

--- a/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/IntegrationTests.cs
@@ -237,7 +237,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
             .AddSorting()
             .AddProjections()
             .AddQueryType<PagingAndProjection>()
-            .AddObjectType<Book>(o => 
+            .AddObjectType<Book>(o =>
                 o.ImplementsNode()
                     .IdField(f => f.Id)
                     .ResolveNode(_ => default!))
@@ -331,7 +331,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Book {
                 title
                 id
@@ -369,7 +369,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Book {
                 title
                 id
@@ -411,7 +411,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Author {
                 name
             }
@@ -450,7 +450,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Author {
                 name
             }
@@ -487,7 +487,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Book {
                 title
                 author {
@@ -528,7 +528,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     }
                 }
             }
-            
+
             fragment Test on Book {
                 title
                 author {
@@ -795,12 +795,12 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
         // assert
         result.MatchSnapshot();
     }
-    
+
     [Fact]
     public async Task Duplicate_Filter_Attribute_Throws()
     {
         // arrange
-        async Task Error() 
+        async Task Error()
             => await new ServiceCollection()
                 .AddGraphQL()
                 .AddQueryType<DuplicateAttribute>()
@@ -814,12 +814,12 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
             The field `DuplicateAttribute.addBook` declares the data middleware `UseFiltering` more than once.
             """);
     }
-    
+
     [QueryType]
     public static class StaticQuery
     {
         [UseOffsetPaging]
-        public static IEnumerable<Bar> GetBars() 
+        public static IEnumerable<Bar> GetBars()
             => new[] { Bar.Create("tox") };
     }
 
@@ -835,7 +835,7 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
                     var data = new[]
                     {
                         Bar.Create("a"),
-                        Bar.Create("b")
+                        Bar.Create("b"),
                     }.AsQueryable();
                     return Task.FromResult(data);
                 })
@@ -854,15 +854,15 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
     {
         [UsePaging]
         [UseProjection]
-        public IQueryable<Book> GetBooks() 
+        public IQueryable<Book> GetBooks()
             => new[]
             {
                 new Book
                 {
                     Id = 1,
                     Title = "BookTitle",
-                    Author = new Author { Name = "Author" }
-                }
+                    Author = new Author { Name = "Author" },
+                },
             }.AsQueryable();
     }
 
@@ -873,15 +873,15 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
         [UseProjection]
         [UseFiltering]
         [UseSorting]
-        public IQueryable<Book> GetBooks() 
+        public IQueryable<Book> GetBooks()
             => new[]
             {
                 new Book
                 {
                     Id = 1,
                     Title = "BookTitle",
-                    Author = new Author { Name = "Author" }
-                }
+                    Author = new Author { Name = "Author" },
+                },
             }.AsQueryable();
     }
 
@@ -891,21 +891,21 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
         [UseProjection(Scope = "Foo")]
         [UseFiltering(Scope = "Foo")]
         [UseSorting(Scope = "Foo")]
-        public IQueryable<Book> GetBooks() 
+        public IQueryable<Book> GetBooks()
             => new[]
             {
                 new Book
                 {
-                    Id = 1, 
-                    Title = "BookTitle", 
+                    Id = 1,
+                    Title = "BookTitle",
                     Author = new Author
                     {
-                        Name = "Author"
-                    }
-                }
+                        Name = "Author",
+                    },
+                },
             }.AsQueryable();
     }
-    
+
     public class FirstOrDefaultQuery
     {
         [UseFirstOrDefault]
@@ -914,22 +914,22 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
         {
             new Book
             {
-                Id = 1, 
-                Title = "BookTitle", 
+                Id = 1,
+                Title = "BookTitle",
                 Author = new Author
                 {
-                    Name = "Author"
-                }
+                    Name = "Author",
+                },
             },
             new Book
             {
-                Id = 2, 
-                Title = "BookTitle2", 
+                Id = 2,
+                Title = "BookTitle2",
                 Author = new Author
                 {
-                    Name = "Author2"
-                }
-            }
+                    Name = "Author2",
+                },
+            },
         }.AsQueryable().Where(x => x.Id == book.Id);
     }
 
@@ -937,17 +937,17 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
     {
         [UseFirstOrDefault]
         [UseProjection]
-        public IQueryable<Author> AddPublisher(Publisher publisher) 
+        public IQueryable<Author> AddPublisher(Publisher publisher)
             => new[]
             {
                 new Author
                 {
-                    Name = "Author", 
+                    Name = "Author",
                     Publishers = new List<Publisher>
                     {
-                        publisher
-                    }
-                }
+                        publisher,
+                    },
+                },
             }.AsQueryable();
     }
 
@@ -955,29 +955,29 @@ public class IntegrationTests(AuthorFixture authorFixture) : IClassFixture<Autho
     {
         [UseFirstOrDefault]
         [UseProjection]
-        public IQueryable<Author> AddBook(Book book) 
+        public IQueryable<Author> AddBook(Book book)
             => new[]
             {
                 new Author
                 {
-                    Name = "Author", 
-                    Books = new List<Book> { book }
-                }
+                    Name = "Author",
+                    Books = new List<Book> { book },
+                },
             }.AsQueryable();
     }
-    
+
     public class DuplicateAttribute
     {
         [UseFiltering]
         [UseFiltering]
-        public IQueryable<Author> AddBook(Book book) 
+        public IQueryable<Author> AddBook(Book book)
             => new[]
             {
                 new Author
                 {
-                    Name = "Author", 
-                    Books = new List<Book> { book }
-                }
+                    Name = "Author",
+                    Books = new List<Book> { book },
+                },
             }.AsQueryable();
     }
 }

--- a/src/HotChocolate/Fusion/src/Abstractions/FusionGraphPackage.cs
+++ b/src/HotChocolate/Fusion/src/Abstractions/FusionGraphPackage.cs
@@ -28,7 +28,7 @@ public sealed class FusionGraphPackage : IDisposable, IAsyncDisposable
         new()
         {
             Indented = true,
-            MaxDirectivesPerLine = 0
+            MaxDirectivesPerLine = 0,
         };
 
     private readonly Package _package;

--- a/src/HotChocolate/Fusion/src/CommandLine/Commands/ComposeCommand.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Commands/ComposeCommand.cs
@@ -173,7 +173,7 @@ internal sealed class ComposeCommand : Command
         features.Add(
             new TransportFeature
             {
-                DefaultClientName = settings.Transport.DefaultClientName
+                DefaultClientName = settings.Transport.DefaultClientName,
             });
 
         if (settings.NodeField.Enabled)

--- a/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetHttpCommand.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetHttpCommand.cs
@@ -18,13 +18,13 @@ internal sealed class SubgraphConfigSetHttpCommand : Command
         var url = new Option<Uri>("--url")
         {
             Description = "The url of the graphql-http endpoint.",
-            IsRequired = true
+            IsRequired = true,
         };
 
         var clientName = new Option<string>("--client-name")
         {
             Description = "The name of the graphql-http configuration.",
-            IsRequired = false
+            IsRequired = false,
         };
 
         var configFile = new SubgraphConfigFileOption();
@@ -61,7 +61,7 @@ internal sealed class SubgraphConfigSetHttpCommand : Command
                 SubgraphName,
                 new[]
                 {
-                    new HttpClientConfiguration(uri, clientName)
+                    new HttpClientConfiguration(uri, clientName),
                 });
             var configJson = FormatSubgraphConfig(config);
             await File.WriteAllTextAsync(configFile.FullName, configJson, cancellationToken);
@@ -69,9 +69,9 @@ internal sealed class SubgraphConfigSetHttpCommand : Command
         else if (configFile.Extension.EqualsOrdinal(".fsp"))
         {
             var config = await LoadSubgraphConfigFromSubgraphPackageAsync(configFile.FullName, cancellationToken);
-            
+
             var clients = config.Clients.ToList();
-            
+
             clients.RemoveAll(t => t is HttpClientConfiguration);
             clients.Add(new HttpClientConfiguration(uri, clientName));
 
@@ -84,7 +84,7 @@ internal sealed class SubgraphConfigSetHttpCommand : Command
             var config = await LoadSubgraphConfigAsync(configFile.FullName, cancellationToken);
 
             var clients = config.Clients.ToList();
-            
+
             clients.RemoveAll(t => t is HttpClientConfiguration);
             clients.Add(new HttpClientConfiguration(uri, clientName));
 

--- a/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetNameCommand.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetNameCommand.cs
@@ -16,7 +16,7 @@ internal sealed class SubgraphConfigSetNameCommand : Command
 
         var subgraphName = new Argument<string>("name")
         {
-            Description = "The subgraph name."
+            Description = "The subgraph name.",
         };
 
         var configFile = new SubgraphConfigFileOption();
@@ -53,7 +53,7 @@ internal sealed class SubgraphConfigSetNameCommand : Command
         else if (configFile.Extension.EqualsOrdinal(".fsp"))
         {
             var config = await LoadSubgraphConfigFromSubgraphPackageAsync(configFile.FullName, cancellationToken);
-            
+
             await ReplaceSubgraphConfigInSubgraphPackageAsync(
                 configFile.FullName,
                 config with { Name = subgraphName });

--- a/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetWebSocketCommand.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphConfigSetWebSocketCommand.cs
@@ -18,13 +18,13 @@ internal sealed class SubgraphConfigSetWebSocketCommand : Command
         var url = new Option<Uri>("--url")
         {
             Description = "The url of the graphql-ws endpoint.",
-            IsRequired = true
+            IsRequired = true,
         };
 
         var clientName = new Option<string>("--client-name")
         {
             Description = "The name of graphql-ws configuration.",
-            IsRequired = false
+            IsRequired = false,
         };
 
         var configFile = new SubgraphConfigFileOption();
@@ -61,7 +61,7 @@ internal sealed class SubgraphConfigSetWebSocketCommand : Command
                 SubgraphName,
                 new[]
                 {
-                    new WebSocketClientConfiguration(uri, clientName)
+                    new WebSocketClientConfiguration(uri, clientName),
                 });
             var configJson = FormatSubgraphConfig(config);
             await File.WriteAllTextAsync(configFile.FullName, configJson, cancellationToken);
@@ -69,9 +69,9 @@ internal sealed class SubgraphConfigSetWebSocketCommand : Command
         else if (configFile.Extension.EqualsOrdinal(".fsp"))
         {
             var config = await LoadSubgraphConfigFromSubgraphPackageAsync(configFile.FullName, cancellationToken);
-            
+
             var clients = config.Clients.ToList();
-            
+
             clients.RemoveAll(t => t is WebSocketClientConfiguration);
             clients.Add(new WebSocketClientConfiguration(uri, clientName));
 
@@ -84,7 +84,7 @@ internal sealed class SubgraphConfigSetWebSocketCommand : Command
             var config = await LoadSubgraphConfigAsync(configFile.FullName, cancellationToken);
 
             var clients = config.Clients.ToList();
-            
+
             clients.RemoveAll(t => t is WebSocketClientConfiguration);
             clients.Add(new WebSocketClientConfiguration(uri, clientName));
 

--- a/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphPackCommand.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Commands/SubgraphPackCommand.cs
@@ -50,7 +50,7 @@ internal sealed class SubgraphPackCommand : Command
         configFile ??= new FileInfo(Combine(workingDirectory.FullName, ConfigFile));
         extensionFiles ??= new List<FileInfo>
         {
-            new FileInfo(Combine(workingDirectory.FullName, ExtensionFile))
+            new FileInfo(Combine(workingDirectory.FullName, ExtensionFile)),
         };
 
         if (!schemaFile.Exists)

--- a/src/HotChocolate/Fusion/src/CommandLine/Helpers/PackageHelper.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Helpers/PackageHelper.cs
@@ -24,7 +24,7 @@ internal static class PackageHelper
         new()
         {
             Indented = true,
-            MaxDirectivesPerLine = 0
+            MaxDirectivesPerLine = 0,
         };
 
     public static async Task CreateSubgraphPackageAsync(

--- a/src/HotChocolate/Fusion/src/Composition/Entities/EntityResolver.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Entities/EntityResolver.cs
@@ -73,7 +73,7 @@ internal sealed class EntityResolver
                 OperationType.Query,
                 Variables.Select(t => t.Value.Definition).ToList(),
                 new[] { new DirectiveNode("schema", new ArgumentNode("name", SubgraphName)) },
-                SelectionSet)
+                SelectionSet),
         };
 
         if (Variables.Count > 0)

--- a/src/HotChocolate/Fusion/src/Composition/Entities/EntityResolverKind.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Entities/EntityResolverKind.cs
@@ -4,5 +4,5 @@ public enum EntityResolverKind
 {
     Single = 0,
     Batch = 1,
-    Subscribe = 2
+    Subscribe = 2,
 }

--- a/src/HotChocolate/Fusion/src/Composition/FusionGraphComposer.cs
+++ b/src/HotChocolate/Fusion/src/Composition/FusionGraphComposer.cs
@@ -37,13 +37,13 @@ public sealed class FusionGraphComposer
                 new RefResolverEntityEnricher(),
                 new PatternEntityEnricher(),
                 new RequireEnricher(),
-                new NodeEntityEnricher()
+                new NodeEntityEnricher(),
             },
             new ITypeMergeHandler[]
             {
                 new InterfaceTypeMergeHandler(), new UnionTypeMergeHandler(),
                 new InputObjectTypeMergeHandler(), new EnumTypeMergeHandler(),
-                new ScalarTypeMergeHandler()
+                new ScalarTypeMergeHandler(),
             },
             fusionTypePrefix,
             fusionTypeSelf,
@@ -111,7 +111,7 @@ public sealed class FusionGraphComposer
             _fusionTypePrefix,
             _fusionTypeSelf)
         {
-            Abort = cancellationToken
+            Abort = cancellationToken,
         };
 
         // Run the merge pipeline on the composition context.
@@ -157,7 +157,7 @@ public sealed class FusionGraphComposer
             _fusionTypePrefix,
             _fusionTypeSelf)
         {
-            Abort = cancellationToken
+            Abort = cancellationToken,
         };
 
         // Run the merge pipeline on the composition context.

--- a/src/HotChocolate/Fusion/src/Composition/FusionTypes.cs
+++ b/src/HotChocolate/Fusion/src/Composition/FusionTypes.cs
@@ -47,7 +47,7 @@ public sealed class FusionTypes
             intType = new ScalarType(SpecScalarTypes.Int) { IsSpecScalar = true };
             _fusionGraph.Types.Add(intType);
         }
-        
+
         if (!_fusionGraph.Types.TryGetType<ScalarType>(SpecScalarTypes.String, out var stringType))
         {
             stringType = new ScalarType(SpecScalarTypes.String) { IsSpecScalar = true };
@@ -210,7 +210,7 @@ public sealed class FusionTypes
     {
         var directiveArgs = new List<Argument>
         {
-            new(SubgraphArg, subgraphName), new(SelectArg, select.ToString(false))
+            new(SubgraphArg, subgraphName), new(SelectArg, select.ToString(false)),
         };
 
         if (arguments is { Count: > 0 })
@@ -238,7 +238,7 @@ public sealed class FusionTypes
             {
                 EntityResolverKind.Batch => FusionEnumValueNames.Batch,
                 EntityResolverKind.Subscribe => FusionEnumValueNames.Subscribe,
-                _ => throw new NotSupportedException()
+                _ => throw new NotSupportedException(),
             };
 
             directiveArgs.Add(new Argument(KindArg, kindValue));
@@ -289,12 +289,12 @@ public sealed class FusionTypes
             Arguments =
             {
                 new InputField(SubgraphArg, new NonNullType(typeName)),
-                new InputField(NameArg, typeName)
+                new InputField(NameArg, typeName),
             },
             ContextData =
             {
-                [WellKnownContextData.IsFusionType] = true
-            }
+                [WellKnownContextData.IsFusionType] = true,
+            },
         };
         _fusionGraph.DirectiveTypes.Add(directiveType);
         return directiveType;
@@ -323,7 +323,7 @@ public sealed class FusionTypes
     }
 
     public Directive CreateHttpDirective(string subgraphName, string? clientName, Uri location)
-        =>  clientName is null 
+        =>  clientName is null
             ? new Directive(
                 Transport,
                 new Argument(SubgraphArg, subgraphName),
@@ -354,7 +354,7 @@ public sealed class FusionTypes
     }
 
     public Directive CreateWebSocketDirective(string subgraphName, string? clientName, Uri location)
-        =>  clientName is null 
+        =>  clientName is null
             ? new Directive(
                 Transport,
                 new Argument(SubgraphArg, subgraphName),

--- a/src/HotChocolate/Fusion/src/Composition/LogEntryKind.cs
+++ b/src/HotChocolate/Fusion/src/Composition/LogEntryKind.cs
@@ -18,5 +18,5 @@ public enum LogSeverity
     /// <summary>
     /// The entry contains an error message.
     /// </summary>
-    Error
+    Error,
 }

--- a/src/HotChocolate/Fusion/src/Composition/Pipeline/ApplyTagDirectiveMiddleware.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Pipeline/ApplyTagDirectiveMiddleware.cs
@@ -46,8 +46,8 @@ internal sealed class ApplyTagDirectiveMiddleware : IMergeMiddleware
                 {
                     new InputField(
                         WellKnownDirectives.Name,
-                        new NonNullType(context.FusionGraph.Types["String"]))
-                }
+                        new NonNullType(context.FusionGraph.Types["String"])),
+                },
             };
 
             needsDirectiveType = true;
@@ -68,7 +68,7 @@ internal sealed class ApplyTagDirectiveMiddleware : IMergeMiddleware
         HashSet<string> tags)
     {
         var tagContext = context.GetTagContext();
-        
+
         ApplyDirectives(tagContext, context.FusionGraph, context.Subgraphs, tagDirectiveType, tags);
 
         foreach (var type in context.FusionGraph.Types)

--- a/src/HotChocolate/Fusion/src/Composition/Pipeline/MergeHandler/MergeStatus.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Pipeline/MergeHandler/MergeStatus.cs
@@ -13,5 +13,5 @@ internal enum MergeStatus
     /// <summary>
     /// The merge operation completed successfully.
     /// </summary>
-    Completed
+    Completed,
 }

--- a/src/HotChocolate/Fusion/src/Composition/Pipeline/ParseSubGraphSchemaMiddleware.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Pipeline/ParseSubGraphSchemaMiddleware.cs
@@ -17,7 +17,7 @@ internal sealed class ParseSubgraphSchemaMiddleware : IMergeMiddleware
         {
             var schema = SchemaParser.Parse(config.Schema);
             schema.Name = config.Name;
-            
+
             var alignTypes = new AlignTypesVisitor(schema);
 
             foreach (var sourceText in config.Extensions)
@@ -49,7 +49,7 @@ internal sealed class ParseSubgraphSchemaMiddleware : IMergeMiddleware
         {
             return true;
         }
-        
+
         foreach (var directive in schema.Directives[WellKnownDirectives.Tag])
         {
             if (directive.Arguments[0] is { Name: WellKnownDirectives.Name, Value: StringValueNode name } &&
@@ -104,7 +104,7 @@ internal sealed class ParseSubgraphSchemaMiddleware : IMergeMiddleware
                 schema.DirectiveTypes.Add(
                     new DirectiveType(directiveType.Name)
                     {
-                        IsRepeatable = directiveType.IsRepeatable
+                        IsRepeatable = directiveType.IsRepeatable,
                     });
             }
         }
@@ -112,7 +112,7 @@ internal sealed class ParseSubgraphSchemaMiddleware : IMergeMiddleware
 
     private void AlignTypes(Schema schema)
     {
-        
+
     }
 
     private static void TryCreateMissingType<T>(

--- a/src/HotChocolate/Fusion/src/Core/Clients/TransportFeatures.cs
+++ b/src/HotChocolate/Fusion/src/Core/Clients/TransportFeatures.cs
@@ -10,14 +10,14 @@ public enum TransportFeatures
     /// Standard GraphQL over HTTP POST request.
     /// </summary>
     Standard = 0,
-    
+
     /// <summary>
     /// GraphQL multipart request.
     /// </summary>
     FileUpload = 1,
-    
+
     /// <summary>
     /// All Features.
     /// </summary>
-    All = Standard | FileUpload
+    All = Standard | FileUpload,
 }

--- a/src/HotChocolate/Fusion/src/Core/Execution/FusionContextExtensions.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/FusionContextExtensions.cs
@@ -14,7 +14,7 @@ internal static class FusionContextExtensions
 
         var workItem = new ExecutionState(selectionSet, result, exportKeys)
         {
-            SelectionSetData = { [0] = parentData }
+            SelectionSetData = { [0] = parentData },
         };
 
         context.State.RegisterState(workItem);

--- a/src/HotChocolate/Fusion/src/Core/Execution/Nodes/QueryPlanNodeKind.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Nodes/QueryPlanNodeKind.cs
@@ -48,5 +48,5 @@ internal enum QueryPlanNodeKind
     /// <summary>
     /// The <see cref="If"/> node executes its child nodes based on a condition.
     /// </summary>
-    If
+    If,
 }

--- a/src/HotChocolate/Fusion/src/Core/Execution/RequestState.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/RequestState.cs
@@ -115,12 +115,12 @@ internal sealed class RequestState
             {
                 return;
             }
-            
+
             state = new ExecutionState(selectionSet, result, exportKeys)
             {
-                SelectionSetData = { [0] = parentData }
+                SelectionSetData = { [0] = parentData },
             };
-            
+
             if (!_map.TryGetValue(state.SelectionSet, out states))
             {
                 var temp = new List<ExecutionState> { state };
@@ -168,14 +168,14 @@ internal sealed class RequestState
 
         AddState(states, state);
     }
-    
+
     private static void AddState(List<ExecutionState>? states, ExecutionState state)
     {
         if (states is null)
         {
             return;
         }
-        
+
         var taken = false;
         Monitor.Enter(states, ref taken);
 

--- a/src/HotChocolate/Fusion/src/Core/Metadata/FusionGraphConfigurationReader.cs
+++ b/src/HotChocolate/Fusion/src/Core/Metadata/FusionGraphConfigurationReader.cs
@@ -141,7 +141,7 @@ internal sealed class FusionGraphConfigurationReader
             {
                 continue;
             }
-            
+
             var config = TryReadHttpClientConfig(typeNames, directiveNode);
             if (config is not null)
             {
@@ -179,13 +179,13 @@ internal sealed class FusionGraphConfigurationReader
                 case LocationArg:
                     baseAddress = Expect<StringValueNode>(argument.Value).Value;
                     break;
-                
+
                 case KindArg:
                     kind = Expect<StringValueNode>(argument.Value).Value;
                     break;
             }
         }
-        
+
         if (!kind.EqualsOrdinal("HTTP"))
         {
             return null;
@@ -216,7 +216,7 @@ internal sealed class FusionGraphConfigurationReader
             {
                 continue;
             }
-            
+
             var config = TryReadWebSocketClientConfig(typeNames, directiveNode);
             if (config is not null)
             {
@@ -254,7 +254,7 @@ internal sealed class FusionGraphConfigurationReader
                 case LocationArg:
                     baseAddress = Expect<StringValueNode>(argument.Value).Value;
                     break;
-                
+
                 case KindArg:
                     kind = Expect<StringValueNode>(argument.Value).Value;
                     break;
@@ -318,7 +318,7 @@ internal sealed class FusionGraphConfigurationReader
                     break;
             }
         }
-        
+
         _subgraphNames.Add(subgraph);
 
         if(!_subgraphInfos.TryGetValue(subgraph, out var subgraphInfo))
@@ -404,7 +404,7 @@ internal sealed class FusionGraphConfigurationReader
                     break;
             }
         }
-        
+
         _subgraphNames.Add(schemaName);
 
         return new ArgumentVariableDefinition(name, schemaName, type, argumentName);
@@ -440,7 +440,7 @@ internal sealed class FusionGraphConfigurationReader
         }
 
         _subgraphNames.Add(schemaName);
-        
+
         return new FieldVariableDefinition(name, schemaName, select);
     }
 
@@ -494,7 +494,7 @@ internal sealed class FusionGraphConfigurationReader
                         FusionEnumValueNames.Batch => ResolverKind.Batch,
                         FusionEnumValueNames.Subscribe => ResolverKind.Subscribe,
                         _ => throw new InvalidOperationException(
-                            FusionGraphConfigurationReader_ReadResolverDefinition_InvalidKindValue)
+                            FusionGraphConfigurationReader_ReadResolverDefinition_InvalidKindValue),
                     };
                     break;
 
@@ -503,7 +503,7 @@ internal sealed class FusionGraphConfigurationReader
                     break;
             }
         }
-        
+
         _subgraphNames.Add(subgraph);
 
         FragmentSpreadNode? placeholder = null;

--- a/src/HotChocolate/Fusion/src/Core/Metadata/ObjectFieldFlags.cs
+++ b/src/HotChocolate/Fusion/src/Core/Metadata/ObjectFieldFlags.cs
@@ -16,5 +16,5 @@ public enum ObjectFieldFlags : byte
     /// <summary>
     /// This field represents the __typename field.
     /// </summary>
-    TypeName = 2
+    TypeName = 2,
 }

--- a/src/HotChocolate/Fusion/src/Core/Planning/Pipeline/ExecutionStepDiscoveryMiddleware.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/Pipeline/ExecutionStepDiscoveryMiddleware.cs
@@ -91,7 +91,7 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
         var operation = context.Operation;
         List<ISelection>? leftovers = null;
         var path = new List<ISelection>();
-        
+
         // if this is the root selection set of a query we will
         // look for some special selections.
         if (!context.HasHandledSpecialQueryFields && parentSelection is null)
@@ -141,7 +141,7 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
             {
                 var pathIndex = path.Count;
                 path.Add(selection);
-                
+
                 var field = selection.Field;
                 var fieldInfo = selectionSetTypeMetadata.Fields[field.Name];
 
@@ -205,15 +205,15 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
                         preferBatching,
                         context.ParentSelections);
                 }
-                
+
                 path.RemoveAt(pathIndex);
             }
-            
+
             // if the current execution step has now way to resolve the data
             // we will try to resolve it from the root.
-            if(executionStep.ParentSelection is not null && 
+            if(executionStep.ParentSelection is not null &&
                 executionStep.ParentSelectionPath is not null &&
-                executionStep.Resolver is null && 
+                executionStep.Resolver is null &&
                 executionStep.SelectionResolvers.Count == 0)
             {
                 if (!EnsureStepCanBeResolvedFromRoot(
@@ -332,7 +332,7 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
         {
             var pathIndex = path.Count;
             path.Add(selection);
-            
+
             parentSelectionLookup.TryAdd(selection, parentSelection);
             var field = declaringType.Fields[selection.Field.Name];
 
@@ -393,7 +393,7 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
             {
                 (leftovers ??= new()).Add(selection);
             }
-            
+
             path.RemoveAt(pathIndex);
         }
 
@@ -804,7 +804,7 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
             {
                 return false;
             }
-            
+
             current = current.Parent;
         }
 
@@ -833,6 +833,6 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
     {
         Query,
         Batch,
-        Subscription
+        Subscription,
     }
 }

--- a/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
@@ -85,7 +85,7 @@ internal abstract class RequestDocumentFormatter
     }
 
     private SelectionSetNode CreateRootLevelQuery(
-        SelectionPath path, 
+        SelectionPath path,
         SelectionSetNode selectionSet)
     {
         var current = path;
@@ -95,9 +95,9 @@ internal abstract class RequestDocumentFormatter
             selectionSet = new SelectionSetNode(
                 new[]
                 {
-                    current.Selection.SyntaxNode.WithSelectionSet(selectionSet)
+                    current.Selection.SyntaxNode.WithSelectionSet(selectionSet),
                 });
-            
+
             current = current.Parent;
         }
 

--- a/src/HotChocolate/Fusion/test/Composition.Tests/ErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Composition.Tests/ErrorTests.cs
@@ -83,9 +83,9 @@ public class ErrorTests(ITestOutputHelper output)
                     Array.Empty<string>(),
                     new IClientConfiguration[]
                     {
-                        new HttpClientConfiguration(new Uri("http://localhost"))
+                        new HttpClientConfiguration(new Uri("http://localhost")),
                     },
-                    null)
+                    null),
             });
 
         Assert.Null(fusionConfig);

--- a/src/HotChocolate/Fusion/test/Core.Tests/ConfigurationRewriterTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/ConfigurationRewriterTests.cs
@@ -37,7 +37,7 @@ public class ConfigurationRewriterTests
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var configuration = SchemaFormatter.FormatAsDocument(fusionGraph);

--- a/src/HotChocolate/Fusion/test/Core.Tests/DataTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/DataTests.cs
@@ -28,7 +28,7 @@ public class DataTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()

--- a/src/HotChocolate/Fusion/test/Core.Tests/DemoIntegrationTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/DemoIntegrationTests.cs
@@ -28,7 +28,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // assert
@@ -49,7 +49,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // assert
@@ -69,7 +69,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -120,7 +120,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -165,7 +165,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -212,7 +212,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             default,
             cts.Token);
@@ -262,7 +262,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             default,
             cts.Token);
@@ -312,7 +312,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -377,7 +377,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
                     new[]
                     {
                         demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -427,7 +427,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
                     new[]
                     {
                         demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.ReEncodeIds));
 
@@ -477,7 +477,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
                     new[]
                     {
                         demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -527,7 +527,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -579,7 +579,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -632,7 +632,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -679,7 +679,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -735,7 +735,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -775,7 +775,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
 
         Assert.Null(result.ExpectQueryResult().Errors);
     }
-    
+
     [Fact]
     public async Task Fetch_User_With_Invalid_Node_Field()
     {
@@ -788,7 +788,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -836,7 +836,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -889,7 +889,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -940,7 +940,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -993,7 +993,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
         var fusionGraph =
             await new FusionGraphComposer(logFactory: _logFactory)
                 .ComposeAsync(
-                    new[] { demoProject.Accounts.ToConfiguration(AccountsExtensionSdl), },
+                    new[] { demoProject.Accounts.ToConfiguration(AccountsExtensionSdl) },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 
         var config = new HotReloadConfiguration(
@@ -1069,7 +1069,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()
@@ -1113,7 +1113,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -1166,7 +1166,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -1219,7 +1219,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -1276,7 +1276,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -1331,7 +1331,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -1572,7 +1572,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
         var fusionGraph = await new FusionGraphComposer(logFactory: _logFactory).ComposeAsync(
             new[]
             {
-                demoProject.Appointment.ToConfiguration()
+                demoProject.Appointment.ToConfiguration(),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 

--- a/src/HotChocolate/Fusion/test/Core.Tests/ErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/ErrorTests.cs
@@ -37,7 +37,7 @@ public class ErrorTests
                     new[]
                     {
                         demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -87,7 +87,7 @@ public class ErrorTests
                     new[]
                     {
                         demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -137,7 +137,7 @@ public class ErrorTests
                     new[]
                     {
                         demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                        demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
                     },
                     new FusionFeatureCollection(FusionFeatures.NodeField));
 

--- a/src/HotChocolate/Fusion/test/Core.Tests/EventStreamTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/EventStreamTests.cs
@@ -33,7 +33,7 @@ public class EventStreamTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl, onlyHttp: true),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl, onlyHttp: true)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl, onlyHttp: true),
             },
             default,
             cts.Token);

--- a/src/HotChocolate/Fusion/test/Core.Tests/FileUploadTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/FileUploadTests.cs
@@ -100,7 +100,7 @@ public class FileUploadTests
         CollectSnapshotData(snapshot, request, result, fusionGraph);
         await snapshot.MatchAsync(cts.Token);
     }
-    
+
     [Fact]
     public async Task UploadFile_2()
     {
@@ -139,7 +139,7 @@ public class FileUploadTests
         var input = new Dictionary<string, object?>()
         {
             ["productId"] = 1,
-            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray()))
+            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray())),
         };
 
         // act

--- a/src/HotChocolate/Fusion/test/Core.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/IntrospectionTests.cs
@@ -26,7 +26,7 @@ public class IntrospectionTests(ITestOutputHelper output)
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         var executor = await new ServiceCollection()

--- a/src/HotChocolate/Fusion/test/Core.Tests/RequestPlannerTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/RequestPlannerTests.cs
@@ -28,7 +28,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -65,7 +65,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -111,7 +111,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -143,7 +143,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -175,7 +175,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -214,7 +214,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -256,7 +256,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -301,7 +301,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -338,7 +338,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -383,7 +383,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -429,7 +429,7 @@ public class RequestPlannerTests
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
                 demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
-                demoProject.Products.ToConfiguration(ProductsExtensionSdl)
+                demoProject.Products.ToConfiguration(ProductsExtensionSdl),
             });
 
         // act
@@ -474,7 +474,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -508,7 +508,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -543,7 +543,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -577,7 +577,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -614,7 +614,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -653,7 +653,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -692,7 +692,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews2.ToConfiguration(Reviews2ExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             },
             new FusionFeatureCollection(FusionFeatures.NodeField));
 
@@ -780,7 +780,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Reviews.ToConfiguration(ReviewsExtensionSdl),
-                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl)
+                demoProject.Accounts.ToConfiguration(AccountsExtensionSdl),
             });
 
         // act
@@ -1068,7 +1068,7 @@ public class RequestPlannerTests
             new[]
             {
                 demoProject.Authors.ToConfiguration(),
-                demoProject.Books.ToConfiguration()
+                demoProject.Books.ToConfiguration(),
             });
 
         // act
@@ -1135,7 +1135,7 @@ public class RequestPlannerTests
         var fusionGraph = await FusionGraphComposer.ComposeAsync(new[]
         {
             new SubgraphConfiguration("A", schemaA, Array.Empty<string>(), CreateClients(), null),
-            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null)
+            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null),
         });
 
         // act
@@ -1193,7 +1193,7 @@ public class RequestPlannerTests
         var fusionGraph = await FusionGraphComposer.ComposeAsync(new[]
         {
             new SubgraphConfiguration("A", schemaA, Array.Empty<string>(), CreateClients(), null),
-            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null)
+            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null),
         });
 
         // act
@@ -1253,7 +1253,7 @@ public class RequestPlannerTests
         var fusionGraph = await FusionGraphComposer.ComposeAsync(new[]
         {
             new SubgraphConfiguration("A", schemaA, Array.Empty<string>(), CreateClients(), null),
-            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null)
+            new SubgraphConfiguration("B", schemaB, Array.Empty<string>(), CreateClients(), null),
         });
 
         // act
@@ -1316,6 +1316,6 @@ public class RequestPlannerTests
     private static IClientConfiguration[] CreateClients()
         => new IClientConfiguration[]
         {
-            new HttpClientConfiguration(new Uri("http://nothing"))
+            new HttpClientConfiguration(new Uri("http://nothing")),
         };
 }

--- a/src/HotChocolate/Fusion/test/Core.Tests/UnionTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/UnionTests.cs
@@ -66,7 +66,7 @@ public class UnionTests
         var input = new Dictionary<string, object?>()
         {
             ["productId"] = 1,
-            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray()))
+            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray())),
         };
 
         // act
@@ -83,7 +83,7 @@ public class UnionTests
         CollectSnapshotData(snapshot, request, result, fusionGraph);
         await snapshot.MatchAsync(cts.Token);
     }
-    
+
     [Fact]
     public async Task Error_Union_With_Inline_Fragment_Errors_Not_Null()
     {
@@ -128,7 +128,7 @@ public class UnionTests
         var input = new Dictionary<string, object?>()
         {
             ["productId"] = 0,
-            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray()))
+            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray())),
         };
 
         // act
@@ -187,7 +187,7 @@ public class UnionTests
         var input = new Dictionary<string, object?>()
         {
             ["productId"] = 1,
-            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray()))
+            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray())),
         };
 
         // act
@@ -246,7 +246,7 @@ public class UnionTests
         var input = new Dictionary<string, object?>()
         {
             ["productId"] = 0,
-            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray()))
+            ["file"] = new StreamFile("abc", () => new MemoryStream("abc"u8.ToArray())),
         };
 
         // act

--- a/src/HotChocolate/Fusion/test/Shared/Appointments/AppointmentQuery.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Appointments/AppointmentQuery.cs
@@ -37,14 +37,14 @@ public class AppointmentQuery
         {
             return new Patient1()
             {
-                Id = 1
+                Id = 1,
             };
         }
         if (id == 2)
         {
             return new Patient1()
             {
-                Id = 2
+                Id = 2,
             };
         }
 

--- a/src/HotChocolate/Fusion/test/Shared/Authors/AuthorRepository.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Authors/AuthorRepository.cs
@@ -8,7 +8,7 @@ public sealed class AuthorRepository
     {
         _authors = new[]
         {
-            new Author("1", "First author", "The first author")
+            new Author("1", "First author", "The first author"),
         }.ToDictionary(t => t.Id);
     }
 

--- a/src/HotChocolate/Fusion/test/Shared/Books/BookRepository.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Books/BookRepository.cs
@@ -8,7 +8,7 @@ public sealed class BookRepository
     {
         _books = new[]
         {
-            new Book("1", "1", "The first book")
+            new Book("1", "1", "The first book"),
         }.ToDictionary(t => t.Id);
     }
 

--- a/src/HotChocolate/Fusion/test/Shared/DemoSubgraph.cs
+++ b/src/HotChocolate/Fusion/test/Shared/DemoSubgraph.cs
@@ -12,7 +12,7 @@ public sealed class DemoSubgraph
         new()
         {
             Indented = true,
-            MaxDirectivesPerLine = 0
+            MaxDirectivesPerLine = 0,
         };
 
     public DemoSubgraph(
@@ -56,7 +56,7 @@ public sealed class DemoSubgraph
                 new IClientConfiguration[]
                 {
                     new HttpClientConfiguration(HttpEndpointUri),
-                    new WebSocketClientConfiguration(WebSocketEndpointUri)
+                    new WebSocketClientConfiguration(WebSocketEndpointUri),
                 },
                 null);
 
@@ -78,7 +78,7 @@ public sealed class DemoSubgraph
                 new IClientConfiguration[]
                 {
                     new HttpClientConfiguration(HttpEndpointUri),
-                    new WebSocketClientConfiguration(WebSocketEndpointUri)
+                    new WebSocketClientConfiguration(WebSocketEndpointUri),
                 },
                 configurationExtensions);
 
@@ -97,7 +97,7 @@ public sealed class DemoSubgraph
                 new IClientConfiguration[]
                 {
                     new HttpClientConfiguration(HttpEndpointUri),
-                    new WebSocketClientConfiguration(WebSocketEndpointUri)
+                    new WebSocketClientConfiguration(WebSocketEndpointUri),
                 },
                 null);
 }

--- a/src/HotChocolate/Fusion/test/Shared/Products/ProductRepository.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Products/ProductRepository.cs
@@ -10,7 +10,7 @@ public sealed class ProductRepository
         {
             new Product(1, "Table", 899, 100, new ProductDimension(250, 150)),
             new Product(2, "Couch", 1299, 1000, new ProductDimension(2500, 150)),
-            new Product(3, "Chair", 54, 50, new ProductDimension(15, 30))
+            new Product(3, "Chair", 54, 50, new ProductDimension(15, 30)),
         }.ToDictionary(t => t.Id);
     }
 

--- a/src/HotChocolate/Fusion/test/Shared/Reviews/ReviewRepository.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Reviews/ReviewRepository.cs
@@ -10,7 +10,7 @@ public class ReviewRepository
         _authors = new[]
         {
             new Author(1, "@ada"),
-            new Author(2, "@alan")
+            new Author(2, "@alan"),
         }.ToDictionary(t => t.Id);
 
         _reviews = new[]
@@ -18,7 +18,7 @@ public class ReviewRepository
             new Review(1, _authors[1], new Product(1), "Love it!"),
             new Review(2, _authors[2], new Product(2), "Too expensive."),
             new Review(3, _authors[1], new Product(3), "Could be better."),
-            new Review(4, _authors[2], new Product(1), "Prefer something else.")
+            new Review(4, _authors[2], new Product(1), "Prefer something else."),
         }.ToDictionary(t => t.Id);
     }
 

--- a/src/HotChocolate/Fusion/test/Shared/Reviews/ReviewsSubscription.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Reviews/ReviewsSubscription.cs
@@ -10,7 +10,7 @@ public sealed class ReviewsSubscription
         var authors = new Author[]
         {
             new Author(1, "@ada"),
-            new Author(2, "@complete")
+            new Author(2, "@complete"),
         };
 
         var reviews = new Review[]
@@ -18,7 +18,7 @@ public sealed class ReviewsSubscription
             new Review(1, authors[0], new Product(1), "Love it!"),
             new Review(2, authors[1], new Product(2), "Too expensive."),
             new Review(3, authors[0], new Product(3), "Could be better."),
-            new Review(4, authors[1], new Product(1), "Prefer something else.")
+            new Review(4, authors[1], new Product(1), "Prefer something else."),
         };
 
         foreach (var review in reviews)

--- a/src/HotChocolate/Fusion/test/Shared/Reviews2/ReviewRepository.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Reviews2/ReviewRepository.cs
@@ -10,7 +10,7 @@ public sealed class ReviewRepository
         _authors = new[]
         {
             new User(1, "@ada"),
-            new User(2, "@alan")
+            new User(2, "@alan"),
         }.ToDictionary(t => t.Id);
 
         _reviews = new[]
@@ -18,7 +18,7 @@ public sealed class ReviewRepository
             new Review(1, _authors[1], new Product(1), "Love it!"),
             new Review(2, _authors[2], new Product(2), "Too expensive."),
             new Review(3, _authors[1], new Product(3), "Could be better."),
-            new Review(4, _authors[2], new Product(1), "Prefer something else.")
+            new Review(4, _authors[2], new Product(1), "Prefer something else."),
         }.ToDictionary(t => t.Id);
     }
 

--- a/src/HotChocolate/Fusion/test/Shared/Reviews2/ReviewsSubscription.cs
+++ b/src/HotChocolate/Fusion/test/Shared/Reviews2/ReviewsSubscription.cs
@@ -10,7 +10,7 @@ public sealed class ReviewsSubscription
         var authors = new User[]
         {
             new User(1, "@ada"),
-            new User(2, "@complete")
+            new User(2, "@complete"),
         };
 
         var reviews = new Review[]
@@ -18,7 +18,7 @@ public sealed class ReviewsSubscription
             new Review(1, authors[0], new Product(1), "Love it!"),
             new Review(2, authors[1], new Product(2), "Too expensive."),
             new Review(3, authors[0], new Product(3), "Could be better."),
-            new Review(4, authors[1], new Product(1), "Prefer something else.")
+            new Review(4, authors[1], new Product(1), "Prefer something else."),
         };
 
         foreach (var review in reviews)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Extensions/SyntaxComparison.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Extensions/SyntaxComparison.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Language;
 public enum SyntaxComparison
 {
     Reference = 0,
-    Syntax = 1
+    Syntax = 1,
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FloatFormat.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FloatFormat.cs
@@ -13,5 +13,5 @@ public enum FloatFormat
     /// <summary>
     /// The value has the e notation eg. 6.022e23
     /// </summary>
-    Exponential = 1
+    Exponential = 1,
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FloatValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FloatValueNode.cs
@@ -170,7 +170,7 @@ public sealed class FloatValueNode : IValueNode<string>, IFloatValueLiteral
 
     /// <inheritdoc />
     public IEnumerable<ISyntaxNode> GetNodes() => Enumerable.Empty<ISyntaxNode>();
-    
+
     /// <summary>
     /// Returns the GraphQL syntax representation of this <see cref="ISyntaxNode"/>.
     /// </summary>
@@ -306,7 +306,7 @@ public sealed class FloatValueNode : IValueNode<string>, IFloatValueLiteral
             _floatValue = _floatValue,
             _doubleValue = _doubleValue,
             _decimalValue = _decimalValue,
-            _stringValue = Value
+            _stringValue = Value,
         };
 
     /// <summary>

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/IntValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/IntValueNode.cs
@@ -614,7 +614,7 @@ public sealed class IntValueNode : IValueNode<string>, IIntValueLiteral
             _intValue = _intValue,
             _longValue = _longValue,
             _sbyteValue = _sbyteValue,
-            _memory = _memory
+            _memory = _memory,
         };
 
     /// <summary>

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/OperationType.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/OperationType.cs
@@ -4,5 +4,5 @@ public enum OperationType
 {
     Query = 0,
     Mutation = 1,
-    Subscription = 2
+    Subscription = 2,
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
@@ -991,7 +991,7 @@ internal sealed class SyntaxEqualityComparer : IEqualityComparer<ISyntaxNode>
             SyntaxKind.ListNullability => GetHashCode((ListNullabilityNode)node),
             SyntaxKind.RequiredModifier => GetHashCode((RequiredModifierNode)node),
             SyntaxKind.OptionalModifier => GetHashCode((OptionalModifierNode)node),
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(),
         };
     }
 
@@ -1013,7 +1013,7 @@ internal sealed class SyntaxEqualityComparer : IEqualityComparer<ISyntaxNode>
             SyntaxKind.ListValue => GetHashCode((ListValueNode)node),
             SyntaxKind.NullValue => GetHashCode((NullValueNode)node),
             SyntaxKind.Variable => GetHashCode((VariableNode)node),
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(),
         };
     }
 

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxKind.cs
@@ -48,5 +48,5 @@ public enum SyntaxKind
     ListNullability,
     RequiredModifier,
     OptionalModifier,
-    SchemaCoordinate
+    SchemaCoordinate,
 }

--- a/src/HotChocolate/Language/src/Language.Utf8/GraphQLKeywords.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/GraphQLKeywords.cs
@@ -12,7 +12,7 @@ internal static class GraphQLKeywords
         (byte)'h',
         (byte)'e',
         (byte)'m',
-        (byte)'a'
+        (byte)'a',
     };
 
     public static ReadOnlySpan<byte> Scalar => new[]
@@ -22,7 +22,7 @@ internal static class GraphQLKeywords
         (byte)'a',
         (byte)'l',
         (byte)'a',
-        (byte)'r'
+        (byte)'r',
     };
 
     public static ReadOnlySpan<byte> Type => new[]
@@ -30,7 +30,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'y',
         (byte)'p',
-        (byte)'e'
+        (byte)'e',
     };
 
     public static ReadOnlySpan<byte> Interface => new[]
@@ -43,7 +43,7 @@ internal static class GraphQLKeywords
         (byte)'f',
         (byte)'a',
         (byte)'c',
-        (byte)'e'
+        (byte)'e',
     };
 
     public static ReadOnlySpan<byte> Union => new[]
@@ -52,7 +52,7 @@ internal static class GraphQLKeywords
         (byte)'n',
         (byte)'i',
         (byte)'o',
-        (byte)'n'
+        (byte)'n',
     };
 
     public static ReadOnlySpan<byte> Enum => new[]
@@ -60,7 +60,7 @@ internal static class GraphQLKeywords
         (byte)'e',
         (byte)'n',
         (byte)'u',
-        (byte)'m'
+        (byte)'m',
     };
 
     public static ReadOnlySpan<byte> Input => new[]
@@ -69,7 +69,7 @@ internal static class GraphQLKeywords
         (byte)'n',
         (byte)'p',
         (byte)'u',
-        (byte)'t'
+        (byte)'t',
     };
 
     public static ReadOnlySpan<byte> Extend => new[]
@@ -79,7 +79,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'e',
         (byte)'n',
-        (byte)'d'
+        (byte)'d',
     };
 
     public static ReadOnlySpan<byte> Implements => new[]
@@ -93,7 +93,7 @@ internal static class GraphQLKeywords
         (byte)'e',
         (byte)'n',
         (byte)'t',
-        (byte)'s'
+        (byte)'s',
     };
 
     public static ReadOnlySpan<byte> Repeatable => new[]
@@ -107,7 +107,7 @@ internal static class GraphQLKeywords
         (byte)'a',
         (byte)'b',
         (byte)'l',
-        (byte)'e'
+        (byte)'e',
     };
 
     public static ReadOnlySpan<byte> Directive => new[]
@@ -120,7 +120,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'i',
         (byte)'v',
-        (byte)'e'
+        (byte)'e',
     };
 
     // query
@@ -130,7 +130,7 @@ internal static class GraphQLKeywords
         (byte)'u',
         (byte)'e',
         (byte)'r',
-        (byte)'y'
+        (byte)'y',
     };
 
     public static ReadOnlySpan<byte> Mutation => new[]
@@ -142,7 +142,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'i',
         (byte)'o',
-        (byte)'n'
+        (byte)'n',
     };
 
     public static ReadOnlySpan<byte> Subscription => new[]
@@ -158,7 +158,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'i',
         (byte)'o',
-        (byte)'n'
+        (byte)'n',
     };
 
     public static ReadOnlySpan<byte> Fragment => new[]
@@ -170,14 +170,14 @@ internal static class GraphQLKeywords
         (byte)'m',
         (byte)'e',
         (byte)'n',
-        (byte)'t'
+        (byte)'t',
     };
 
     // general
     public static ReadOnlySpan<byte> On => new[]
     {
         (byte)'o',
-        (byte)'n'
+        (byte)'n',
     };
 
     public static ReadOnlySpan<byte> True => new[]
@@ -185,7 +185,7 @@ internal static class GraphQLKeywords
         (byte)'t',
         (byte)'r',
         (byte)'u',
-        (byte)'e'
+        (byte)'e',
     };
 
     public static ReadOnlySpan<byte> False => new[]
@@ -194,7 +194,7 @@ internal static class GraphQLKeywords
         (byte)'a',
         (byte)'l',
         (byte)'s',
-        (byte)'e'
+        (byte)'e',
     };
 
     public static ReadOnlySpan<byte> Null => new[]
@@ -202,6 +202,6 @@ internal static class GraphQLKeywords
         (byte)'n',
         (byte)'u',
         (byte)'l',
-        (byte)'l'
+        (byte)'l',
     };
 }

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8Helper.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8Helper.cs
@@ -149,7 +149,7 @@ internal static class Utf8Helper
             >= 48 and <= 57 => a - 48,
             >= 65 and <= 70 => a - 55,
             >= 97 and <= 102 => a - 87,
-            _ => -1
+            _ => -1,
         };
     }
 }

--- a/src/HotChocolate/Language/src/Language.Visitors/Contracts/SyntaxVisitorActionKind.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/Contracts/SyntaxVisitorActionKind.cs
@@ -5,5 +5,5 @@ public enum SyntaxVisitorActionKind
     Continue,
     Skip,
     Break,
-    SkipAndLeave
+    SkipAndLeave,
 }

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
@@ -76,7 +76,7 @@ public class SyntaxRewriter<TContext>
             VariableDefinitionNode n => RewriteVariableDefinition(n, context),
             VariableNode n => RewriteVariable(n, context),
             IValueNode n => RewriteCustomValue(n, context),
-            _ => throw new ArgumentOutOfRangeException(nameof(node))
+            _ => throw new ArgumentOutOfRangeException(nameof(node)),
         };
 
     protected virtual void OnLeave(
@@ -856,7 +856,7 @@ public class SyntaxRewriter<TContext>
         StringValueNode node,
         TContext context)
         => node;
-    
+
     protected virtual IValueNode? RewriteCustomValue(
         IValueNode node,
         TContext context)

--- a/src/HotChocolate/Language/src/Language.Web/HashRepresentation.cs
+++ b/src/HotChocolate/Language/src/Language.Web/HashRepresentation.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Language;
 public enum HashFormat
 {
     Base64,
-    Hex
+    Hex,
 }

--- a/src/HotChocolate/Language/src/Language.Web/MD5DocumentHashProvider.cs
+++ b/src/HotChocolate/Language/src/Language.Web/MD5DocumentHashProvider.cs
@@ -36,7 +36,7 @@ public sealed class MD5DocumentHashProvider : DocumentHashProviderBase
         {
             HashFormat.Base64 => Convert.ToBase64String(hashSpan),
             HashFormat.Hex => ToHexString(hashSpan),
-            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported)
+            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported),
         };
     }
 #else

--- a/src/HotChocolate/Language/src/Language.Web/Sha1DocumentHashProvider.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Sha1DocumentHashProvider.cs
@@ -40,7 +40,7 @@ public sealed class Sha1DocumentHashProvider : DocumentHashProviderBase
         {
             HashFormat.Base64 => Convert.ToBase64String(hashSpan),
             HashFormat.Hex => ToHexString(hashSpan),
-            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported)
+            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported),
         };
     }
 #else

--- a/src/HotChocolate/Language/src/Language.Web/Sha256DocumentHashProvider.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Sha256DocumentHashProvider.cs
@@ -38,7 +38,7 @@ public sealed class Sha256DocumentHashProvider : DocumentHashProviderBase
         {
             HashFormat.Base64 => Convert.ToBase64String(hashSpan),
             HashFormat.Hex => ToHexString(hashSpan),
-            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported)
+            _ => throw new NotSupportedException(ComputeHash_FormatNotSupported),
         };
     }
 #else

--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Constants.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Constants.cs
@@ -28,7 +28,7 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'N',
         (byte)'a',
         (byte)'m',
-        (byte)'e'
+        (byte)'e',
     };
 
     private static ReadOnlySpan<byte> Query => new[]
@@ -37,7 +37,7 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'u',
         (byte)'e',
         (byte)'r',
-        (byte)'y'
+        (byte)'y',
     };
 
     private static ReadOnlySpan<byte> Variables => new[]
@@ -50,8 +50,8 @@ public ref partial struct Utf8GraphQLRequestParser
             (byte)'b',
             (byte)'l',
             (byte)'e',
-            (byte)'s'
-        };
+            (byte)'s',
+    };
 
     private static ReadOnlySpan<byte> Extensions => new[]
     {
@@ -64,7 +64,7 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'i',
         (byte)'o',
         (byte)'n',
-        (byte)'s'
+        (byte)'s',
     };
 
     private static ReadOnlySpan<byte> Type => new[]
@@ -72,13 +72,13 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'t',
         (byte)'y',
         (byte)'p',
-        (byte)'e'
+        (byte)'e',
     };
 
     private static ReadOnlySpan<byte> Id => new[]
     {
         (byte)'i',
-        (byte)'d'
+        (byte)'d',
     };
 
     private static ReadOnlySpan<byte> Payload => new[]
@@ -89,6 +89,6 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'l',
         (byte)'o',
         (byte)'a',
-        (byte)'d'
+        (byte)'d',
     };
 }

--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Response.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Response.cs
@@ -16,7 +16,7 @@ public ref partial struct Utf8GraphQLRequestParser
             TokenKind.Integer => ParseScalarSyntax(),
             TokenKind.Float => ParseScalarSyntax(),
             TokenKind.Name => ParseScalarSyntax(),
-            _ => throw ThrowHelper.UnexpectedToken(_reader)
+            _ => throw ThrowHelper.UnexpectedToken(_reader),
         };
     }
 

--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Syntax.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Syntax.cs
@@ -17,7 +17,7 @@ public ref partial struct Utf8GraphQLRequestParser
             TokenKind.Integer => ParseScalarSyntax(),
             TokenKind.Float => ParseScalarSyntax(),
             TokenKind.Name => ParseScalarSyntax(),
-            _ => throw ThrowHelper.UnexpectedToken(_reader)
+            _ => throw ThrowHelper.UnexpectedToken(_reader),
         };
     }
 

--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Values.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Values.cs
@@ -18,7 +18,7 @@ public ref partial struct Utf8GraphQLRequestParser
             TokenKind.Integer => ParseScalar(),
             TokenKind.Float => ParseScalar(),
             TokenKind.Name => ParseScalar(),
-            _ => throw ThrowHelper.UnexpectedToken(_reader)
+            _ => throw ThrowHelper.UnexpectedToken(_reader),
         };
     }
 
@@ -32,7 +32,7 @@ public ref partial struct Utf8GraphQLRequestParser
             TokenKind.Integer => SkipScalar(),
             TokenKind.Float => SkipScalar(),
             TokenKind.Name => SkipScalar(),
-            _ => throw ThrowHelper.UnexpectedToken(_reader)
+            _ => throw ThrowHelper.UnexpectedToken(_reader),
         };
     }
 

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
@@ -126,7 +126,7 @@ public class DirectiveDefinitionNodeTests
                         new NamedTypeNode(new NameNode("type")),
                         NullValueNode.Default,
                         Array.Empty<DirectiveNode>()
-                    )
+                    ),
             });
 
         // assert
@@ -246,11 +246,11 @@ public class DirectiveDefinitionNodeTests
                 new StringValueNode("def"),
                 new NamedTypeNode("efg"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
         var locations = new List<NameNode>
         {
-            new(DirectiveLocation.Field.ToString())
+            new(DirectiveLocation.Field.ToString()),
         };
 
         // act
@@ -273,12 +273,12 @@ public class DirectiveDefinitionNodeTests
                 new StringValueNode("def"),
                 new NamedTypeNode("efg"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var locations = new List<NameNode>
         {
-            new(DirectiveLocation.Field.ToString())
+            new(DirectiveLocation.Field.ToString()),
         };
 
         var a = new DirectiveDefinitionNode(
@@ -327,12 +327,12 @@ public class DirectiveDefinitionNodeTests
                 new StringValueNode("def"),
                 new NamedTypeNode("efg"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var locations = new List<NameNode>
         {
-            new(DirectiveLocation.Field.ToString())
+            new(DirectiveLocation.Field.ToString()),
         };
 
         var a = new DirectiveDefinitionNode(
@@ -381,12 +381,12 @@ public class DirectiveDefinitionNodeTests
                 new StringValueNode("def"),
                 new NamedTypeNode("efg"),
                 null,
-                Array.Empty<DirectiveNode>())
+                Array.Empty<DirectiveNode>()),
         };
 
         var locations = new List<NameNode>
         {
-            new(DirectiveLocation.Field.ToString())
+            new(DirectiveLocation.Field.ToString()),
         };
 
         var a = new DirectiveDefinitionNode(

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DocumentNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DocumentNodeTests.cs
@@ -151,8 +151,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var definitions2 = new List<IDefinitionNode>
@@ -168,8 +168,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var a = new DocumentNode(
@@ -212,8 +212,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var definitions2 = new List<IDefinitionNode>
@@ -229,8 +229,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var a = new DocumentNode(
@@ -274,8 +274,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var definitions2 = new List<IDefinitionNode>
@@ -291,8 +291,8 @@ public class DocumentNodeTests
                         null,
                         new("DEF"),
                         null,
-                        Array.Empty<DirectiveNode>())
-                })
+                        Array.Empty<DirectiveNode>()),
+                }),
         };
 
         var a = new DocumentNode(

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeDefinitionNodeTests.cs
@@ -246,7 +246,7 @@ public class EnumTypeDefinitionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeDefinitionNode(
@@ -287,7 +287,7 @@ public class EnumTypeDefinitionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeDefinitionNode(
@@ -329,7 +329,7 @@ public class EnumTypeDefinitionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeDefinitionNode(

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeExtensionNodeTests.cs
@@ -203,7 +203,7 @@ public class EnumTypeExtensionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeExtensionNode(
@@ -241,7 +241,7 @@ public class EnumTypeExtensionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeExtensionNode(
@@ -279,7 +279,7 @@ public class EnumTypeExtensionNodeTests
         // arrange
         var values = new List<EnumValueDefinitionNode>
         {
-            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>())
+            new EnumValueDefinitionNode(null, new("DEF"), null, Array.Empty<DirectiveNode>()),
         };
 
         var a = new EnumTypeExtensionNode(

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
@@ -52,7 +52,7 @@ public class FragmentSpreadNodeTests
             new("aa"),
             new List<DirectiveNode>
             {
-                new("bb")
+                new("bb"),
             });
 
         // act

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SelectionSetNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SelectionSetNodeTests.cs
@@ -30,7 +30,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
 
         // act
@@ -68,7 +68,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
 
         // act
@@ -100,7 +100,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
         var b = new SelectionSetNode(
             new Location(2, 2, 2, 2),
@@ -114,7 +114,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
         var c = new SelectionSetNode(
             new Location(1, 1, 1, 1),
@@ -128,7 +128,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
         var d = new SelectionSetNode(
             new Location(2, 2, 2, 2),
@@ -142,7 +142,7 @@ public class SelectionSetNodeTests
                     new List<ArgumentNode>(0),
                     new SelectionSetNode(
                         TestLocations.Location1,
-                        new List<ISelectionNode>(0)))
+                        new List<ISelectionNode>(0))),
             });
 
         // act
@@ -174,7 +174,7 @@ public class SelectionSetNodeTests
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
-                )
+                ),
             };
 
         // act
@@ -204,7 +204,7 @@ public class SelectionSetNodeTests
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
-                )
+                ),
             };
 
         var selectionSet = new SelectionSetNode
@@ -236,7 +236,7 @@ public class SelectionSetNodeTests
                     Array.Empty<DirectiveNode>(),
                     Array.Empty<ArgumentNode>(),
                     null
-                )
+                ),
             };
 
         var selectionSet = new SelectionSetNode
@@ -258,7 +258,7 @@ public class SelectionSetNodeTests
                         Array.Empty<DirectiveNode>(),
                         Array.Empty<ArgumentNode>(),
                         null
-                    )
+                    ),
             });
 
         // assert

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableDefinitionNodeTests.cs
@@ -219,7 +219,7 @@ public class VariableDefinitionNodeTests
             new StringValueNode("baz"),
             new List<DirectiveNode>
             {
-                    new DirectiveNode("qux")
+                    new DirectiveNode("qux"),
             });
 
         // act
@@ -242,7 +242,7 @@ public class VariableDefinitionNodeTests
             new StringValueNode("baz"),
             new List<DirectiveNode>
             {
-                    new DirectiveNode("qux")
+                    new DirectiveNode("qux"),
             });
 
         // act
@@ -283,7 +283,7 @@ public class VariableDefinitionNodeTests
             new StringValueNode("baz"),
             new List<DirectiveNode>
             {
-                    new DirectiveNode("qux")
+                    new DirectiveNode("qux"),
             });
 
         // act

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
@@ -19,7 +19,7 @@ public class GraphQLRequestParserTests
             JsonConvert.SerializeObject(
                 new GraphQLRequestDto
                 {
-                    Query = FileResource.Open("kitchen-sink.graphql").NormalizeLineBreaks()
+                    Query = FileResource.Open("kitchen-sink.graphql").NormalizeLineBreaks(),
                 }).NormalizeLineBreaks());
 
         // act
@@ -47,7 +47,7 @@ public class GraphQLRequestParserTests
                 new GraphQLRequestDto
                 {
                     Query = FileResource.Open("kitchen-sink.graphql")
-                        .NormalizeLineBreaks()
+                        .NormalizeLineBreaks(),
                 }).NormalizeLineBreaks());
 
         // act
@@ -64,7 +64,7 @@ public class GraphQLRequestParserTests
         var json = JsonConvert.SerializeObject(
             new GraphQLRequestDto
             {
-                Query = FileResource.Open("kitchen-sink.graphql").NormalizeLineBreaks()
+                Query = FileResource.Open("kitchen-sink.graphql").NormalizeLineBreaks(),
             }).NormalizeLineBreaks();
 
         // act
@@ -83,7 +83,7 @@ public class GraphQLRequestParserTests
                 new GraphQLRequestDto
                 {
                     Query = FileResource.Open("kitchen-sink.graphql")
-                        .NormalizeLineBreaks()
+                        .NormalizeLineBreaks(),
                 }).NormalizeLineBreaks());
 
         // act
@@ -102,7 +102,7 @@ public class GraphQLRequestParserTests
             new GraphQLRequestDto
             {
                 Query = FileResource.Open("kitchen-sink.graphql")
-                    .NormalizeLineBreaks()
+                    .NormalizeLineBreaks(),
             }).NormalizeLineBreaks();
 
         // act
@@ -122,7 +122,7 @@ public class GraphQLRequestParserTests
                 new GraphQLRequestDto
                 {
                     Query = FileResource.Open("kitchen-sink.graphql")
-                        .NormalizeLineBreaks()
+                        .NormalizeLineBreaks(),
                 }).NormalizeLineBreaks());
 
         // act
@@ -151,7 +151,7 @@ public class GraphQLRequestParserTests
             JsonConvert.SerializeObject(
                 new GraphQLRequestDto
                 {
-                    Query = FileResource.Open("russian-literals.graphql").NormalizeLineBreaks()
+                    Query = FileResource.Open("russian-literals.graphql").NormalizeLineBreaks(),
                 }).NormalizeLineBreaks());
 
         // act
@@ -207,7 +207,7 @@ public class GraphQLRequestParserTests
         var request = new GraphQLRequestDto
         {
             Query = FileResource.Open("kitchen-sink.graphql")
-                .NormalizeLineBreaks()
+                .NormalizeLineBreaks(),
         };
 
         var buffer = Encoding.UTF8.GetBytes(request.Query);
@@ -261,7 +261,7 @@ public class GraphQLRequestParserTests
         {
             CustomProperty = "FooBar",
             Query = FileResource.Open("kitchen-sink.graphql")
-                .NormalizeLineBreaks()
+                .NormalizeLineBreaks(),
         };
 
         var source = Encoding.UTF8.GetBytes(
@@ -304,7 +304,7 @@ public class GraphQLRequestParserTests
         {
             Id = "FooBar",
             Query = FileResource.Open("kitchen-sink.graphql")
-                .NormalizeLineBreaks()
+                .NormalizeLineBreaks(),
         };
 
         var source = Encoding.UTF8.GetBytes(
@@ -366,7 +366,7 @@ public class GraphQLRequestParserTests
                                     new Dictionary<string, object>
                                     {
                                         { "a" , "b"},
-                                    }
+                                    },
                                 }},
                     },
                     Extensions = new Dictionary<string, object>
@@ -386,9 +386,9 @@ public class GraphQLRequestParserTests
                                         { "aa" , "bb"},
                                         { "ab" , null},
                                         { "ac" , false},
-                                    }
+                                    },
                                 }},
-                    }
+                    },
                 }).NormalizeLineBreaks());
 
         // act
@@ -439,7 +439,7 @@ public class GraphQLRequestParserTests
                                     new Dictionary<string, object>
                                     {
                                         { "a" , "b"},
-                                    }
+                                    },
                                 }},
                     },
                     Extensions = new Dictionary<string, object>
@@ -457,9 +457,9 @@ public class GraphQLRequestParserTests
                                     new Dictionary<string, object>
                                     {
                                         { "aa" , "bb"},
-                                    }
+                                    },
                                 }},
-                    }
+                    },
                 }).NormalizeLineBreaks());
 
         // act
@@ -489,14 +489,14 @@ public class GraphQLRequestParserTests
                                         { "c" , 1},
                                         { "d" , 1.1},
                                         { "e" , false},
-                                        { "f" , null}
+                                        { "f" , null},
                                     }},
                                 { "c" , new List<object>
                                     {
                                         new Dictionary<string, object>
                                         {
                                             { "a" , "b"},
-                                        }
+                                        },
                                     }},
                             }
                         },
@@ -507,7 +507,7 @@ public class GraphQLRequestParserTests
                         {
                             "id",
                             "bar"
-                        }
+                        },
                 }).NormalizeLineBreaks());
 
         // act

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ReaderTests.cs
@@ -183,8 +183,8 @@ public class ReaderTests
                 (byte)191,
                 (byte)'a',
                 (byte)'b',
-                (byte)'c'
-            };
+                (byte)'c',
+        };
 
 
         var tokens = new List<SyntaxTokenInfo>();

--- a/src/HotChocolate/Language/test/Language.Tests/SyntaxNodeVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/SyntaxNodeVisitorTests.cs
@@ -164,7 +164,7 @@ public class SyntaxNodeVisitorTests
             : base(new Dictionary<SyntaxKind, VisitorAction>
             {
                     { SyntaxKind.ObjectValue, VisitorAction.Continue },
-                    { SyntaxKind.ObjectField, VisitorAction.Continue }
+                    { SyntaxKind.ObjectField, VisitorAction.Continue },
             })
         {
         }

--- a/src/HotChocolate/Skimmed/src/Skimmed/Extensions/TypeExtensions.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Extensions/TypeExtensions.cs
@@ -10,7 +10,7 @@ public static class TypeExtensions
         {
             TypeKind.List => true,
             TypeKind.NonNull when ((NonNullType) type).NullableType.Kind == TypeKind.List => true,
-            _ => false
+            _ => false,
         };
 
     public static bool IsInputType(this IType type)
@@ -39,7 +39,7 @@ public static class TypeExtensions
         {
             ListType listType => listType.ElementType,
             NonNullType nonNullType => nonNullType.NullableType,
-            _ => type
+            _ => type,
         };
 
     public static INamedType NamedType(this IType type)
@@ -71,7 +71,7 @@ public static class TypeExtensions
             INamedType namedType => new NamedTypeNode(namedType.Name),
             ListType listType => new ListTypeNode(ToTypeNode(listType.ElementType)),
             NonNullType nonNullType => new NonNullTypeNode((INullableTypeNode) ToTypeNode(nonNullType.NullableType)),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
 
     public static IType ReplaceNameType(this IType type, Func<string, INamedType> newNamedType)
@@ -80,6 +80,6 @@ public static class TypeExtensions
             INamedType namedType => newNamedType(namedType.Name),
             ListType listType => new ListType(ReplaceNameType(listType.ElementType, newNamedType)),
             NonNullType nonNullType => new NonNullType(ReplaceNameType(nonNullType.NullableType, newNamedType)),
-            _ => throw new NotSupportedException()
+            _ => throw new NotSupportedException(),
         };
 }

--- a/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaFormatter.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaFormatter.cs
@@ -11,7 +11,7 @@ public static class SchemaFormatter
         new()
         {
             Indented = true,
-            MaxDirectivesPerLine = 0
+            MaxDirectivesPerLine = 0,
         };
 
     public static string FormatAsString(Schema schema, bool indented = true)

--- a/src/HotChocolate/Skimmed/src/Skimmed/SpecScalarTypes.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/SpecScalarTypes.cs
@@ -15,7 +15,7 @@ public static class SpecScalarTypes
             Boolean,
             Float,
             ID,
-            Int
+            Int,
         };
 
     public static bool IsSpecScalar(string name)

--- a/src/HotChocolate/Skimmed/src/Skimmed/TypeComparison.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/TypeComparison.cs
@@ -3,5 +3,5 @@ namespace HotChocolate.Skimmed;
 public enum TypeComparison
 {
     Reference = 0,
-    Structural = 1
+    Structural = 1,
 }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionClient.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionClient.cs
@@ -21,9 +21,9 @@ public static class IntrospectionClient
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new JsonStringEnumConverter() }
+        Converters = { new JsonStringEnumConverter() },
     };
-    
+
     internal static JsonSerializerOptions SerializerOptions => _serializerOptions;
 
     /// <summary>
@@ -41,7 +41,7 @@ public static class IntrospectionClient
         HttpClient client,
         CancellationToken cancellationToken = default)
         => IntrospectServerAsync(client, default, cancellationToken);
-    
+
     /// <summary>
     /// Downloads the schema information from a GraphQL server
     /// and returns the schema syntax tree.
@@ -57,7 +57,7 @@ public static class IntrospectionClient
     /// </param>
     /// <returns>Returns a parsed GraphQL schema syntax tree.</returns>
     public static Task<DocumentNode> IntrospectServerAsync(
-        HttpClient client, 
+        HttpClient client,
         IntrospectionOptions options,
         CancellationToken cancellationToken = default)
     {
@@ -68,9 +68,9 @@ public static class IntrospectionClient
 
         return IntrospectServerInternalAsync(client, options, cancellationToken);
     }
-    
+
     private static async Task<DocumentNode> IntrospectServerInternalAsync(
-        HttpClient client, 
+        HttpClient client,
         IntrospectionOptions options,
         CancellationToken cancellationToken = default)
     {
@@ -120,7 +120,7 @@ public static class IntrospectionClient
 
         return IntrospectServerInternalAsync(client, options, cancellationToken);
     }
-    
+
     private static async Task<DocumentNode> IntrospectServerInternalAsync(
         GraphQLHttpClient client,
         IntrospectionOptions options,
@@ -128,7 +128,7 @@ public static class IntrospectionClient
     {
         var capabilities = await InspectServerAsync(client, options, cancellationToken).ConfigureAwait(false);
         var result = await IntrospectAsync(client, capabilities, options, cancellationToken).ConfigureAwait(false);
-        
+
         EnsureNoGraphQLErrors(result);
 
         return IntrospectionFormatter.Format(result).RemoveBuiltInTypes();
@@ -148,8 +148,8 @@ public static class IntrospectionClient
         HttpClient client,
         CancellationToken cancellationToken = default)
         => InspectServerAsync(client, default, cancellationToken);
-        
-    
+
+
     /// <summary>
     /// Gets the supported GraphQL server capabilities from the server by doing an introspection query.
     /// </summary>
@@ -164,7 +164,7 @@ public static class IntrospectionClient
     /// </param>
     /// <returns>Returns an object that indicates what capabilities the GraphQL server has.</returns>
     public static Task<ServerCapabilities> InspectServerAsync(
-        HttpClient client, 
+        HttpClient client,
         IntrospectionOptions options,
         CancellationToken cancellationToken = default)
     {
@@ -175,9 +175,9 @@ public static class IntrospectionClient
 
         return InspectServerInternalAsync(client, options, cancellationToken);
     }
-    
+
     private static async Task<ServerCapabilities> InspectServerInternalAsync(
-        HttpClient client, 
+        HttpClient client,
         IntrospectionOptions options,
         CancellationToken cancellationToken = default)
     {
@@ -232,7 +232,7 @@ public static class IntrospectionClient
         {
             return;
         }
-        
+
         var message = new StringBuilder();
 
         for (var i = 0; i < result.Errors.Count; i++)
@@ -257,7 +257,7 @@ public static class IntrospectionClient
 
         using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
         using var result = await response.ReadAsResultAsync(cancellationToken).ConfigureAwait(false);
-        
+
         IntrospectionData? data = null;
         IReadOnlyList<IntrospectionError>? errors = null;
 
@@ -265,7 +265,7 @@ public static class IntrospectionClient
         {
             data = result.Data.Deserialize<IntrospectionData>(_serializerOptions);
         }
-        
+
         if (result.Errors.ValueKind is JsonValueKind.Array)
         {
             errors = result.Errors.Deserialize<IntrospectionError[]>(_serializerOptions);

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
@@ -7,7 +7,7 @@ using HotChocolate.Utilities.Introspection.Properties;
 namespace HotChocolate.Utilities.Introspection;
 
 /// <summary>
-/// A utility to format an introspection result into a GraphQL schema document. 
+/// A utility to format an introspection result into a GraphQL schema document.
 /// </summary>
 internal static class IntrospectionFormatter
 {
@@ -254,7 +254,7 @@ internal static class IntrospectionFormatter
     private static DirectiveDefinitionNode CreateDirectiveDefinition(
         Directive directive)
     {
-        var locations = directive.Locations?.Select(t => new NameNode(t)).ToList() ?? 
+        var locations = directive.Locations?.Select(t => new NameNode(t)).ToList() ??
             InferDirectiveLocation(directive);
 
         return new DirectiveDefinitionNode
@@ -330,7 +330,7 @@ internal static class IntrospectionFormatter
                         WellKnownDirectives.DeprecationReasonArgument,
                         new StringValueNode(deprecationReason)
                     )
-                )
+                ),
             };
         }
         return Array.Empty<DirectiveNode>();

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
@@ -5,7 +5,7 @@ using HotChocolate.Language;
 namespace HotChocolate.Utilities.Introspection;
 
 /// <summary>
-/// A utility to build the GraphQL introspection request document. 
+/// A utility to build the GraphQL introspection request document.
 /// </summary>
 internal static class IntrospectionQueryBuilder
 {
@@ -28,7 +28,7 @@ internal static class IntrospectionQueryBuilder
                 new SelectionSetNode(
                     new ISelectionNode[]
                     {
-                        new FieldNode("name")
+                        new FieldNode("name"),
                     })));
 
         selections.Add(
@@ -41,7 +41,7 @@ internal static class IntrospectionQueryBuilder
                 new SelectionSetNode(
                     new ISelectionNode[]
                     {
-                        new FieldNode("name")
+                        new FieldNode("name"),
                     })));
 
         if (features.HasSubscriptionSupport)
@@ -56,10 +56,10 @@ internal static class IntrospectionQueryBuilder
                     new SelectionSetNode(
                         new ISelectionNode[]
                         {
-                            new FieldNode("name")
+                            new FieldNode("name"),
                         })));
         }
-        
+
         selections.Add(CreateTypesField());
 
         selections.Add(
@@ -81,15 +81,15 @@ internal static class IntrospectionQueryBuilder
                         {
                             new FieldNode(
                                 new NameNode("__schema"),
-                                null, 
+                                null,
                                 null,
                                 Array.Empty<DirectiveNode>(),
                                 Array.Empty<ArgumentNode>(),
-                                new SelectionSetNode(selections))
+                                new SelectionSetNode(selections)),
                         })),
                 BuildFullTypeFragment(features.HasArgumentDeprecation),
                 BuildInputValueFragment(),
-                BuildTypeRefFragment(options.TypeDepth)
+                BuildTypeRefFragment(options.TypeDepth),
             });
     }
 
@@ -106,9 +106,9 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("FullType"),
-                        Array.Empty<DirectiveNode>())
+                        Array.Empty<DirectiveNode>()),
                 }));
-    
+
     private static FieldNode CreateDirectivesField(bool hasLocationsField, bool hasRepeatableDirective)
     {
         var selections = new List<ISelectionNode>
@@ -127,8 +127,8 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
-                            Array.Empty<DirectiveNode>())
-                    }))
+                            Array.Empty<DirectiveNode>()),
+                    })),
         };
 
         if (hasLocationsField)
@@ -173,7 +173,7 @@ internal static class IntrospectionQueryBuilder
                     CreateInputFields(),
                     CreateInterfacesField(),
                     CreateEnumValuesField(),
-                    CreatePossibleTypesField()
+                    CreatePossibleTypesField(),
                 }));
 
     private static FieldNode CreateFields(bool includeDeprecatedArgs)
@@ -184,7 +184,7 @@ internal static class IntrospectionQueryBuilder
             Array.Empty<DirectiveNode>(),
             new[]
             {
-                new ArgumentNode("includeDeprecated", true)
+                new ArgumentNode("includeDeprecated", true),
             },
             new SelectionSetNode(
                 new ISelectionNode[]
@@ -194,7 +194,7 @@ internal static class IntrospectionQueryBuilder
                     CreateArgsField(includeDeprecatedArgs),
                     CreateTypeField(),
                     new FieldNode("isDeprecated"),
-                    new FieldNode("deprecationReason")
+                    new FieldNode("deprecationReason"),
                 }));
 
     private static FieldNode CreateArgsField(bool includeDeprecated)
@@ -206,7 +206,7 @@ internal static class IntrospectionQueryBuilder
                 Array.Empty<DirectiveNode>(),
                 new[]
                 {
-                    new ArgumentNode("includeDeprecated", true)
+                    new ArgumentNode("includeDeprecated", true),
                 },
                 new SelectionSetNode(
                     new ISelectionNode[]
@@ -216,7 +216,7 @@ internal static class IntrospectionQueryBuilder
                             new NameNode("InputValue"),
                             Array.Empty<DirectiveNode>()),
                         new FieldNode("isDeprecated"),
-                        new FieldNode("deprecationReason")
+                        new FieldNode("deprecationReason"),
                     }))
             : new FieldNode(
                 new NameNode("args"),
@@ -230,7 +230,7 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
-                            Array.Empty<DirectiveNode>())
+                            Array.Empty<DirectiveNode>()),
                     }));
 
 
@@ -247,7 +247,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
-                        Array.Empty<DirectiveNode>())
+                        Array.Empty<DirectiveNode>()),
                 }));
 
     private static FieldNode CreateInputFields()
@@ -263,7 +263,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("InputValue"),
-                        Array.Empty<DirectiveNode>())
+                        Array.Empty<DirectiveNode>()),
                 }));
 
     private static FieldNode CreateInterfacesField()
@@ -279,7 +279,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
-                        Array.Empty<DirectiveNode>())
+                        Array.Empty<DirectiveNode>()),
                 }));
 
     private static FieldNode CreateEnumValuesField()
@@ -290,7 +290,7 @@ internal static class IntrospectionQueryBuilder
             Array.Empty<DirectiveNode>(),
             new[]
             {
-                new ArgumentNode("includeDeprecated", true)
+                new ArgumentNode("includeDeprecated", true),
             },
             new SelectionSetNode(
                 new ISelectionNode[]
@@ -314,7 +314,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
-                        Array.Empty<DirectiveNode>())
+                        Array.Empty<DirectiveNode>()),
                 }));
 
     private static FragmentDefinitionNode BuildInputValueFragment()
@@ -379,7 +379,7 @@ internal static class IntrospectionQueryBuilder
                         null,
                         Array.Empty<DirectiveNode>(),
                         Array.Empty<ArgumentNode>(),
-                        null)
+                        null),
                 })
             : new SelectionSetNode(
                 new ISelectionNode[]
@@ -398,6 +398,6 @@ internal static class IntrospectionQueryBuilder
                         Array.Empty<DirectiveNode>(),
                         Array.Empty<ArgumentNode>(),
                         null),
-                    ofType
+                    ofType,
                 });
 }

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryHelper.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryHelper.cs
@@ -38,7 +38,7 @@ internal static class IntrospectionQueryHelper
         {
             Method = options.Method,
             Uri = options.Uri,
-            OnMessageCreated = options.OnMessageCreated
+            OnMessageCreated = options.OnMessageCreated,
         };
 
     private static string GetArgumentDeprecationQuery() => GetQueryFile(_argumentDeprecationQueryFile);

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/TypeKind.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/Models/TypeKind.cs
@@ -14,7 +14,7 @@ public enum TypeKind
     ENUM = 8,
     SCALAR = 16,
     LIST = 32,
-    NON_NULL = 64
+    NON_NULL = 64,
 }
 #pragma warning restore CA1707
 #pragma warning restore CS1720

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
@@ -15,11 +15,11 @@ public class IntrospectionQueryBuilderTests
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }
-    
+
     [Fact]
     public void Create_Query_With_ArgumentDeprecation()
     {
@@ -27,16 +27,16 @@ public class IntrospectionQueryBuilderTests
         var options = new IntrospectionOptions();
         var features = new ServerCapabilities
         {
-            HasArgumentDeprecation = true
+            HasArgumentDeprecation = true,
         };
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }
-    
+
     [Fact]
     public void Create_Query_With_DirectiveLocations()
     {
@@ -44,16 +44,16 @@ public class IntrospectionQueryBuilderTests
         var options = new IntrospectionOptions();
         var features = new ServerCapabilities
         {
-            HasDirectiveLocations = true
+            HasDirectiveLocations = true,
         };
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }
-    
+
     [Fact]
     public void Create_Query_With_RepeatableDirectives()
     {
@@ -61,16 +61,16 @@ public class IntrospectionQueryBuilderTests
         var options = new IntrospectionOptions();
         var features = new ServerCapabilities
         {
-            HasRepeatableDirectives = true
+            HasRepeatableDirectives = true,
         };
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }
-    
+
     [Fact]
     public void Create_Query_With_SchemaDescription()
     {
@@ -78,16 +78,16 @@ public class IntrospectionQueryBuilderTests
         var options = new IntrospectionOptions();
         var features = new ServerCapabilities
         {
-            HasSchemaDescription = true
+            HasSchemaDescription = true,
         };
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }
-    
+
     [Fact]
     public void Create_Query_With_SubscriptionSupport()
     {
@@ -95,12 +95,12 @@ public class IntrospectionQueryBuilderTests
         var options = new IntrospectionOptions();
         var features = new ServerCapabilities
         {
-            HasSubscriptionSupport = true
+            HasSubscriptionSupport = true,
         };
 
         // act
         var document = IntrospectionQueryBuilder.Build(features, options);
-        
+
         //assert
         document.Print().MatchSnapshot();
     }

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/MiddlewareCompilerTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/MiddlewareCompilerTests.cs
@@ -20,11 +20,11 @@ public class MiddlewareCompilerTests
                         new List<IParameterHandler>
                         {
                             new TypeParameterHandler(typeof(string), Expression.Constant("abc")),
-                            new ServiceParameterHandler(services)
+                            new ServiceParameterHandler(services),
                         });
-            
+
         // assert
-        var middleware = 
+        var middleware =
             factory.Invoke(new EmptyServiceProvider(), c => default);
         Assert.Equal("abc", middleware.Some);
     }
@@ -40,21 +40,21 @@ public class MiddlewareCompilerTests
                         new List<IParameterHandler>
                         {
                             new TypeParameterHandler(typeof(string), Expression.Constant("abc")),
-                            new ServiceParameterHandler(services)
+                            new ServiceParameterHandler(services),
                         });
 
-        var middleware = 
+        var middleware =
             factory.Invoke(new EmptyServiceProvider(), c => default);
 
         // act
-        var pipeline =  
+        var pipeline =
             MiddlewareCompiler<CustomClassMiddleware>.CompileDelegate<CustomContext>(
                 (context, middleware) =>
                     new List<IParameterHandler>
                     {
-                        new TypeParameterHandler(typeof(string), Expression.Constant("def"))
+                        new TypeParameterHandler(typeof(string), Expression.Constant("def")),
                     });
-            
+
         // assert
         var context = new CustomContext(new EmptyServiceProvider());
         pipeline.Invoke(context, middleware);


### PR DESCRIPTION
- Enforce trailing commas in lists;
- Add trailing commas in some of the projects.

Now, I think naming conventions can't be properly configured in a generic way.
Rider would simply ignore them.

There are Rider settings, but they are:
- Rider-specific,
- per-solution,
- are currently ignored in the repo.

So I'll refrain from further action on this for now.