### PR TITLE
Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,13 +2,21 @@ name: Bug Report
 description: Report a bug to help us improve.
 labels: [🐛 bug]
 body:
-  - type: checkboxes
+  - type: markdown
     attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the issue you encountered. [Github Issue Tracker](https://github.com/ChilliCream/graphql-platform/issues)
-      options:
-      - label: I have searched the existing issues
-        required: true
+      value: |
+        **Before you start...**
+
+        This form is only for submitting bug reports. If you have a usage question
+        or are unsure if this is really a bug, make sure to:
+
+        - Read the [documentation](https://chillicream.com/docs)
+        - Ask on [Slack](https://slack.chillicream.com/)
+        - Look for / ask questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/hotchocolate)
+
+        Also try to search for your issue &ndash; it may have already been answered or even fixed in the main branch.
+        However, if you find that an old, closed issue still persists in the latest version,
+        you should open a new issue using the form below, instead of commenting on the old issue.
   - type: dropdown
     id: product
     attributes:
@@ -21,11 +29,26 @@ body:
         - Green Donut
     validations:
       required: true
-  - type: textarea
-    id: description
+  - type: input
+    id: version
     attributes:
-      label: Describe the bug
-      description: Also tell us, what did you expect to happen?
+      label: Version
+      description: What version of the selected product are you running?
+      placeholder: "12.0.0"
+    validations:
+      required: true
+  - type: input
+    id: reproduction-url
+    attributes:
+      label: Link to minimal reproduction
+      description: |
+        Add the URL to a public Git repository or ZIP file.
+
+        The reproduction should be **minimal** - i.e. it should contain only the bare minimum amount of code needed
+        to show the bug.
+
+        Please do not just fill in a random link. The issue will be closed if no valid reproduction is provided.
+      placeholder: Reproduction URL
     validations:
       required: true
   - type: textarea
@@ -33,9 +56,20 @@ body:
     attributes:
       label: Steps to reproduce
       description: |
-        A list of steps that can be followed to recreate the bug.
-        If it cannot be described in simple steps, create a GitHub repository with code that clearly showcases the described bug. Include a link to the repository in the box below.
-      value: "1. "
+        What do we need to do after opening your reproduction in order to make the bug happen?
+        Clear and concise reproduction instructions are important for us to be able to triage your issue in a timely manner.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is expected?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What is actually happening?
     validations:
       required: true
   - type: textarea
@@ -47,18 +81,11 @@ body:
         This will be automatically formatted into code, so no need for backticks.
       render: shell
   - type: textarea
+    id: additional-context
     attributes:
-      label: Additional Context?
+      label: Additional context
       description: |
         Please add any other contextual information about the problem, that might be relevant and help explain the issue you're facing.
         You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: What version of the selected product are you running?
-      placeholder: "12.0.0"
-    validations:
-      required: true


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated the bug report template, inspired by the [Vue.js template](https://github.com/vuejs/core/blob/f1068fc60ca511f68ff0aaedcc18b39124791d29/.github/ISSUE_TEMPLATE/bug_report.yml).

---

- The Stack Overflow link links to https://stackoverflow.com/questions/tagged/hotchocolate, which is only one of the four products. Is that a problem? There is also a `strawberryshake` tag, but nothing for Banana Cake Pop or Green Donut.
- The text specifies either a public Git repository or a ZIP file – is that okay, or would you prefer only repositories?
- Would it make sense to merge the logs and additional-context into a single field (without syntax highlighting), so that there aren't too many fields?