### PR TITLE
DefaultValue attribute on an input object doesn't get applied (#6897)

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DefaultValueTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/DefaultValueTests.cs
@@ -1,0 +1,61 @@
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+
+namespace HotChocolate.AspNetCore;
+
+public class DefaultValueTests
+{
+    public class MyInputObjectOut
+    {
+        public int Result { get; set; }
+    }
+
+    public class MyInputObject
+    {
+        [DefaultValue(500)]
+        public Optional<int> ValuesToRetrieveInBatch { get; set; }
+
+    }
+
+    public class Queries
+    {
+        public string Hello() => "Hello World";
+    }
+
+    public class Mutations
+    {
+        public MyInputObjectOut DoSomething(MyInputObject input) =>
+            new MyInputObjectOut() { Result = input.ValuesToRetrieveInBatch.Value };
+    }
+
+
+    [Fact]
+    public void DefaultValueTests_Simple()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services
+            .AddGraphQLServer()
+            .AddQueryType<Queries>()
+            .AddMutationType<Mutations>();
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        IRequestExecutorResolver executorResolver = serviceProvider.GetRequiredService<IRequestExecutorResolver>();
+        IRequestExecutor executor = executorResolver.GetRequestExecutorAsync().Result;
+
+        // Act
+        IExecutionResult result = executor.ExecuteAsync("mutation{ doSomething(input: { }) { result } }").Result;
+
+        // Extract the data from the result
+        var jsonResult = result.ToJson();
+
+        // Parse the JSON result and extract the 'result' value
+        var jObject = JObject.Parse(jsonResult);
+        var actualResult = jObject["data"]["doSomething"]["result"].Value<int>();
+
+        // Assert
+        Assert.Equal(500, actualResult);
+    }
+}

--- a/src/HotChocolate/Core/src/Abstractions/Optional.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Optional.cs
@@ -164,9 +164,9 @@ public readonly struct Optional<T>
     /// </summary>
     public static Optional<T> From(IOptional optional)
     {
-        if (optional.HasValue)
+        if (optional.HasValue || optional.Value != default)
         {
-            return new Optional<T>((T?)optional.Value);
+            return new Optional<T>((T?)optional.Value, optional.HasValue);
         }
 
         return new Optional<T>();

--- a/src/HotChocolate/Core/test/Abstractions.Tests/OptionalTests.cs
+++ b/src/HotChocolate/Core/test/Abstractions.Tests/OptionalTests.cs
@@ -189,4 +189,17 @@ public class OptionalTests
         Assert.False(fromEmptyOptional.HasValue);
         Assert.True(fromEmptyOptional.IsEmpty);
     }
+
+    [Fact]
+    public void Optional_From_DefaultValueAttribute_Provided()
+    {
+        const int defaultValue = 500;
+        Optional<int> a = Optional<int>.Empty(defaultValue);
+        var b = Optional<int>.From(a);
+
+        Assert.False(a.HasValue);
+        Assert.False(b.HasValue);
+        Assert.Equal(defaultValue, b.Value);
+    }
+
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- The fix for #4677 by #4965 took away the [DefaultValue] attribute's effectiveness on a property of type Optional<T>.   To avoid the null reference issue that was occuring in #4677, but still allow for [DefaultVaue] attributes to work, in the `From()` we check if `optional.Value != default`

Closes #6897 