### PR TITLE
fix: ApolloFederation does not require any entities to be present

### DIFF
--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationTypeInterceptor.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/FederationTypeInterceptor.cs
@@ -283,14 +283,6 @@ internal sealed class FederationTypeInterceptor : TypeInterceptor
         }
     }
 
-    public override void OnTypesInitialized()
-    {
-        if (_entityTypes.Count == 0)
-        {
-            throw EntityType_NoEntities();
-        }
-    }
-
     public override void OnBeforeCompleteType(
         ITypeCompletionContext completionContext,
         DefinitionBase definition)

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.Designer.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.Designer.cs
@@ -198,14 +198,6 @@ namespace HotChocolate.ApolloFederation.Properties
             }
         }
 
-        internal static string ThrowHelper_EntityType_NoEntities
-        {
-            get
-            {
-                return ResourceManager.GetString("ThrowHelper_EntityType_NoEntities", resourceCulture);
-            }
-        }
-
         internal static string ThrowHelper_EntityResolver_NoEntityResolverFound
         {
             get

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.resx
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Properties/FederationResources.resx
@@ -171,9 +171,6 @@
   <data name="FieldDescriptorExtensions_Override_From_CannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or empty.</value>
   </data>
-  <data name="ThrowHelper_EntityType_NoEntities" xml:space="preserve">
-    <value>The schema has no types with a KeyDirective and therefore no entities. Apollo federation requires at least one entity.</value>
-  </data>
   <data name="ThrowHelper_EntityResolver_NoEntityResolverFound" xml:space="preserve">
     <value>The apollo gateway tries to resolve an entity for which no EntityResolver method was found.</value>
   </data>

--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/ThrowHelper.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/ThrowHelper.cs
@@ -84,18 +84,6 @@ internal static class ThrowHelper
             scalarType);
 
     /// <summary>
-    /// The schema doesn't contain any types with a key directive
-    /// and therefore no entities. An Apollo federation service
-    /// needs at least one entity.
-    /// </summary>
-    public static SchemaException EntityType_NoEntities() =>
-        new SchemaException(
-            SchemaErrorBuilder.New()
-                .SetMessage(ThrowHelper_EntityType_NoEntities)
-                // .SetCode(ErrorCodes.ApolloFederation.NoEntitiesDeclared)
-                .Build());
-
-    /// <summary>
     /// The apollo gateway tries to resolve an entity for which no
     /// EntityResolver method was found.
     /// </summary>
@@ -126,7 +114,7 @@ internal static class ThrowHelper
         MemberInfo member)
     {
         var type = member.ReflectedType ?? member.DeclaringType!;
-        
+
         return new SchemaException(
             SchemaErrorBuilder.New()
                 .SetMessage("The specified key attribute must not specify a fieldset when annotated to a field.")
@@ -209,10 +197,10 @@ internal static class ThrowHelper
                     ThrowHelper_FederationVersion_Unknown,
                     version)
                 .Build());
-    
+
     public static SchemaException Contact_Not_Repeatable() =>
         new SchemaException(
             SchemaErrorBuilder.New()
                 .SetMessage("The @contact directive is not repeatable and can.")
-                .Build()); 
+                .Build());
 }

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntityTypeTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntityTypeTests.cs
@@ -2,29 +2,11 @@ using System.Threading.Tasks;
 using HotChocolate.ApolloFederation.Types;
 using HotChocolate.Execution;
 using Microsoft.Extensions.DependencyInjection;
-using static HotChocolate.ApolloFederation.Properties.FederationResources;
 
 namespace HotChocolate.ApolloFederation;
 
 public class EntityTypeTests
 {
-    [Fact]
-    public async Task TestEntityTypeCodeFirstNoEntities_ShouldThrow()
-    {
-        async Task CreateSchema()
-        {
-            // arrange
-            await new ServiceCollection()
-                .AddGraphQL()
-                .AddApolloFederation()
-                .AddQueryType<Query<Address>>()
-                .BuildSchemaAsync();
-        }
-
-        var exception = await Assert.ThrowsAsync<SchemaException>(CreateSchema);
-        Assert.Contains(ThrowHelper_EntityType_NoEntities, exception.Message);
-    }
-
     [Fact]
     public async Task TestEntityTypeCodeFirstClassKeyAttributeSingleKey()
     {
@@ -98,7 +80,7 @@ public class EntityTypeTests
         Assert.Collection(entityType.Types.Values,
             t => Assert.Equal("UserWithNestedKeyClassAttribute", t.Name));
     }
-    
+
     public sealed class Query<T>
     {
         public T GetEntity(int id) => default!;


### PR DESCRIPTION
You can federate GraphQL services without specifying any entities (i.e. to expose all queries through the gateway). Current logic was incorrectly throwing exception where there were no entities.
