### PR TITLE
Return proper exit codes from Fusion CLI

### DIFF
--- a/src/HotChocolate/Fusion/src/CommandLine/Program.cs
+++ b/src/HotChocolate/Fusion/src/CommandLine/Program.cs
@@ -5,14 +5,12 @@ namespace HotChocolate.Fusion.CommandLine;
 public static class Program
 {
     [RequiresUnreferencedCode("HotChocolate.Fusion is not trim compatible.")]
-    public static async Task Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         var builder = App.CreateBuilder();
 
         var app = builder.Build();
 
-        await app.InvokeAsync(args);        
+        return await app.InvokeAsync(args);
     }
 }
-
-


### PR DESCRIPTION
Currently every command, even unsuccessful ones (like an unhandled exception), returns a 0 exit code. 
An error during composition is therefore treated as success and won't fail CI, which just caused us some headaches... 😅

This PR returns the actual exit code as reported by the command handler or exception handler.