### PR TITLE
Update Subscription docs (remove generic argument in SubscribeAsync)

### DIFF
--- a/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
+++ b/website/src/docs/hotchocolate/v13/defining-a-schema/subscriptions.md
@@ -104,7 +104,7 @@ public class SubscriptionType : ObjectType
                 var receiver = context.Service<ITopicEventReceiver>();
 
                 ISourceStream stream =
-                    await receiver.SubscribeAsync<string, Book>("bookAdded");
+                    await receiver.SubscribeAsync<Book>("bookAdded");
 
                 return stream;
             });
@@ -346,7 +346,7 @@ public class Subscription
 {
     public ValueTask<ISourceStream<Book>> SubscribeToBooks(
         [Service] ITopicEventReceiver receiver)
-        => receiver.SubscribeAsync<string, Book>("ExampleTopic");
+        => receiver.SubscribeAsync<Book>("ExampleTopic");
 
     [Subscribe(With = nameof(SubscribeToBooks))]
     public Book BookAdded([EventMessage] Book book)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Removed first generic argument from `SubscribeAsync`.

Closes #6799
