### PR TITLE
feat[ApolloFederation]: add support for federation v2.6 and v2.7

### DIFF
--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Extensions/ApolloFederationRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Extensions/ApolloFederationRequestExecutorBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class ApolloFederationRequestExecutorBuilderExtensions
     /// </exception>
     public static IRequestExecutorBuilder AddApolloFederation(
         this IRequestExecutorBuilder builder,
-        FederationVersion version = FederationVersion.Latest)
+        FederationVersion version = FederationVersion.Default)
     {
         ArgumentNullException.ThrowIfNull(builder);
         builder.SetContextData(FederationContextData.FederationVersion, version);

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Extensions/FederationVersionExtensions.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Extensions/FederationVersionExtensions.cs
@@ -14,8 +14,10 @@ internal static class FederationVersionExtensions
         [new Uri(FederationVersionUrls.Federation23)] = FederationVersion.Federation23,
         [new Uri(FederationVersionUrls.Federation24)] = FederationVersion.Federation24,
         [new Uri(FederationVersionUrls.Federation25)] = FederationVersion.Federation25,
+        [new Uri(FederationVersionUrls.Federation26)] = FederationVersion.Federation26,
+        [new Uri(FederationVersionUrls.Federation27)] = FederationVersion.Federation27,
     };
-    
+
     private static readonly Dictionary<FederationVersion, Uri> _versionToUri = new()
     {
         [FederationVersion.Federation20] = new(FederationVersionUrls.Federation20),
@@ -24,8 +26,10 @@ internal static class FederationVersionExtensions
         [FederationVersion.Federation23] = new(FederationVersionUrls.Federation23),
         [FederationVersion.Federation24] = new(FederationVersionUrls.Federation24),
         [FederationVersion.Federation25] = new(FederationVersionUrls.Federation25),
+        [FederationVersion.Federation26] = new(FederationVersionUrls.Federation26),
+        [FederationVersion.Federation27] = new(FederationVersionUrls.Federation27),
     };
-    
+
     public static FederationVersion GetFederationVersion<T>(
         this IDescriptor<T> descriptor)
         where T : DefinitionBase
@@ -40,7 +44,7 @@ internal static class FederationVersionExtensions
         // TODO : resources
         throw new InvalidOperationException("The configuration state is invalid.");
     }
-    
+
     public static FederationVersion GetFederationVersion(
         this IDescriptorContext context)
     {
@@ -56,26 +60,26 @@ internal static class FederationVersionExtensions
 
     public static Uri ToUrl(this FederationVersion version)
     {
-        if(_versionToUri.TryGetValue(version, out var url))
+        if (_versionToUri.TryGetValue(version, out var url))
         {
             return url;
         }
-        
+
         // TODO : resources
         throw new ArgumentException("The federation version is not supported.", nameof(version));
     }
-    
+
     public static FederationVersion ToVersion(this Uri url)
     {
-        if(_uriToVersion.TryGetValue(url, out var version))
+        if (_uriToVersion.TryGetValue(url, out var version))
         {
             return version;
         }
-        
+
         // TODO : resources
         throw new ArgumentException("The federation url is not supported.", nameof(url));
     }
-    
+
     public static bool TryToVersion(this Uri url, out FederationVersion version)
         => _uriToVersion.TryGetValue(url, out version);
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationTypeNames.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationTypeNames.cs
@@ -12,12 +12,14 @@ internal static class FederationTypeNames
     public const string KeyDirective_Name = "key";
     public const string LinkDirective_Name = "link";
     public const string OverrideDirective_Name = "override";
+    public const string PolicyDirective_Name = "policy";
     public const string ProvidesDirective_Name = "provides";
     public const string RequiresDirective_Name = "requires";
     public const string RequiresScopesDirective_Name = "requiresScopes";
     public const string ShareableDirective_Name = "shareable";
     public const string FieldSetType_Name = "FieldSet";
     public const string ScopeType_Name = "Scope";
+    public const string PolicyType_Name = "Policy";
     public const string AnyType_Name = "_Any";
     public const string EntityType_Name = "_Entity";
     public const string ServiceType_Name = "_Service";

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersion.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersion.cs
@@ -13,6 +13,8 @@ public enum FederationVersion
     Federation23 = 2_3,
     Federation24 = 2_4,
     Federation25 = 2_5,
-    // Federation26 = 2_6,
-    Latest = Federation25,
+    Federation26 = 2_6,
+    Federation27 = 2_7,
+    // default to latest-1
+    Default = Federation26,
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersion.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersion.cs
@@ -17,4 +17,5 @@ public enum FederationVersion
     Federation27 = 2_7,
     // default to latest-1
     Default = Federation26,
+    Latest = Federation27
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersionUrls.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationVersionUrls.cs
@@ -8,4 +8,6 @@ internal static class FederationVersionUrls
     public const string Federation23 = "https://specs.apollo.dev/federation/v2.3";
     public const string Federation24 = "https://specs.apollo.dev/federation/v2.4";
     public const string Federation25 = "https://specs.apollo.dev/federation/v2.5";
+    public const string Federation26 = "https://specs.apollo.dev/federation/v2.6";
+    public const string Federation27 = "https://specs.apollo.dev/federation/v2.7";
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.Designer.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.Designer.cs
@@ -7,196 +7,257 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace HotChocolate.ApolloFederation.Properties {
+namespace HotChocolate.ApolloFederation.Properties
+{
     using System;
-    
-    
+
+
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal partial class FederationResources {
-        
+    internal partial class FederationResources
+    {
+
         private static System.Resources.ResourceManager resourceMan;
-        
+
         private static System.Globalization.CultureInfo resourceCulture;
-        
+
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal FederationResources() {
+        internal FederationResources()
+        {
         }
-        
+
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.Equals(null, resourceMan)) {
+        internal static System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.Equals(null, resourceMan))
+                {
                     System.Resources.ResourceManager temp = new System.Resources.ResourceManager("HotChocolate.ApolloFederation.Properties.FederationResources", typeof(FederationResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static System.Globalization.CultureInfo Culture {
-            get {
+        internal static System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
-        internal static string FieldsetType_Description {
-            get {
+
+        internal static string FieldsetType_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("FieldsetType_Description", resourceCulture);
             }
         }
-        
-        internal static string ScopeType_Description {
-            get {
+
+        internal static string ScopeType_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("ScopeType_Description", resourceCulture);
             }
         }
-        
-        internal static string TagDirective_Description {
-            get {
+
+        internal static string PolicyType_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("PolicyType_Description", resourceCulture);
+            }
+        }
+
+        internal static string TagDirective_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("TagDirective_Description", resourceCulture);
             }
         }
-        
-        internal static string EntityType_Description {
-            get {
+
+        internal static string EntityType_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("EntityType_Description", resourceCulture);
             }
         }
-        
-        internal static string PolicyDirective_Description {
-            get {
-                return ResourceManager.GetString("PolicyDirective_Description", resourceCulture);
-            }
-        }
-        
-        internal static string ThrowHelper_FieldSet_HasInvalidFormat {
-            get {
+
+        internal static string ThrowHelper_FieldSet_HasInvalidFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_FieldSet_HasInvalidFormat", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Scalar_CannotParseValue {
-            get {
+
+        internal static string ThrowHelper_Scalar_CannotParseValue
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Scalar_CannotParseValue", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Key_FieldSet_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_Key_FieldSet_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Key_FieldSet_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Provides_FieldSet_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_Provides_FieldSet_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Provides_FieldSet_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Requires_FieldSet_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_Requires_FieldSet_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Requires_FieldSet_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_ComposeDirective_Name_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_ComposeDirective_Name_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_ComposeDirective_Name_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Link_Url_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_Link_Url_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Link_Url_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Contact_Name_CannotBeEmpty {
-            get {
+
+        internal static string ThrowHelper_Contact_Name_CannotBeEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Contact_Name_CannotBeEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_FederationVersion_Unknown {
-            get {
+
+        internal static string ThrowHelper_FederationVersion_Unknown
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_FederationVersion_Unknown", resourceCulture);
             }
         }
-        
-        internal static string FieldDescriptorExtensions_Key_FieldSet_CannotBeNullOrEmpty {
-            get {
+
+        internal static string FieldDescriptorExtensions_Key_FieldSet_CannotBeNullOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("FieldDescriptorExtensions_Key_FieldSet_CannotBeNullOrEmpty", resourceCulture);
             }
         }
-        
-        internal static string FieldDescriptorExtensions_Requires_FieldSet_CannotBeNullOrEmpty {
-            get {
+
+        internal static string FieldDescriptorExtensions_Requires_FieldSet_CannotBeNullOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("FieldDescriptorExtensions_Requires_FieldSet_CannotBeNullOrEmpty", resourceCulture);
             }
         }
-        
-        internal static string FieldDescriptorExtensions_Provides_FieldSet_CannotBeNullOrEmpty {
-            get {
+
+        internal static string FieldDescriptorExtensions_Provides_FieldSet_CannotBeNullOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("FieldDescriptorExtensions_Provides_FieldSet_CannotBeNullOrEmpty", resourceCulture);
             }
         }
-        
-        internal static string FieldDescriptorExtensions_Override_From_CannotBeNullOrEmpty {
-            get {
+
+        internal static string FieldDescriptorExtensions_Override_From_CannotBeNullOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("FieldDescriptorExtensions_Override_From_CannotBeNullOrEmpty", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_EntityType_NoEntities {
-            get {
+
+        internal static string ThrowHelper_EntityType_NoEntities
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_EntityType_NoEntities", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_EntityResolver_NoEntityResolverFound {
-            get {
+
+        internal static string ThrowHelper_EntityResolver_NoEntityResolverFound
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_EntityResolver_NoEntityResolverFound", resourceCulture);
             }
         }
-        
-        internal static string EntityResolver_MustBeMethod {
-            get {
+
+        internal static string EntityResolver_MustBeMethod
+        {
+            get
+            {
                 return ResourceManager.GetString("EntityResolver_MustBeMethod", resourceCulture);
             }
         }
-        
-        internal static string ThrowHelper_Any_HasInvalidFormat {
-            get {
+
+        internal static string ThrowHelper_Any_HasInvalidFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("ThrowHelper_Any_HasInvalidFormat", resourceCulture);
             }
         }
-        
-        internal static string ExpressionHelper_GetScopedStateWithDefault_NoDefaultValue {
-            get {
+
+        internal static string ExpressionHelper_GetScopedStateWithDefault_NoDefaultValue
+        {
+            get
+            {
                 return ResourceManager.GetString("ExpressionHelper_GetScopedStateWithDefault_NoDefaultValue", resourceCulture);
             }
         }
-        
-        internal static string Any_Description {
-            get {
+
+        internal static string Any_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("Any_Description", resourceCulture);
             }
         }
-        
-        internal static string ResolveReference_MustBeMethod {
-            get {
+
+        internal static string ResolveReference_MustBeMethod
+        {
+            get
+            {
                 return ResourceManager.GetString("ResolveReference_MustBeMethod", resourceCulture);
             }
         }
-        
-        internal static string PolicyCollectionType_ParseValue_ExpectedStringArray {
-            get {
+
+        internal static string PolicyCollectionType_ParseValue_ExpectedStringArray
+        {
+            get
+            {
                 return ResourceManager.GetString("PolicyCollectionType_ParseValue_ExpectedStringArray", resourceCulture);
             }
         }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.cs
@@ -16,17 +16,17 @@ internal partial class FederationResources
 
     public const string ExtendsDirective_Description =
         "Directive to indicate that marks target object as extending part of the federated schema.";
-    
+
     public const string ContactDirective_Description =
         "Provides contact information of the owner responsible for this subgraph schema.";
 
     public const string RequiresDirective_Description =
         "Used to annotate the required input fieldset from a base type for a resolver.";
-    
+
     public const string OverrideDirective_Description =
         "Overrides fields resolution logic from other subgraph. " +
         "Used for migrating fields from one subgraph to another.";
-    
+
     public const string ShareableDirective_Description =
         "Indicates that given object and/or field can be resolved by multiple subgraphs.";
 
@@ -38,7 +38,7 @@ internal partial class FederationResources
 
     public const string ComposeDirective_Description =
         "Marks underlying custom directive to be included in the Supergraph schema.";
-    
+
     public const string ServiceType_Description =
         "This type provides a field named sdl: String! which exposes the SDL of the " +
         "service's schema. This SDL (schema definition language) is a printed version " +
@@ -48,8 +48,12 @@ internal partial class FederationResources
     public const string AuthenticatedDirective_Description =
         "Indicates to composition that the target element is accessible " +
         "only to the authenticated supergraph users.";
-    
+
     public const string RequiresScopesDirective_Description =
         "Indicates to composition that the target element is accessible only " +
         "to the authenticated supergraph users with the appropriate JWT scopes.";
+
+    public const string PolicyDirective_Description =
+        "Indicates to composition that the target element is restricted based " +
+        "on authorization policies.";
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.cs
@@ -56,4 +56,13 @@ internal partial class FederationResources
     public const string PolicyDirective_Description =
         "Indicates to composition that the target element is restricted based " +
         "on authorization policies.";
+
+    public const string LinkDirective_Description =
+        "Links definitions within the document to external schemas.";
+
+    public const string LinkDirective_Url_Description =
+        "Gets imported specification url.";
+
+    public const string LinkDirective_Import_Description =
+        "Gets optional list of imported element names.";
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.resx
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.resx
@@ -121,16 +121,16 @@
     <value>Scalar representing a set of fields.</value>
   </data>
   <data name="ScopeType_Description" xml:space="preserve">
-    <value>Scalar representing a JWT scope</value>
+    <value>Scalar representing a JWT scope.</value>
+  </data>
+  <data name="PolicyType_Description" xml:space="preserve">
+    <value>Scalar representing an authorization policy.</value>
   </data>
   <data name="TagDirective_Description" xml:space="preserve">
     <value>Allows users to annotate fields and types with additional metadata information.</value>
   </data>
   <data name="EntityType_Description" xml:space="preserve">
     <value>Union of all types that key directive applied. This information is needed by the Apollo federation gateway.</value>
-  </data>
-  <data name="PolicyDirective_Description" xml:space="preserve">
-    <value>Indicates to composition that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor.</value>
   </data>
   <data name="ThrowHelper_FieldSet_HasInvalidFormat" xml:space="preserve">
     <value>The fieldset has an invalid format.</value>

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/AuthenticatedDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/AuthenticatedDirective.cs
@@ -25,9 +25,9 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-[Package(Federation24)]
+[Package(Federation25)]
 [DirectiveType(
-    AuthenticatedDirective_Name, 
+    AuthenticatedDirective_Name,
     DirectiveLocation.Enum |
     DirectiveLocation.FieldDefinition |
     DirectiveLocation.Interface |

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ComposeDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ComposeDirective.cs
@@ -14,7 +14,7 @@ namespace HotChocolate.ApolloFederation.Types;
 ///
 /// <example>
 /// extend schema @composeDirective(name: "@custom")
-///   @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@composeDirective"])
+///   @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@composeDirective"])
 ///   @link(url: "https://myspecs.dev/custom/v1.0", import: ["@custom"])
 ///
 /// directive @custom on FIELD_DEFINITION
@@ -24,10 +24,10 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-[Package(Federation25)]
+[Package(Federation21)]
 [DirectiveType(ComposeDirective_Name, DirectiveLocation.Schema, IsRepeatable = true)]
 [GraphQLDescription(ComposeDirective_Description)]
 public sealed class ComposeDirective(string name)
-{    
+{
     public string Name { get; } = name;
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalDirective.cs
@@ -33,7 +33,7 @@ namespace HotChocolate.ApolloFederation.Types;
 [Package(Federation20)]
 [DirectiveType(ExternalDirective_Name, DirectiveLocation.FieldDefinition | DirectiveLocation.Object)]
 [GraphQLDescription(ExternalDirective_Description)]
-[ExternalLegacySupportAttribute]
+[ExternalLegacySupport]
 public sealed class ExternalDirective
 {
     public static ExternalDirective Default { get; } = new();

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalDirective.cs
@@ -6,7 +6,11 @@ namespace HotChocolate.ApolloFederation.Types;
 
 /// <summary>
 /// <code>
+/// # federation v1 definition
 /// directive @external on FIELD_DEFINITION
+///
+/// # federation v2 definition (applying on object = shorthand for applying on all fields)
+/// directive @external on OBJECT | FIELD_DEFINITION
 /// </code>
 ///
 /// The @external directive is used to mark a field as owned by another service.
@@ -27,8 +31,9 @@ namespace HotChocolate.ApolloFederation.Types;
 /// </example>
 /// </summary>
 [Package(Federation20)]
-[DirectiveType(ExternalDirective_Name, DirectiveLocation.FieldDefinition)]
+[DirectiveType(ExternalDirective_Name, DirectiveLocation.FieldDefinition | DirectiveLocation.Object)]
 [GraphQLDescription(ExternalDirective_Description)]
+[ExternalLegacySupportAttribute]
 public sealed class ExternalDirective
 {
     public static ExternalDirective Default { get; } = new();

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalLegacySupportAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ExternalLegacySupportAttribute.cs
@@ -2,19 +2,18 @@ using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.ApolloFederation.Types;
 
-internal sealed class KeyLegacySupportAttribute : DirectiveTypeDescriptorAttribute
+internal sealed class ExternalLegacySupportAttribute : DirectiveTypeDescriptorAttribute
 {
     protected override void OnConfigure(
         IDescriptorContext context,
         IDirectiveTypeDescriptor descriptor,
         Type type)
     {
-        // federation v1 @key only specified "fields" parameter
+        // federation v1 only supported @external on fields
         if (descriptor.GetFederationVersion() == FederationVersion.Federation10)
         {
-            var desc = (IDirectiveTypeDescriptor<KeyDirective>)descriptor;
-            desc.BindArgumentsExplicitly();
-            desc.Argument(t => t.Fields);
+            var desc = (IDirectiveTypeDescriptor<ExternalDirective>)descriptor;
+            desc.Location(DirectiveLocation.Field);
         }
     }
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/InterfaceObjectDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/InterfaceObjectDirective.cs
@@ -19,7 +19,7 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-[Package(Federation22)]
+[Package(Federation23)]
 [DirectiveType(InterfaceObject_Name, DirectiveLocation.Object)]
 [GraphQLDescription(InterfaceObjectDirective_Description)]
 public sealed class InterfaceObjectDirective

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/LinkDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/LinkDirective.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using HotChocolate.ApolloFederation.Properties;
 using static HotChocolate.ApolloFederation.FederationTypeNames;
 
 namespace HotChocolate.ApolloFederation.Types;
@@ -7,6 +8,7 @@ namespace HotChocolate.ApolloFederation.Types;
 /// Object representation of @link directive.
 /// </summary>
 [DirectiveType(LinkDirective_Name, DirectiveLocation.Schema, IsRepeatable = true)]
+[GraphQLDescription(FederationResources.LinkDirective_Description)]
 public sealed class LinkDirective
 {
     /// <summary>
@@ -28,10 +30,12 @@ public sealed class LinkDirective
     /// Gets imported specification url.
     /// </summary>
     [GraphQLType<NonNullType<StringType>>]
+    [GraphQLDescription(FederationResources.LinkDirective_Url_Description)]
     public Uri Url { get; }
 
     /// <summary>
     /// Gets optional list of imported element names.
     /// </summary>
+    [GraphQLDescription(FederationResources.LinkDirective_Import_Description)]
     public IReadOnlySet<string>? Import { get; }
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideAttribute.cs
@@ -34,33 +34,27 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-public sealed class OverrideAttribute : ObjectFieldDescriptorAttribute
+/// <remarks>
+/// Initializes new instance of <see cref="OverrideAttribute"/>
+/// </remarks>
+/// <param name="from">
+/// Name of the subgraph to be overridden
+/// </param>
+/// <param name="label">
+/// Optional label that will be evaulated at runtime to determine whether field should be overriden
+/// </param>
+public sealed class OverrideAttribute(string from, string? label = null) : ObjectFieldDescriptorAttribute
 {
-
-    /// <summary>
-    /// Initializes new instance of <see cref="OverrideAttribute"/>
-    /// </summary>
-    /// <param name="from">
-    /// Name of the subgraph to be overridden
-    /// </param>
-    /// <param name="label">
-    /// Optional label that will be evaulated at runtime to determine whether field should be overriden
-    /// </param>
-    public OverrideAttribute(string from, string? label = null)
-    {
-        From = from;
-        Label = label;
-    }
 
     /// <summary>
     /// Get name of the subgraph to be overridden.
     /// </summary>
-    public string From { get; }
+    public string From { get; } = from;
 
     /// <summary>
     /// Get optional label that will be evaulated at runtime to determine whether field should be overriden.
     /// </summary>
-    public string? Label { get; }
+    public string? Label { get; } = label;
 
     protected override void OnConfigure(
         IDescriptorContext context,

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideAttribute.cs
@@ -19,6 +19,20 @@ namespace HotChocolate.ApolloFederation.Types;
 ///   description: String @override(from: "BarSubgraph")
 /// }
 /// </example>
+///
+/// The progressive @override feature enables the gradual, progressive deployment of a subgraph
+/// with an @override field. As a subgraph developer, you can customize the percentage of traffic
+/// that the overriding and overridden subgraphs each resolve for a field. You apply a label to
+/// an @override field to set the percentage of traffic for the field that should be resolved by
+/// the overriding subgraph, with the remaining percentage resolved by the overridden subgraph.
+/// See <see href = "https://www.apollographql.com/docs/federation/entities-advanced/#incremental-migration-with-progressive-override">Apollo documentation</see>
+/// for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID!
+///   description: String @override(from: "BarSubgraph", label: "percent(1)")
+/// }
+/// </example>
 /// </summary>
 public sealed class OverrideAttribute : ObjectFieldDescriptorAttribute
 {
@@ -29,9 +43,13 @@ public sealed class OverrideAttribute : ObjectFieldDescriptorAttribute
     /// <param name="from">
     /// Name of the subgraph to be overridden
     /// </param>
-    public OverrideAttribute(string from)
+    /// <param name="label">
+    /// Optional label that will be evaulated at runtime to determine whether field should be overriden
+    /// </param>
+    public OverrideAttribute(string from, string? label = null)
     {
         From = from;
+        Label = label;
     }
 
     /// <summary>
@@ -39,11 +57,16 @@ public sealed class OverrideAttribute : ObjectFieldDescriptorAttribute
     /// </summary>
     public string From { get; }
 
+    /// <summary>
+    /// Get optional label that will be evaulated at runtime to determine whether field should be overriden.
+    /// </summary>
+    public string? Label { get; }
+
     protected override void OnConfigure(
         IDescriptorContext context,
         IObjectFieldDescriptor descriptor,
         MemberInfo member)
     {
-        descriptor.Override(From);
+        descriptor.Override(From, Label);
     }
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDescriptorExtensions.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDescriptorExtensions.cs
@@ -13,12 +13,28 @@ public static class OverrideDescriptorExtensions
     ///   description: String @override(from: "BarSubgraph")
     /// }
     /// </example>
+    /// The progressive @override feature enables the gradual, progressive deployment of a subgraph
+    /// with an @override field. As a subgraph developer, you can customize the percentage of traffic
+    /// that the overriding and overridden subgraphs each resolve for a field. You apply a label to
+    /// an @override field to set the percentage of traffic for the field that should be resolved by
+    /// the overriding subgraph, with the remaining percentage resolved by the overridden subgraph.
+    /// See <see href = "https://www.apollographql.com/docs/federation/entities-advanced/#incremental-migration-with-progressive-override">Apollo documentation</see>
+    /// for additional details.
+    /// <example>
+    /// type Foo @key(fields: "id") {
+    ///   id: ID!
+    ///   description: String @override(from: "BarSubgraph", label: "percent(1)")
+    /// }
+    /// </example>
     /// </summary>
     /// <param name="descriptor">
     /// The object field descriptor on which this directive shall be annotated.
     /// </param>
     /// <param name="from">
     /// Name of the subgraph to be overridden.
+    /// </param>
+    /// <param name="label">
+    /// Optional label that will be used at runtime to evaluate whether to override the field or not.
     /// </param>
     /// <returns>
     /// Returns the object field descriptor.
@@ -31,11 +47,12 @@ public static class OverrideDescriptorExtensions
     /// </exception>
     public static IObjectFieldDescriptor Override(
         this IObjectFieldDescriptor descriptor,
-        string from)
+        string from,
+        string? label = null)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         ArgumentException.ThrowIfNullOrEmpty(from);
 
-        return descriptor.Directive(new OverrideDirective(from));
+        return descriptor.Directive(new OverrideDirective(from, label));
     }
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDirective.cs
@@ -6,7 +6,11 @@ namespace HotChocolate.ApolloFederation.Types;
 
 /// <summary>
 /// <code>
+/// # federation v2.0 definition
 /// directive @override(from: String!) on FIELD_DEFINITION
+///
+/// # federation v2.7 definition
+/// directive @override(from: String!, label: String) on FIELD_DEFINITION
 /// </code>
 ///
 /// The @override directive is used to indicate that the current subgraph is taking
@@ -19,11 +23,28 @@ namespace HotChocolate.ApolloFederation.Types;
 ///   description: String @override(from: "BarSubgraph")
 /// }
 /// </example>
+///
+/// The progressive @override feature enables the gradual, progressive deployment of a subgraph
+/// with an @override field. As a subgraph developer, you can customize the percentage of traffic
+/// that the overriding and overridden subgraphs each resolve for a field. You apply a label to
+/// an @override field to set the percentage of traffic for the field that should be resolved by
+/// the overriding subgraph, with the remaining percentage resolved by the overridden subgraph.
+/// See <see href = "https://www.apollographql.com/docs/federation/entities-advanced/#incremental-migration-with-progressive-override">Apollo documentation</see>
+/// for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID!
+///   description: String @override(from: "BarSubgraph", label: "percent(1)")
+/// }
+/// </example>
 /// </summary>
 [Package(Federation20)]
 [DirectiveType(OverrideDirective_Name, DirectiveLocation.FieldDefinition)]
 [GraphQLDescription(OverrideDirective_Description)]
-public sealed class OverrideDirective(string from)
+[OverrideLegacySupport]
+public sealed class OverrideDirective(string from, string? label)
 {
     public string From { get; } = from;
+
+    public string? Label { get; } = label;
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideDirective.cs
@@ -38,13 +38,31 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
+/// <param name="from">
+/// Name of the subgraph to be overridden
+/// </param>
 [Package(Federation20)]
 [DirectiveType(OverrideDirective_Name, DirectiveLocation.FieldDefinition)]
 [GraphQLDescription(OverrideDirective_Description)]
 [OverrideLegacySupport]
-public sealed class OverrideDirective(string from, string? label)
+public sealed class OverrideDirective(string from)
 {
+
+    /// <summary>
+    /// Creates new instance of @override directive.
+    /// </summary>
+    /// <param name="from">
+    /// Name of the subgraph to be overridden
+    /// </param>
+    /// <param name="label">
+    /// Optional label that will be evaulated at runtime to determine whether field should be overriden
+    /// </param>
+    public OverrideDirective(string from, string? label = null) : this(from)
+    {
+        Label = label;
+    }
+
     public string From { get; } = from;
 
-    public string? Label { get; } = label;
+    public string? Label { get; }
 }

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideLegacySupportAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/OverrideLegacySupportAttribute.cs
@@ -1,0 +1,20 @@
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.ApolloFederation.Types;
+
+internal sealed class OverrideLegacySupportAttribute : DirectiveTypeDescriptorAttribute
+{
+    protected override void OnConfigure(
+        IDescriptorContext context,
+        IDirectiveTypeDescriptor descriptor,
+        Type type)
+    {
+        // prior to version 2.7 @override only specified "from" parameter
+        if (descriptor.GetFederationVersion() < FederationVersion.Federation27)
+        {
+            var desc = (IDirectiveTypeDescriptor<OverrideDirective>)descriptor;
+            desc.BindArgumentsExplicitly();
+            desc.Argument(t => t.From);
+        }
+    }
+}

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyAttribute.cs
@@ -22,6 +22,12 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
+/// <remarks>
+/// Initializes new instance of <see cref="PolicyAttribute"/>
+/// </remarks>
+/// <param name="policies">
+/// Array of required authentication policies.
+/// </param>
 [AttributeUsage(
     AttributeTargets.Class
     | AttributeTargets.Enum
@@ -31,23 +37,13 @@ namespace HotChocolate.ApolloFederation.Types;
     | AttributeTargets.Struct,
     AllowMultiple = true
 )]
-public sealed class PolicyAttribute : DescriptorAttribute
+public sealed class PolicyAttribute(string[] policies) : DescriptorAttribute
 {
-    /// <summary>
-    /// Initializes new instance of <see cref="PolicyAttribute"/>
-    /// </summary>
-    /// <param name="policies">
-    /// Array of required authentication policies.
-    /// </param>
-    public PolicyAttribute(string[] policies)
-    {
-        Policies = policies;
-    }
 
     /// <summary>
     /// Retrieves array of required authentication policies.
     /// </summary>
-    public string[] Policies { get; }
+    public string[] Policies { get; } = policies;
 
     protected internal override void TryConfigure(
         IDescriptorContext context,

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyAttribute.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.ApolloFederation.Types;
+
+/// <summary>
+/// <code>
+/// directive @policy(policies: [[Policy!]!]!) on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+///
+/// Indicates to composition that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor.
+/// Refer to the <see href = "https://www.apollographql.com/docs/router/configuration/authorization#policy"> Apollo Router article</see> for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @policy(policies: [["policy1"]])
+/// }
+/// </example>
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class
+    | AttributeTargets.Enum
+    | AttributeTargets.Interface
+    | AttributeTargets.Method
+    | AttributeTargets.Property
+    | AttributeTargets.Struct,
+    AllowMultiple = true
+)]
+public sealed class PolicyAttribute : DescriptorAttribute
+{
+    /// <summary>
+    /// Initializes new instance of <see cref="PolicyAttribute"/>
+    /// </summary>
+    /// <param name="policies">
+    /// Array of required authentication policies.
+    /// </param>
+    public PolicyAttribute(string[] policies)
+    {
+        Policies = policies;
+    }
+
+    /// <summary>
+    /// Retrieves array of required authentication policies.
+    /// </summary>
+    public string[] Policies { get; }
+
+    protected internal override void TryConfigure(
+        IDescriptorContext context,
+        IDescriptor descriptor,
+        ICustomAttributeProvider element)
+    {
+        switch (descriptor)
+        {
+            case IEnumTypeDescriptor desc:
+                desc.Policy(Policies);
+                break;
+
+            case IObjectTypeDescriptor desc:
+                desc.Policy(Policies);
+                break;
+
+            case IObjectFieldDescriptor desc:
+                desc.Policy(Policies);
+                break;
+
+            case IInterfaceTypeDescriptor desc:
+                desc.Policy(Policies);
+                break;
+
+            case IInterfaceFieldDescriptor desc:
+                desc.Policy(Policies);
+                break;
+        }
+    }
+}

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyDescriptorExtensions.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyDescriptorExtensions.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.Linq;
+using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
+using HotChocolate.Types.Helpers;
+
+namespace HotChocolate.ApolloFederation.Types;
+
+/// <summary>
+/// Provides extensions for applying @policy directive on type system descriptors.
+/// </summary>
+public static class PolicyDescriptorExtensions
+{
+    /// <summary>
+    /// Applies @policy directive to indicate that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor.
+    /// <example>
+    /// type Foo @key(fields: "id") {
+    ///   id: ID
+    ///   description: String @policy(policies: [["policy1"]])
+    /// }
+    /// </example>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The type descriptor on which this directive shall be annotated.
+    /// </param>
+    /// <param name="policies">Required authorization policies</param>
+    /// <returns>
+    /// Returns the type descriptor.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IEnumTypeDescriptor Policy(
+        this IEnumTypeDescriptor descriptor,
+        IReadOnlyList<Policy> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies, def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Applies @policy directive to indicate that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor.
+    /// <example>
+    /// type Foo @key(fields: "id") {
+    ///   id: ID
+    ///   description: String @policy(policies: [["policy1"]])
+    /// }
+    /// </example>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The type descriptor on which this directive shall be annotated.
+    /// </param>
+    /// <param name="policies">Required authrorization policies</param>
+    /// <returns>
+    /// Returns the type descriptor.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="descriptor"/> is <c>null</c>.
+    /// </exception>
+    public static IEnumTypeDescriptor Policy(
+        this IEnumTypeDescriptor descriptor,
+        IReadOnlyList<string> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies.Select(p => new Policy(p)).ToArray(), def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{Policy})"/>
+    public static IInterfaceFieldDescriptor Policy(
+        this IInterfaceFieldDescriptor descriptor,
+        IReadOnlyList<Policy> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies, def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{string})"/>
+    public static IInterfaceFieldDescriptor Policy(
+        this IInterfaceFieldDescriptor descriptor,
+        IReadOnlyList<string> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies.Select(p => new Policy(p)).ToArray(), def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{Policy})"/>
+    public static IInterfaceTypeDescriptor Policy(
+        this IInterfaceTypeDescriptor descriptor,
+        IReadOnlyList<Policy> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies, def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{string})"/>
+    public static IInterfaceTypeDescriptor Policy(
+        this IInterfaceTypeDescriptor descriptor,
+        IReadOnlyList<string> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies.Select(p => new Policy(p)).ToArray(), def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{Policy})"/>
+    public static IObjectFieldDescriptor Policy(
+        this IObjectFieldDescriptor descriptor,
+        IReadOnlyList<Policy> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies, def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{string})"/>
+    public static IObjectFieldDescriptor Policy(
+        this IObjectFieldDescriptor descriptor,
+        IReadOnlyList<string> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies.Select(p => new Policy(p)).ToArray(), def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{Policy})"/>
+    public static IObjectTypeDescriptor Policy(
+        this IObjectTypeDescriptor descriptor,
+        IReadOnlyList<Policy> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies, def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    /// <inheritdoc cref="Policy(IEnumTypeDescriptor, IReadOnlyList{string})"/>
+    public static IObjectTypeDescriptor Policy(
+        this IObjectTypeDescriptor descriptor,
+        IReadOnlyList<string> policies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        descriptor.Extend().OnBeforeCreate(
+            (ctx, def) =>
+            {
+                AddPolicies(policies.Select(p => new Policy(p)).ToArray(), def, ctx.TypeInspector);
+            });
+
+        return descriptor;
+    }
+
+    private static void AddPolicies(
+        IReadOnlyList<Policy> policies,
+        IHasDirectiveDefinition definition,
+        ITypeInspector typeInspector)
+    {
+        var directive = definition
+            .Directives
+            .Select(t => t.Value)
+            .OfType<PolicyDirective>()
+            .FirstOrDefault();
+
+        if (directive is null)
+        {
+            directive = new PolicyDirective([]);
+            definition.AddDirective(directive, typeInspector);
+        }
+
+        var newPolicies = policies.ToHashSet();
+        directive.Policies.Add(newPolicies);
+    }
+}

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/PolicyDirective.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using HotChocolate.ApolloFederation.Properties;
+using static HotChocolate.ApolloFederation.FederationTypeNames;
+
+namespace HotChocolate.ApolloFederation.Types;
+
+/// <summary>
+/// <code>
+/// directive @policy(policies: [[Policy!]!]!) on
+///     ENUM
+///   | FIELD_DEFINITION
+///   | INTERFACE
+///   | OBJECT
+///   | SCALAR
+/// </code>
+///
+/// Indicates to composition that the target element is restricted based on authorization policies that are evaluated in a Rhai script or coprocessor.
+/// Refer to the <see href = "https://www.apollographql.com/docs/router/configuration/authorization#policy"> Apollo Router article</see> for additional details.
+/// <example>
+/// type Foo @key(fields: "id") {
+///   id: ID
+///   description: String @policy(policies: [["policy1"]])
+/// }
+/// </example>
+/// </summary>
+/// <param name="policies">
+/// List of a list of of authorization policies to evaluate.
+/// </param>
+[Package(FederationVersionUrls.Federation26)]
+[DirectiveType(
+    PolicyDirective_Name,
+    DirectiveLocation.Enum |
+    DirectiveLocation.FieldDefinition |
+    DirectiveLocation.Interface |
+    DirectiveLocation.Object |
+    DirectiveLocation.Scalar)]
+[GraphQLDescription(FederationResources.PolicyDirective_Description)]
+public sealed class PolicyDirective(List<IReadOnlySet<Policy>> policies)
+{
+    /// <summary>
+    /// Retrieves list of a list of authorization policies to evaluate.
+    /// </summary>
+    public List<IReadOnlySet<Policy>> Policies { get; } = policies;
+}

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ProvidesAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/ProvidesAttribute.cs
@@ -31,25 +31,21 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-public sealed class ProvidesAttribute : ObjectFieldDescriptorAttribute
+/// <remarks>
+/// Initializes a new instance of <see cref="ProvidesAttribute"/>.
+/// </remarks>
+/// <param name="fieldSet">
+/// Gets the fields that is guaranteed to be selectable by the gateway.
+/// Grammatically, a field set is a selection set minus the braces.
+/// </param>
+public sealed class ProvidesAttribute(string fieldSet) : ObjectFieldDescriptorAttribute
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="ProvidesAttribute"/>.
-    /// </summary>
-    /// <param name="fieldSet">
-    /// Gets the fields that is guaranteed to be selectable by the gateway.
-    /// Grammatically, a field set is a selection set minus the braces.
-    /// </param>
-    public ProvidesAttribute(string fieldSet)
-    {
-        FieldSet = fieldSet;
-    }
 
     /// <summary>
     /// Gets the fields that are guaranteed to be selectable by the gateway.
     /// Grammatically, a field set is a selection set minus the braces.
     /// </summary>
-    public string FieldSet { get; }
+    public string FieldSet { get; } = fieldSet;
 
     protected override void OnConfigure(
         IDescriptorContext context,

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresAttribute.cs
@@ -28,28 +28,24 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
-public sealed class RequiresAttribute : ObjectFieldDescriptorAttribute
+/// <remarks>
+/// Initializes a new instance of <see cref="RequiresAttribute"/>.
+/// </remarks>
+/// <param name="fieldSet">
+/// The <paramref name="fieldSet"/> describes which fields may
+/// not be needed by the client, but are required by
+/// this service as additional information from other services.
+/// Grammatically, a field set is a selection set minus the braces.
+/// </param>
+public sealed class RequiresAttribute(string fieldSet) : ObjectFieldDescriptorAttribute
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="RequiresAttribute"/>.
-    /// </summary>
-    /// <param name="fieldSet">
-    /// The <paramref name="fieldSet"/> describes which fields may
-    /// not be needed by the client, but are required by
-    /// this service as additional information from other services.
-    /// Grammatically, a field set is a selection set minus the braces.
-    /// </param>
-    public RequiresAttribute(string fieldSet)
-    {
-        FieldSet = fieldSet;
-    }
 
     /// <summary>
     /// Gets the fieldset which describes fields that may not be needed by the client,
     /// but are required by this service as additional information from other services.
     /// Grammatically, a field set is a selection set minus the braces.
     /// </summary>
-    public string FieldSet { get; }
+    public string FieldSet { get; } = fieldSet;
 
     protected override void OnConfigure(
         IDescriptorContext context,

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresScopesAttribute.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresScopesAttribute.cs
@@ -22,6 +22,12 @@ namespace HotChocolate.ApolloFederation.Types;
 /// }
 /// </example>
 /// </summary>
+/// <remarks>
+/// Initializes new instance of <see cref="RequiresScopesAttribute"/>
+/// </remarks>
+/// <param name="scopes">
+/// Array of required JWT scopes.
+/// </param>
 [AttributeUsage(
     AttributeTargets.Class
     | AttributeTargets.Enum
@@ -31,23 +37,13 @@ namespace HotChocolate.ApolloFederation.Types;
     | AttributeTargets.Struct,
     AllowMultiple = true
 )]
-public sealed class RequiresScopesAttribute : DescriptorAttribute
+public sealed class RequiresScopesAttribute(string[] scopes) : DescriptorAttribute
 {
-    /// <summary>
-    /// Initializes new instance of <see cref="RequiresScopesAttribute"/>
-    /// </summary>
-    /// <param name="scopes">
-    /// Array of required JWT scopes.
-    /// </param>
-    public RequiresScopesAttribute(string[] scopes)
-    {
-        Scopes = scopes;
-    }
 
     /// <summary>
     /// Retrieves array of required JWT scopes.
     /// </summary>
-    public string[] Scopes { get; }
+    public string[] Scopes { get; } = scopes;
 
     protected internal override void TryConfigure(
         IDescriptorContext context,
@@ -59,19 +55,19 @@ public sealed class RequiresScopesAttribute : DescriptorAttribute
             case IEnumTypeDescriptor desc:
                 desc.RequiresScopes(Scopes);
                 break;
-            
+
             case IObjectTypeDescriptor desc:
                 desc.RequiresScopes(Scopes);
                 break;
-            
+
             case IObjectFieldDescriptor desc:
                 desc.RequiresScopes(Scopes);
                 break;
-            
+
             case IInterfaceTypeDescriptor desc:
                 desc.RequiresScopes(Scopes);
                 break;
-            
+
             case IInterfaceFieldDescriptor desc:
                 desc.RequiresScopes(Scopes);
                 break;

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresScopesDirective.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Directives/RequiresScopesDirective.cs
@@ -26,7 +26,7 @@ namespace HotChocolate.ApolloFederation.Types;
 /// <param name="scopes">
 /// List of a list of required JWT scopes.
 /// </param>
-[Package(FederationVersionUrls.Federation24)]
+[Package(FederationVersionUrls.Federation25)]
 [DirectiveType(
     RequiresScopesDirective_Name,
     DirectiveLocation.Enum |

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Policy.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/Policy.cs
@@ -1,0 +1,23 @@
+namespace HotChocolate.ApolloFederation.Types;
+
+/// <summary>
+/// Scalar <code>Policy</code> representation.
+/// </summary>
+public readonly record struct Policy
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="Policy"/>.
+    /// </summary>
+    /// <param name="value">
+    /// Policy value
+    /// </param>
+    public Policy(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Retrieve policy value
+    /// </summary>
+    public string Value { get; }
+}

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/PolicyType.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Types/PolicyType.cs
@@ -1,0 +1,41 @@
+using HotChocolate.ApolloFederation.Properties;
+using HotChocolate.Language;
+
+namespace HotChocolate.ApolloFederation.Types;
+
+/// <summary>
+/// The <code>Policy</code> scalar representing an authorization policy. Serializes as a string.
+/// </summary>
+public sealed class PolicyType : ScalarType<Policy, StringValueNode>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="PolicyType"/>.
+    /// </summary>
+    public PolicyType() : this(FederationTypeNames.PolicyType_Name)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PolicyType"/>.
+    /// </summary>
+    /// <param name="name">
+    /// Scalar name
+    /// </param>
+    /// <param name="bind">
+    /// Defines if this scalar shall bind implicitly to <see cref="Policy"/>.
+    /// </param>
+    public PolicyType(string name, BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, bind)
+    {
+        Description = FederationResources.PolicyType_Description;
+    }
+
+    protected override Policy ParseLiteral(StringValueNode valueSyntax)
+        => new(valueSyntax.Value);
+
+    public override IValueNode ParseResult(object? resultValue)
+        => ParseValue(resultValue);
+
+    protected override StringValueNode ParseValue(Policy runtimeValue)
+        => new(runtimeValue.Value);
+}

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Subgraph_SDL.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Subgraph_SDL.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.5", import: [ "@key", "@provides", "FieldSet", "@external" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "FieldSet", "@external" ]) {
   query: Query
 }
 
@@ -40,12 +40,12 @@ type _Service {
 union _Entity = Product | User
 
 "Directive to indicate that a field is owned by another service, for example via Apollo federation."
-directive @external on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
 
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-"Object representation of @link directive."
+"Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
 "Used to annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the federation gateway."

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.5", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
   query: Query
 }
 
@@ -40,12 +40,12 @@ type _Service {
 union _Entity = Product | User
 
 "Directive to indicate that a field is owned by another service, for example via Apollo federation."
-directive @external on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
 
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-"Object representation of @link directive."
+"Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
 "Used to annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the federation gateway."

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.5", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
   query: Query
 }
 
@@ -40,12 +40,12 @@ type _Service {
 union _Entity = Product | User
 
 "Directive to indicate that a field is owned by another service, for example via Apollo federation."
-directive @external on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
 
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-"Object representation of @link directive."
+"Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
 "Used to annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the federation gateway."

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/OverrideDirectiveTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/OverrideDirectiveTests.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using HotChocolate.ApolloFederation.Resolvers;
+using HotChocolate.ApolloFederation.Types;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using HotChocolate.Types.Relay;
+using Microsoft.Extensions.DependencyInjection;
+using Snapshooter.Xunit;
+
+namespace HotChocolate.ApolloFederation.Directives;
+
+public class OverrideDirectiveTests
+{
+    [Fact]
+    public async Task OverrideDirective_Annotation()
+    {
+        // arrange
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddApolloFederation(FederationVersion.Federation20)
+            .AddQueryType()
+            .AddType<Foo>()
+            .BuildSchemaAsync();
+
+        var entityType = schema.GetType<ObjectType>(FederationTypeNames.ServiceType_Name);
+        var sdlResolver = entityType.Fields[WellKnownFieldNames.Sdl].Resolver!;
+
+        // act
+        var value = await sdlResolver(TestHelper.CreateResolverContext(schema));
+        value!.ToString().MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task OverrideDirective_Progressive_Annotation()
+    {
+        // arrange
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddApolloFederation(FederationVersion.Federation27)
+            .AddQueryType()
+            .AddType<Foo>()
+            .BuildSchemaAsync();
+
+        var entityType = schema.GetType<ObjectType>(FederationTypeNames.ServiceType_Name);
+        var sdlResolver = entityType.Fields[WellKnownFieldNames.Sdl].Resolver!;
+
+        // act
+        var value = await sdlResolver(TestHelper.CreateResolverContext(schema));
+        value!.ToString().MatchSnapshot();
+    }
+
+    [Key("id")]
+    public class Foo(string id)
+    {
+        [ID]
+        public string Id { get; } = id;
+
+        [Override("bar")]
+        public string Name => "abc";
+
+        [Override("bar", "percent(1)")]
+        public string Description => "xyz";
+
+        [ReferenceResolver]
+        public static Foo? ResolveReference(string id)
+        {
+            return new Foo(id);
+        }
+    }
+}

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ComposeDirectiveTests.TestServiceTypeEmptyQueryTypePureCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ComposeDirectiveTests.TestServiceTypeEmptyQueryTypePureCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @composeDirective(name: "custom") @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.5", import: [ "@composeDirective", "@key", "FieldSet" ]) @link(url: "https:\/\/specs.custom.dev\/custom\/v1.0", import: [ "@custom" ]) {
+schema @composeDirective(name: "custom") @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@composeDirective", "@key", "FieldSet" ]) @link(url: "https:\/\/specs.custom.dev\/custom\/v1.0", import: [ "@custom" ]) {
   query: Query
 }
 
@@ -27,7 +27,7 @@ directive @custom on FIELD_DEFINITION
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-"Object representation of @link directive."
+"Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
 "Scalar representing a set of fields."

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Annotation.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Annotation.snap
@@ -1,34 +1,16 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "FieldSet", "@external" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.0", import: [ "@override", "@key", "FieldSet" ]) {
   query: Query
 }
 
-type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+type Foo @key(fields: "id") {
   id: ID!
-  sku: String
-  package: String
-  variation: ProductVariation
-  dimensions: ProductDimension
-  createdBy: User @provides(fields: "totalProductsCreated")
-}
-
-type ProductDimension {
-  size: String
-  weight: Float
-}
-
-type ProductVariation {
-  id: ID!
+  name: String! @override(from: "bar")
+  description: String! @override(from: "bar")
 }
 
 type Query {
-  product(id: ID!): Product
   _service: _Service!
   _entities(representations: [_Any!]!): [_Entity]!
-}
-
-type User @key(fields: "email") {
-  email: ID! @external
-  totalProductsCreated: Int @external
 }
 
 "This type provides a field named sdl: String! which exposes the SDL of the service's schema. This SDL (schema definition language) is a printed version of the service's schema including the annotations of federation directives. This SDL does not include the additions of the federation spec."
@@ -37,10 +19,7 @@ type _Service {
 }
 
 "Union of all types that key directive applied. This information is needed by the Apollo federation gateway."
-union _Entity = Product | User
-
-"Directive to indicate that a field is owned by another service, for example via Apollo federation."
-directive @external on OBJECT | FIELD_DEFINITION
+union _Entity = Foo
 
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
@@ -48,8 +27,8 @@ directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJEC
 "Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
-"Used to annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the federation gateway."
-directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+"Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+directive @override(from: String!) on FIELD_DEFINITION
 
 "Scalar representing a set of fields."
 scalar FieldSet

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Progressive_Annotation.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Progressive_Annotation.snap
@@ -1,34 +1,16 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "FieldSet", "@external" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.7", import: [ "@override", "@key", "FieldSet" ]) {
   query: Query
 }
 
-type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+type Foo @key(fields: "id") {
   id: ID!
-  sku: String
-  package: String
-  variation: ProductVariation
-  dimensions: ProductDimension
-  createdBy: User @provides(fields: "totalProductsCreated")
-}
-
-type ProductDimension {
-  size: String
-  weight: Float
-}
-
-type ProductVariation {
-  id: ID!
+  name: String! @override(from: "bar")
+  description: String! @override(from: "bar", label: "percent(1)")
 }
 
 type Query {
-  product(id: ID!): Product
   _service: _Service!
   _entities(representations: [_Any!]!): [_Entity]!
-}
-
-type User @key(fields: "email") {
-  email: ID! @external
-  totalProductsCreated: Int @external
 }
 
 "This type provides a field named sdl: String! which exposes the SDL of the service's schema. This SDL (schema definition language) is a printed version of the service's schema including the annotations of federation directives. This SDL does not include the additions of the federation spec."
@@ -37,10 +19,7 @@ type _Service {
 }
 
 "Union of all types that key directive applied. This information is needed by the Apollo federation gateway."
-union _Entity = Product | User
-
-"Directive to indicate that a field is owned by another service, for example via Apollo federation."
-directive @external on OBJECT | FIELD_DEFINITION
+union _Entity = Foo
 
 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
@@ -48,8 +27,8 @@ directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJEC
 "Links definitions within the document to external schemas."
 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
-"Used to annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the federation gateway."
-directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+"Overrides fields resolution logic from other subgraph. Used for migrating fields from one subgraph to another."
+directive @override(from: String! label: String) on FIELD_DEFINITION
 
 "Scalar representing a set of fields."
 scalar FieldSet

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ServiceTypeTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ServiceTypeTests.cs
@@ -34,7 +34,7 @@ public class ServiceTypeTests
             .Parse((string)value!)
             .MatchInlineSnapshot(
                 """
-                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.5", import: [ "@key", "FieldSet" ]) {
+                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
                   query: Query
                 }
 
@@ -58,7 +58,7 @@ public class ServiceTypeTests
                 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
                 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-                "Object representation of @link directive."
+                "Links definitions within the document to external schemas."
                 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
 
                 "Scalar representing a set of fields."
@@ -93,34 +93,34 @@ public class ServiceTypeTests
                 schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.2", import: [ "@key", "FieldSet" ]) {
                   query: Query
                 }
-                
+
                 type Address @key(fields: "matchCode") {
                   matchCode: String
                 }
-                
+
                 type Query {
                   address(id: Int!): Address!
                   _service: _Service!
                   _entities(representations: [_Any!]!): [_Entity]!
                 }
-                
+
                 "This type provides a field named sdl: String! which exposes the SDL of the service's schema. This SDL (schema definition language) is a printed version of the service's schema including the annotations of federation directives. This SDL does not include the additions of the federation spec."
                 type _Service {
                   sdl: String!
                 }
-                
+
                 "Union of all types that key directive applied. This information is needed by the Apollo federation gateway."
                 union _Entity = Address
-                
+
                 "Used to indicate a combination of fields that can be used to uniquely identify and fetch an object or interface."
                 directive @key(fields: FieldSet! resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-                
-                "Object representation of @link directive."
+
+                "Links definitions within the document to external schemas."
                 directive @link("Gets imported specification url." url: String! "Gets optional list of imported element names." import: [String!]) repeatable on SCHEMA
-                
+
                 "Scalar representing a set of fields."
                 scalar FieldSet
-                
+
                 "The _Any scalar is used to pass representations of entities from external services into the root _entities field for execution. Validation of the _Any scalar is done by matching the __typename and @external fields defined in the schema."
                 scalar _Any
                 """);


### PR DESCRIPTION
Adds support for Apollo Federation v2.6/v2.7 and provides small fixes to existing definitions.

* fed v2.6
```graphql
directive @policy(policies: [[federation__Policy!]!]!) on
  | FIELD_DEFINITION
  | OBJECT
  | INTERFACE
  | SCALAR
  | ENUM

scalar Policy
```
* fed v2.7
```graphql
directive @override(from: String!, label: String) on FIELD_DEFINITION
```
* fixes
  * `@authenticated` is available since v2.5
  * `@composeDirective` is available since v2.1
  * `@external` is applicable on fields and objects in v2
  * `@interfaceObject` is available since v2.3
