### PR TITLE
Fixed pattern entity enricher for batch resolvers.

### DIFF
--- a/src/HotChocolate/Fusion/src/Composition/Pipeline/Enrichers/PatternEntityEnricher.cs
+++ b/src/HotChocolate/Fusion/src/Composition/Pipeline/Enrichers/PatternEntityEnricher.cs
@@ -248,7 +248,13 @@ internal sealed partial class PatternEntityEnricher : IEntityEnricher
         {
             if (keyArgument.Type.IsListType() && !keyArgument.ContainsIsDirective())
             {
-                return keyArgument.Type.Equals(keyField.Type.InnerType(), TypeComparison.Structural);
+                var argumentType = keyArgument.Type;
+                if (argumentType.Kind is TypeKind.NonNull)
+                {
+                    argumentType = argumentType.InnerType();
+                }
+                
+                return argumentType.InnerType().Equals(keyField.Type, TypeComparison.Structural);
             }
             
             keyArgument = null;
@@ -261,7 +267,13 @@ internal sealed partial class PatternEntityEnricher : IEntityEnricher
             
             if (keyArgument.Type.IsListType() && !keyArgument.ContainsIsDirective())
             {
-                return keyArgument.Type.Equals(keyField.Type.InnerType(), TypeComparison.Structural);
+                var argumentType = keyArgument.Type;
+                if (argumentType.Kind is TypeKind.NonNull)
+                {
+                    argumentType = argumentType.InnerType();
+                }
+
+                return argumentType.InnerType().Equals(keyField.Type, TypeComparison.Structural);
             }
 
             keyArgument = null;
@@ -288,11 +300,15 @@ internal sealed partial class PatternEntityEnricher : IEntityEnricher
             }
         }
 
-        if (keyArgument?.Type.IsListType() is true && 
-            keyArgument.Type.InnerType().Equals(keyField.Type, TypeComparison.Structural) &&
-            !keyArgument.ContainsIsDirective())
+        if (keyArgument?.Type.IsListType() is true && !keyArgument.ContainsIsDirective())
         {
-            return true;
+            var argumentType = keyArgument.Type;
+            if (argumentType.Kind is TypeKind.NonNull)
+            {
+                argumentType = argumentType.InnerType();
+            }
+
+            return argumentType.InnerType().Equals(keyField.Type, TypeComparison.Structural);
         }
 
         keyArgument = null;

--- a/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/DemoIntegrationTests.Accounts_And_Reviews_Infer_Patterns.graphql
+++ b/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/DemoIntegrationTests.Accounts_And_Reviews_Infer_Patterns.graphql
@@ -92,7 +92,7 @@ type User implements Node
   @variable(subgraph: "Reviews", name: "User_id", select: "id")
   @resolver(subgraph: "Reviews", select: "{ authorById(id: $User_id) }", arguments: [ { name: "User_id", type: "ID!" } ])
   @resolver(subgraph: "Accounts", select: "{ userById(id: $User_id) }", arguments: [ { name: "User_id", type: "ID!" } ])
-  @resolver(subgraph: "Accounts", select: "{ nodes(ids: $User_id) { ... on User { ... User } } }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH")
+  @resolver(subgraph: "Accounts", select: "{ usersById(ids: $User_id) }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH")
   @resolver(subgraph: "Reviews", select: "{ nodes(ids: $User_id) { ... on User { ... User } } }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH") {
   birthdate: Date!
     @source(subgraph: "Accounts")

--- a/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/DemoIntegrationTests.Accounts_And_Reviews_Products_AutoCompose_With_Node.graphql
+++ b/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/DemoIntegrationTests.Accounts_And_Reviews_Products_AutoCompose_With_Node.graphql
@@ -155,7 +155,7 @@ type UploadProductPicturePayload {
 type User implements Node
   @variable(subgraph: "Accounts", name: "User_id", select: "id")
   @resolver(subgraph: "Accounts", select: "{ userById(id: $User_id) }", arguments: [ { name: "User_id", type: "ID!" } ])
-  @resolver(subgraph: "Accounts", select: "{ nodes(ids: $User_id) { ... on User { ... User } } }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH") {
+  @resolver(subgraph: "Accounts", select: "{ usersById(ids: $User_id) }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH") {
   birthdate: Date!
     @source(subgraph: "Accounts")
   id: ID!

--- a/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/RequireTests.Require_Scalar_Arguments_No_Overloads.graphql
+++ b/src/HotChocolate/Fusion/test/Composition.Tests/__snapshots__/RequireTests.Require_Scalar_Arguments_No_Overloads.graphql
@@ -175,7 +175,7 @@ type UploadProductPicturePayload {
 type User implements Node
   @variable(subgraph: "Accounts", name: "User_id", select: "id")
   @resolver(subgraph: "Accounts", select: "{ userById(id: $User_id) }", arguments: [ { name: "User_id", type: "ID!" } ])
-  @resolver(subgraph: "Accounts", select: "{ nodes(ids: $User_id) { ... on User { ... User } } }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH") {
+  @resolver(subgraph: "Accounts", select: "{ usersById(ids: $User_id) }", arguments: [ { name: "User_id", type: "[ID!]!" } ], kind: "BATCH") {
   birthdate: Date!
     @source(subgraph: "Accounts")
   id: ID!


### PR DESCRIPTION
Fixes a bug in the fusion composition pipeline that caused batch resolvers to not be detected automatically even when they adhere to the defined pattern.
Now both nullable and non-null lists of keys are recognized. The nullability of the key itself must match the nullability of the key field on the entity.