### PR TITLE
Adds the limit for the deferred stream's queue size

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
@@ -10,6 +10,7 @@ public interface IRequestExecutorOptionsAccessor
     : IErrorHandlerOptionsAccessor
     , IRequestTimeoutOptionsAccessor
     , IPersistedOperationOptionsAccessor
+    , IStreamOptionsAccessor
 {
     /// <summary>
     /// Specifies that the transport is allowed to provide the schema SDL document as a file.

--- a/src/HotChocolate/Core/src/Execution/Options/IStreamOptionsAccessor.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/IStreamOptionsAccessor.cs
@@ -1,0 +1,14 @@
+namespace HotChocolate.Execution.Options;
+
+/// <summary>
+/// Represents a dedicated options accessor to read the configuration
+/// of the query execution engine streaming features.
+/// </summary>
+public interface IStreamOptionsAccessor
+{
+    /// <summary>
+    /// The number of items that can be prefetched from
+    /// the data source and buffered while streaming.
+    /// </summary>
+    int StreamBufferSize { get; }
+}

--- a/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
@@ -12,6 +12,7 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
     private static readonly TimeSpan _minExecutionTimeout = TimeSpan.FromMilliseconds(100);
     private TimeSpan _executionTimeout;
     private PersistedOperationOptions _persistedOperations = new();
+    private int _streamBufferSize;
 
     /// <summary>
     /// <para>Initializes a new instance of <see cref="RequestExecutorOptions"/>.</para>
@@ -26,6 +27,7 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
         _executionTimeout = Debugger.IsAttached
             ? TimeSpan.FromMinutes(30)
             : TimeSpan.FromSeconds(30);
+        _streamBufferSize = 100;
     }
 
     /// <summary>
@@ -67,6 +69,20 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
         {
             _persistedOperations = value
                 ?? throw new ArgumentNullException(nameof(PersistedOperations));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets maximum allowed number of items that can be
+    /// prefetched from the data source and buffered while streaming.
+    /// The minimum allowed value is <c>1</c> item.
+    /// </summary>
+    public int StreamBufferSize
+    {
+        get => _streamBufferSize;
+        set
+        {
+            _streamBufferSize = value >= 1 ? value : 1; 
         }
     }
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/DeferredExecutionTask.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DeferredExecutionTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using HotChocolate.Utilities;
 using static HotChocolate.WellKnownContextData;
@@ -24,7 +25,7 @@ internal abstract class DeferredExecutionTask
     public IImmutableDictionary<string, object?> ScopedContextData { get; }
 
     /// <summary>
-    /// Starts executing the deferred execution task.
+    /// Creates a dispatcher for the deferred execution task.
     /// </summary>
     /// <param name="operationContextOwner">
     /// The operation context owner.
@@ -35,7 +36,7 @@ internal abstract class DeferredExecutionTask
     /// <param name="patchId">
     /// The internal identifier of the object that the result will be patched into.
     /// </param>
-    public void Begin(OperationContextOwner operationContextOwner, uint resultId, uint patchId)
+    public TaskDispatcher CreateDispatcher(OperationContextOwner operationContextOwner, uint resultId, uint patchId)
     {
         // retrieve the task on which this task depends upon. We do this to ensure that the result
         // of this task is not delivered before the parent result is delivered.
@@ -46,20 +47,7 @@ internal abstract class DeferredExecutionTask
             parentResultId = id;
         }
 
-        var capturedContext = ExecutionContext.Capture();
-        if (capturedContext is null)
-        {
-            ExecuteAsync(operationContextOwner, resultId, parentResultId, patchId).FireAndForget();
-        }
-        else
-        {
-            var execute = () =>
-                ExecutionContext.Run(
-                    capturedContext,
-                    _ => ExecuteAsync(operationContextOwner, resultId, parentResultId, patchId),
-                    null);
-            execute.FireAndForget();
-        }
+        return new(this, operationContextOwner, resultId, parentResultId, patchId);
     }
 
     /// <summary>
@@ -82,4 +70,60 @@ internal abstract class DeferredExecutionTask
         uint resultId,
         uint parentResultId,
         uint patchId);
+
+    /// <summary>
+    /// Wrapper which is used to dispatch the deferred execution task.
+    /// </summary>
+    /// <param name="task">
+    /// Deferred execution task.
+    /// </param>
+    /// <param name="operationContextOwner">
+    /// The operation context owner.
+    /// </param>
+    /// <param name="resultId">
+    /// The internal result identifier.
+    /// </param>
+    /// <param name="parentResultId">
+    /// The parent result identifier.
+    /// </param>
+    /// <param name="patchId">
+    /// The internal identifier of the object that the result will be patched into.
+    /// </param>
+    public class TaskDispatcher(
+        DeferredExecutionTask task,
+        OperationContextOwner operationContextOwner,
+        uint resultId,
+        uint parentResultId,
+        uint patchId)
+    {
+        private bool _isDispatched = false;
+
+        /// <summary>
+        /// Dispatches the deferred execution task.
+        /// </summary>
+        public void Dispatch()
+        {
+            if (_isDispatched)
+            {
+                throw new InvalidOperationException("Task was already dispatched with current dispatcher.");
+            }
+
+            _isDispatched = true;
+
+			var capturedContext = ExecutionContext.Capture();
+	        if (capturedContext is null)
+	        {
+	            task.ExecuteAsync(operationContextOwner, resultId, parentResultId, patchId).FireAndForget();
+	        }
+	        else
+	        {
+	            var execute = () =>
+	                ExecutionContext.Run(
+	                    capturedContext,
+	                    _ => task.ExecuteAsync(operationContextOwner, resultId, parentResultId, patchId),
+	                    null);
+	            execute.FireAndForget();
+	        }
+        }
+    }
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/DeferredFragment.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DeferredFragment.cs
@@ -88,7 +88,8 @@ internal sealed class DeferredFragment : DeferredExecutionTask
                     .BuildResult();
 
             // complete the task and provide the result
-            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result));
+            var cancellationToken = operationContext.RequestAborted;
+            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result), cancellationToken);
         }
         finally
         {

--- a/src/HotChocolate/Core/src/Execution/Processing/DeferredStream.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DeferredStream.cs
@@ -72,6 +72,7 @@ internal sealed class DeferredStream : DeferredExecutionTask
         uint patchId)
     {
         var operationContext = operationContextOwner.OperationContext;
+        var cancellationToken = operationContext.RequestAborted;
 
         try
         {
@@ -83,7 +84,7 @@ internal sealed class DeferredStream : DeferredExecutionTask
             // if there is no child task, then there is no more data, so we can complete.
             if (_task.ChildTask is null)
             {
-                operationContext.DeferredScheduler.Complete(new(resultId, parentResultId));
+                operationContext.DeferredScheduler.Complete(new(resultId, parentResultId), cancellationToken);
                 return;
             }
 
@@ -99,14 +100,18 @@ internal sealed class DeferredStream : DeferredExecutionTask
             await _task.ChildTask.CompleteUnsafeAsync().ConfigureAwait(false);
 
             // we will register this same task again to get the next item.
-            operationContext.DeferredScheduler.Register(this, patchId);
-            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result));
+            var taskDispatcher = operationContext.DeferredScheduler.Register(this, patchId);
+            // we have to complete before dispatching the task again: this protects us from
+            // memory exhaustion if we dispatch tasks faster than we process results.
+            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result), cancellationToken);
+            // now we can dispatch the task.
+            taskDispatcher.Dispatch();
         }
         catch (Exception ex)
         {
             var builder = operationContext.ErrorHandler.CreateUnexpectedError(ex);
             var result = OperationResultBuilder.CreateError(builder.Build());
-            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result));
+            operationContext.DeferredScheduler.Complete(new(resultId, parentResultId, result), cancellationToken);
         }
         finally
         {

--- a/src/HotChocolate/Core/src/Execution/Processing/DeferredWorkScheduler.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/DeferredWorkScheduler.cs
@@ -2,6 +2,7 @@ using HotChocolate.Execution.DependencyInjection;
 using HotChocolate.Execution.Instrumentation;
 using Microsoft.Extensions.DependencyInjection;
 using static HotChocolate.Execution.OperationResultBuilder;
+using static HotChocolate.Execution.Processing.DeferredExecutionTask;
 
 namespace HotChocolate.Execution.Processing;
 
@@ -58,7 +59,7 @@ internal sealed class DeferredWorkScheduler
     /// <summary>
     /// Registers deferred work
     /// </summary>
-    public void Register(DeferredExecutionTask task, ResultData parentResult)
+    public TaskDispatcher Register(DeferredExecutionTask task, ResultData parentResult)
     {
         // first we get the result identifier which is used to refer to the result that we defer.
         var resultId = StateOwner.State.CreateId();
@@ -77,20 +78,22 @@ internal sealed class DeferredWorkScheduler
         // patches that cannot be applied.
         _parentContext.Result.AddPatchId(patchId);
 
-        // with all in place we will start the execution of the deferred task.
-        task.Begin(taskContextOwner, resultId, patchId);
+        // finally we create a dispatcher for the deferred task.
+        return task.CreateDispatcher(taskContextOwner, resultId, patchId);
     }
 
-    public void Register(DeferredExecutionTask task, uint patchId)
+    public TaskDispatcher Register(DeferredExecutionTask task, uint patchId)
     {
         var resultId = StateOwner.State.CreateId();
         var taskContextOwner = _operationContextFactory.Create();
         taskContextOwner.OperationContext.InitializeFrom(_parentContext);
-        task.Begin(taskContextOwner, resultId, patchId);
+
+        // finally we create a dispatcher for the deferred task.
+        return task.CreateDispatcher(taskContextOwner, resultId, patchId);
     }
 
-    public void Complete(DeferredExecutionTaskResult result)
-        => StateOwner.State.Complete(result);
+    public void Complete(DeferredExecutionTaskResult result, CancellationToken cancellationToken)
+        => StateOwner.State.Complete(result, cancellationToken);
 
     public IAsyncEnumerable<IOperationResult> CreateResultStream(IOperationResult initialResult)
         => new DeferredResultStream(

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
@@ -198,7 +198,7 @@ internal sealed partial class ResolverTask
             {
                 // if the stream has more items than the initial requested items then we will
                 // defer the rest of the stream.
-                _operationContext.DeferredScheduler.Register(
+                var taskDispatcher = _operationContext.DeferredScheduler.Register(
                     new DeferredStream(
                         Selection,
                         streamDirective.Label,
@@ -208,6 +208,8 @@ internal sealed partial class ResolverTask
                         enumerator,
                         _context.ScopedContextData),
                     _context.ParentResult);
+
+                taskDispatcher.Dispatch();
             }
 
             return list;

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTaskFactory.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTaskFactory.cs
@@ -348,7 +348,7 @@ internal static class ResolverTaskFactory
             var fragment = fragments[i];
             if (!fragment.IsConditional || fragment.IsIncluded(includeFlags))
             {
-                operationContext.DeferredScheduler.Register(
+                var taskDispatcher = operationContext.DeferredScheduler.Register(
                     new DeferredFragment(
                         fragment,
                         fragment.GetLabel(operationContext.Variables),
@@ -356,6 +356,8 @@ internal static class ResolverTaskFactory
                         parent,
                         scopedContext),
                     parentResult);
+
+                taskDispatcher.Dispatch();
             }
         }
     }

--- a/src/HotChocolate/Core/src/Execution/RequestExecutorResolver.cs
+++ b/src/HotChocolate/Core/src/Execution/RequestExecutorResolver.cs
@@ -300,6 +300,8 @@ internal sealed partial class RequestExecutorResolver
             static s => s.GetRequiredService<RequestExecutorOptions>());
         serviceCollection.AddSingleton<IPersistedOperationOptionsAccessor>(
             static s => s.GetRequiredService<RequestExecutorOptions>());
+        serviceCollection.AddSingleton<IStreamOptionsAccessor>(
+            static s => s.GetRequiredService<RequestExecutorOptions>());
 
         serviceCollection.AddSingleton<IPreparedOperationCache>(
             _ => new DefaultPreparedOperationCache(


### PR DESCRIPTION
Fixes the issue with streaming: if the rate of consuming data by the client is slower than the rate of streaming data by the server, the server prefetches too much data from the source.

Proposed solution is to limit the queue size (size of the result buffer) in `DeferredWorkState`.

Changes:
- size of the queue in `DeferredWorkState` has a limit now;
- action of registering `DeferredExecutionTask` is unbound from its starting with new `TaskDispatcher` class;
- previous `DeferredExecutionTask` has to complete before starting the new one in `DeferredStream`.
