### PR TITLE
[ActivatorUtilitiesConstructor] is dependent on constructor ordering

### DIFF
--- a/src/HotChocolate/Core/src/Types.NodaTime/DurationType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/DurationType.cs
@@ -16,14 +16,6 @@ public class DurationType : StringToStructBaseType<Duration>
     /// <summary>
     /// Initializes a new instance of <see cref="DurationType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public DurationType() : this(DurationPattern.Roundtrip)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="DurationType"/>.
-    /// </summary>
     public DurationType(params IPattern<Duration>[] allowedPatterns) : base("Duration")
     {
         if (allowedPatterns.Length == 0)
@@ -34,6 +26,14 @@ public class DurationType : StringToStructBaseType<Duration>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.DurationType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DurationType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DurationType() : this(DurationPattern.Roundtrip)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/InstantType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/InstantType.cs
@@ -16,14 +16,6 @@ public class InstantType : StringToStructBaseType<Instant>
     /// <summary>
     /// Initializes a new instance of <see cref="InstantType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public InstantType() : this(InstantPattern.ExtendedIso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="InstantType"/>.
-    /// </summary>
     public InstantType(params IPattern<Instant>[] allowedPatterns) : base("Instant")
     {
         if (allowedPatterns.Length == 0)
@@ -34,6 +26,14 @@ public class InstantType : StringToStructBaseType<Instant>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.InstantType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InstantType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public InstantType() : this(InstantPattern.ExtendedIso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/LocalDateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/LocalDateTimeType.cs
@@ -16,14 +16,6 @@ public class LocalDateTimeType : StringToStructBaseType<LocalDateTime>
     /// <summary>
     /// Initializes a new instance of <see cref="LocalDateTimeType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalDateTimeType() : this(LocalDateTimePattern.ExtendedIso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LocalDateTimeType"/>.
-    /// </summary>
     public LocalDateTimeType(params IPattern<LocalDateTime>[] allowedPatterns) : base("LocalDateTime")
     {
         if (allowedPatterns.Length == 0)
@@ -34,6 +26,14 @@ public class LocalDateTimeType : StringToStructBaseType<LocalDateTime>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.LocalDateTimeType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LocalDateTimeType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalDateTimeType() : this(LocalDateTimePattern.ExtendedIso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/LocalDateType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/LocalDateType.cs
@@ -17,14 +17,6 @@ public class LocalDateType : StringToStructBaseType<LocalDate>
     /// <summary>
     /// Initializes a new instance of <see cref="LocalDateType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalDateType() : this(LocalDatePattern.Iso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LocalDateType"/>.
-    /// </summary>
     public LocalDateType(params IPattern<LocalDate>[] allowedPatterns) : base("LocalDate")
     {
         if (allowedPatterns.Length == 0)
@@ -35,6 +27,14 @@ public class LocalDateType : StringToStructBaseType<LocalDate>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.LocalDateType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LocalDateType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalDateType() : this(LocalDatePattern.Iso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/LocalTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/LocalTimeType.cs
@@ -17,14 +17,6 @@ public class LocalTimeType : StringToStructBaseType<LocalTime>
     /// <summary>
     /// Initializes a new instance of <see cref="LocalTimeType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalTimeType() : this(LocalTimePattern.ExtendedIso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LocalTimeType"/>.
-    /// </summary>
     public LocalTimeType(params IPattern<LocalTime>[] allowedPatterns) : base("LocalTime")
     {
         if (allowedPatterns.Length == 0)
@@ -35,6 +27,14 @@ public class LocalTimeType : StringToStructBaseType<LocalTime>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.LocalTimeType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LocalTimeType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalTimeType() : this(LocalTimePattern.ExtendedIso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/OffsetDateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/OffsetDateTimeType.cs
@@ -16,17 +16,6 @@ public class OffsetDateTimeType : StringToStructBaseType<OffsetDateTime>
     /// <summary>
     /// Initializes a new instance of <see cref="OffsetDateTimeType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public OffsetDateTimeType() : this(OffsetDateTimePattern.ExtendedIso)
-    {
-        // Backwards compatibility with the original code's behavior
-        _serializationPattern = OffsetDateTimePattern.GeneralIso;
-        _allowedPatterns = [OffsetDateTimePattern.ExtendedIso,];
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="OffsetDateTimeType"/>.
-    /// </summary>
     public OffsetDateTimeType(params IPattern<OffsetDateTime>[] allowedPatterns)
         : base("OffsetDateTime")
     {
@@ -38,6 +27,17 @@ public class OffsetDateTimeType : StringToStructBaseType<OffsetDateTime>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = _allowedPatterns[0];
         Description = NodaTimeResources.OffsetDateTimeType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OffsetDateTimeType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public OffsetDateTimeType() : this(OffsetDateTimePattern.ExtendedIso)
+    {
+        // Backwards compatibility with the original code's behavior
+        _serializationPattern = OffsetDateTimePattern.GeneralIso;
+        _allowedPatterns = [OffsetDateTimePattern.ExtendedIso,];
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/OffsetDateType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/OffsetDateType.cs
@@ -18,14 +18,6 @@ public class OffsetDateType : StringToStructBaseType<OffsetDate>
     /// <summary>
     /// Initializes a new instance of <see cref="OffsetDateType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public OffsetDateType() : this(OffsetDatePattern.GeneralIso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="OffsetDateType"/>.
-    /// </summary>
     public OffsetDateType(params IPattern<OffsetDate>[] allowedPatterns) : base("OffsetDate")
     {
         if (allowedPatterns.Length == 0)
@@ -36,6 +28,14 @@ public class OffsetDateType : StringToStructBaseType<OffsetDate>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.OffsetDateType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OffsetDateType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public OffsetDateType() : this(OffsetDatePattern.GeneralIso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/OffsetTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/OffsetTimeType.cs
@@ -17,14 +17,6 @@ public class OffsetTimeType : StringToStructBaseType<OffsetTime>
     /// <summary>
     /// Initializes a new instance of <see cref="OffsetTimeType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public OffsetTimeType() : this(OffsetTimePattern.GeneralIso)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="OffsetTimeType"/>.
-    /// </summary>
     public OffsetTimeType(params IPattern<OffsetTime>[] allowedPatterns) : base("OffsetTime")
     {
         if (allowedPatterns.Length == 0)
@@ -35,6 +27,14 @@ public class OffsetTimeType : StringToStructBaseType<OffsetTime>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = _allowedPatterns[0];
         Description = NodaTimeResources.OffsetTimeType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OffsetTimeType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public OffsetTimeType() : this(OffsetTimePattern.GeneralIso)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/OffsetType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/OffsetType.cs
@@ -18,14 +18,6 @@ public class OffsetType : StringToStructBaseType<Offset>
     /// <summary>
     /// Initializes a new instance of <see cref="OffsetType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public OffsetType() : this(OffsetPattern.GeneralInvariantWithZ)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="OffsetType"/>.
-    /// </summary>
     public OffsetType(params IPattern<Offset>[] allowedPatterns) : base("Offset")
     {
         if (allowedPatterns.Length == 0)
@@ -36,6 +28,14 @@ public class OffsetType : StringToStructBaseType<Offset>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.OffsetType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OffsetType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public OffsetType() : this(OffsetPattern.GeneralInvariantWithZ)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/PeriodType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/PeriodType.cs
@@ -17,14 +17,6 @@ public class PeriodType : StringToClassBaseType<Period>
     /// <summary>
     /// Initializes a new instance of <see cref="PeriodType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public PeriodType() : this(PeriodPattern.Roundtrip)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="PeriodType"/>.
-    /// </summary>
     public PeriodType(params IPattern<Period>[] allowedPatterns) : base("Period")
     {
         if (allowedPatterns.Length == 0)
@@ -35,6 +27,14 @@ public class PeriodType : StringToClassBaseType<Period>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.PeriodType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PeriodType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public PeriodType() : this(PeriodPattern.Roundtrip)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.NodaTime/ZonedDateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.NodaTime/ZonedDateTimeType.cs
@@ -22,14 +22,6 @@ public class ZonedDateTimeType : StringToStructBaseType<ZonedDateTime>
     /// <summary>
     /// Initializes a new instance of <see cref="ZonedDateTimeType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ZonedDateTimeType() : this(_default)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ZonedDateTimeType"/>.
-    /// </summary>
     public ZonedDateTimeType(params IPattern<ZonedDateTime>[] allowedPatterns)
         : base("ZonedDateTime")
     {
@@ -41,6 +33,14 @@ public class ZonedDateTimeType : StringToStructBaseType<ZonedDateTime>
         _allowedPatterns = allowedPatterns;
         _serializationPattern = allowedPatterns[0];
         Description = NodaTimeResources.ZonedDateTimeType_Description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ZonedDateTimeType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public ZonedDateTimeType() : this(_default)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars.Upload/UploadType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars.Upload/UploadType.cs
@@ -12,18 +12,6 @@ public class UploadType : ScalarType<IFile, FileValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="UploadType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public UploadType()
-        : this(
-            "Upload",
-            UploadResources.UploadType_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UploadType"/> class.
-    /// </summary>
     public UploadType(
         string name,
         string? description = null,
@@ -31,6 +19,18 @@ public class UploadType : ScalarType<IFile, FileValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UploadType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UploadType()
+        : this(
+            "Upload",
+            UploadResources.UploadType_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     public override IValueNode ParseResult(object? resultValue)

--- a/src/HotChocolate/Core/src/Types.Scalars/EmailAddressType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/EmailAddressType.cs
@@ -35,15 +35,6 @@ public class EmailAddressType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="EmailAddressType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public EmailAddressType()
-        : this(
-            WellKnownScalarTypes.EmailAddress,
-            ScalarResources.EmailAddressType_Description) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EmailAddressType"/> class.
-    /// </summary>
     public EmailAddressType(
         string name,
         string? description = null,
@@ -55,6 +46,15 @@ public class EmailAddressType : RegexType
             bind)
     {
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailAddressType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public EmailAddressType()
+        : this(
+            WellKnownScalarTypes.EmailAddress,
+            ScalarResources.EmailAddressType_Description) { }
 
     /// <inheritdoc />
     protected override SerializationException CreateParseLiteralError(IValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types.Scalars/HexColorType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/HexColorType.cs
@@ -31,17 +31,6 @@ public class HexColorType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="HexColorType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public HexColorType()
-        : this(
-            WellKnownScalarTypes.HexColor,
-            ScalarResources.HexColorType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="HexColorType"/> class.
-    /// </summary>
     public HexColorType(
         string name,
         string? description = null,
@@ -51,6 +40,17 @@ public class HexColorType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HexColorType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public HexColorType()
+        : this(
+            WellKnownScalarTypes.HexColor,
+            ScalarResources.HexColorType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/HslType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/HslType.cs
@@ -31,17 +31,6 @@ public class HslType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="HslType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public HslType()
-        : this(
-            WellKnownScalarTypes.Hsl,
-            ScalarResources.HslType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="HslType"/> class.
-    /// </summary>
     public HslType(
         string name,
         string? description = null,
@@ -51,6 +40,17 @@ public class HslType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HslType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public HslType()
+        : this(
+            WellKnownScalarTypes.Hsl,
+            ScalarResources.HslType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/HslaType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/HslaType.cs
@@ -31,17 +31,6 @@ public class HslaType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="HslaType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public HslaType()
-        : this(
-            WellKnownScalarTypes.Hsla,
-            ScalarResources.HslaType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="HslaType"/> class.
-    /// </summary>
     public HslaType(
         string name,
         string? description = null,
@@ -51,6 +40,17 @@ public class HslaType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HslaType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public HslaType()
+        : this(
+            WellKnownScalarTypes.Hsla,
+            ScalarResources.HslaType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/IPv4Type.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/IPv4Type.cs
@@ -30,18 +30,6 @@ public class IPv4Type : RegexType
             TimeSpan.FromMilliseconds(DefaultRegexTimeoutInMs));
 #endif
 
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IPv4Type"/> class.
-    /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public IPv4Type()
-        : this(
-            WellKnownScalarTypes.IPv4,
-            ScalarResources.IPv4Type_Description)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="IPv4Type"/> class.
     /// </summary>
@@ -54,6 +42,17 @@ public class IPv4Type : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IPv4Type"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public IPv4Type()
+        : this(
+            WellKnownScalarTypes.IPv4,
+            ScalarResources.IPv4Type_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/IPv6Type.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/IPv6Type.cs
@@ -52,17 +52,6 @@ public class IPv6Type : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="IPv6Type"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public IPv6Type()
-        : this(
-            WellKnownScalarTypes.IPv6,
-            ScalarResources.IPv6Type_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IPv6Type"/> class.
-    /// </summary>
     public IPv6Type(
         string name,
         string? description = null,
@@ -72,6 +61,17 @@ public class IPv6Type : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IPv6Type"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public IPv6Type()
+        : this(
+            WellKnownScalarTypes.IPv6,
+            ScalarResources.IPv6Type_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/IsbnType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/IsbnType.cs
@@ -36,17 +36,6 @@ public class IsbnType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="IsbnType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public IsbnType()
-        : this(
-            WellKnownScalarTypes.Isbn,
-            ScalarResources.IsbnType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IsbnType"/> class.
-    /// </summary>
     public IsbnType(
         string name,
         string? description = null,
@@ -56,6 +45,17 @@ public class IsbnType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IsbnType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public IsbnType()
+        : this(
+            WellKnownScalarTypes.Isbn,
+            ScalarResources.IsbnType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/LatitudeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LatitudeType.cs
@@ -15,17 +15,6 @@ public class LatitudeType : ScalarType<double, StringValueNode>
     /// <summary>
     /// Initializes a new instance of <see cref="LatitudeType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LatitudeType()
-        : this(
-            WellKnownScalarTypes.Latitude,
-            ScalarResources.LatitudeType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LatitudeType"/>
-    /// </summary>
     public LatitudeType(
         string name,
         string? description = null,
@@ -33,6 +22,17 @@ public class LatitudeType : ScalarType<double, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of <see cref="LatitudeType"/>
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LatitudeType()
+        : this(
+            WellKnownScalarTypes.Latitude,
+            ScalarResources.LatitudeType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalCurrencyType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalCurrencyType.cs
@@ -15,17 +15,6 @@ public class LocalCurrencyType : ScalarType<decimal, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalCurrencyType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalCurrencyType()
-        : this(
-            WellKnownScalarTypes.LocalCurrency,
-            description: ScalarResources.LocalCurrencyType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LocalCurrencyType"/> class.
-    /// </summary>
     public LocalCurrencyType(
         string name,
         string culture = "en-US",
@@ -37,6 +26,17 @@ public class LocalCurrencyType : ScalarType<decimal, StringValueNode>
     {
         _cultureInfo = CultureInfo.CreateSpecificCulture(culture);
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalCurrencyType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalCurrencyType()
+        : this(
+            WellKnownScalarTypes.LocalCurrency,
+            description: ScalarResources.LocalCurrencyType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalDateType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalDateType.cs
@@ -17,17 +17,6 @@ public class LocalDateType : ScalarType<DateTime, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalDateType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalDateType()
-        : this(
-            WellKnownScalarTypes.LocalDate,
-            ScalarResources.LocalDateType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LocalDateType"/> class.
-    /// </summary>
     public LocalDateType(
         string name,
         string? description = null,
@@ -35,6 +24,17 @@ public class LocalDateType : ScalarType<DateTime, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalDateType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalDateType()
+        : this(
+            WellKnownScalarTypes.LocalDate,
+            ScalarResources.LocalDateType_Description)
+    {
     }
 
     public override IValueNode ParseResult(object? resultValue)

--- a/src/HotChocolate/Core/src/Types.Scalars/LocalTimeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LocalTimeType.cs
@@ -16,17 +16,6 @@ public class LocalTimeType : ScalarType<DateTime, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="LocalTimeType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LocalTimeType()
-        : this(
-            WellKnownScalarTypes.LocalTime,
-            ScalarResources.LocalTimeType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LocalTimeType"/> class.
-    /// </summary>
     public LocalTimeType(
         string name,
         string? description = null,
@@ -34,6 +23,17 @@ public class LocalTimeType : ScalarType<DateTime, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalTimeType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LocalTimeType()
+        : this(
+            WellKnownScalarTypes.LocalTime,
+            ScalarResources.LocalTimeType_Description)
+    {
     }
 
     public override IValueNode ParseResult(object? resultValue)

--- a/src/HotChocolate/Core/src/Types.Scalars/LongitudeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/LongitudeType.cs
@@ -15,17 +15,6 @@ public class LongitudeType : ScalarType<double, StringValueNode>
     /// <summary>
     /// Initializes a new instance of <see cref="LongitudeType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LongitudeType()
-        : this(
-            WellKnownScalarTypes.Longitude,
-            ScalarResources.LongitudeType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LongitudeType"/>
-    /// </summary>
     public LongitudeType(
         string name,
         string? description = null,
@@ -33,6 +22,17 @@ public class LongitudeType : ScalarType<double, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of <see cref="LongitudeType"/>
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LongitudeType()
+        : this(
+            WellKnownScalarTypes.Longitude,
+            ScalarResources.LongitudeType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/MacAddressType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/MacAddressType.cs
@@ -35,17 +35,6 @@ public class MacAddressType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="MacAddressType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public MacAddressType()
-        : this(
-            WellKnownScalarTypes.MacAddress,
-            ScalarResources.MacAddressType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MacAddressType"/> class.
-    /// </summary>
     public MacAddressType(
         string name,
         string? description = null,
@@ -55,6 +44,17 @@ public class MacAddressType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MacAddressType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public MacAddressType()
+        : this(
+            WellKnownScalarTypes.MacAddress,
+            ScalarResources.MacAddressType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NegativeFloatType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NegativeFloatType.cs
@@ -10,22 +10,22 @@ public class NegativeFloatType : FloatType
     /// <summary>
     /// Initializes a new instance of <see cref="NegativeFloatType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NegativeFloatType()
-        : this(
-            WellKnownScalarTypes.NegativeFloat,
-            ScalarResources.NegativeFloatType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="NegativeFloatType"/>
-    /// </summary>
     public NegativeFloatType(
         string name,
         string? description = null,
         BindingBehavior bind = BindingBehavior.Explicit)
         : base(name, description, double.MinValue, 0, bind)
+    {
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of <see cref="NegativeFloatType"/>
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public NegativeFloatType()
+        : this(
+            WellKnownScalarTypes.NegativeFloat,
+            ScalarResources.NegativeFloatType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NegativeIntType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NegativeIntType.cs
@@ -11,17 +11,6 @@ public class NegativeIntType : IntType
     /// <summary>
     /// Initializes a new instance of the <see cref="NegativeIntType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NegativeIntType()
-        : this(
-            WellKnownScalarTypes.NegativeInt,
-            ScalarResources.NegativeIntType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NegativeIntType"/> class.
-    /// </summary>
     public NegativeIntType(
         string name,
         string? description = null,
@@ -29,6 +18,17 @@ public class NegativeIntType : IntType
         : base(name, description, int.MinValue, -1, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NegativeIntType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public NegativeIntType()
+        : this(
+            WellKnownScalarTypes.NegativeInt,
+            ScalarResources.NegativeIntType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/NonEmptyStringType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NonEmptyStringType.cs
@@ -11,22 +11,22 @@ public class NonEmptyStringType : StringType
     /// <summary>
     /// Initializes a new instance of the <see cref="NonEmptyStringType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NonEmptyStringType()
-        : this(
-            WellKnownScalarTypes.NonEmptyString,
-            ScalarResources.NonEmptyStringType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NonEmptyStringType"/> class.
-    /// </summary>
     public NonEmptyStringType(
         string name,
         string? description = null,
         BindingBehavior bind = BindingBehavior.Explicit)
         : base(name, description, bind)
+    {
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NonEmptyStringType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public NonEmptyStringType()
+        : this(
+            WellKnownScalarTypes.NonEmptyString,
+            ScalarResources.NonEmptyStringType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NonNegativeFloatType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NonNegativeFloatType.cs
@@ -11,22 +11,22 @@ public class NonNegativeFloatType : FloatType
     /// <summary>
     /// Initializes a new instance of <see cref="NonNegativeFloatType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NonNegativeFloatType()
-        : this(
-            WellKnownScalarTypes.NonNegativeFloat,
-            ScalarResources.NonNegativeFloatType_Description)
+    public NonNegativeFloatType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, 0, double.MaxValue, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of <see cref="NonNegativeFloatType"/>
     /// </summary>
-    public NonNegativeFloatType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, 0, double.MaxValue, bind)
+    [ActivatorUtilitiesConstructor]
+    public NonNegativeFloatType()
+        : this(
+            WellKnownScalarTypes.NonNegativeFloat,
+            ScalarResources.NonNegativeFloatType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NonNegativeIntType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NonNegativeIntType.cs
@@ -11,22 +11,22 @@ public class NonNegativeIntType : IntType
     /// <summary>
     /// Initializes a new instance of the <see cref="NonNegativeIntType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NonNegativeIntType()
-        : this(
-            WellKnownScalarTypes.NonNegativeInt,
-            ScalarResources.NonNegativeIntType_Description)
+    public NonNegativeIntType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, 0, int.MaxValue, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NonNegativeIntType"/> class.
     /// </summary>
-    public NonNegativeIntType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, 0, int.MaxValue, bind)
+    [ActivatorUtilitiesConstructor]
+    public NonNegativeIntType()
+        : this(
+            WellKnownScalarTypes.NonNegativeInt,
+            ScalarResources.NonNegativeIntType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NonPositiveFloatType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NonPositiveFloatType.cs
@@ -11,22 +11,22 @@ public class NonPositiveFloatType : FloatType
     /// <summary>
     /// Initializes a new instance of <see cref="NonPositiveFloatType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NonPositiveFloatType()
-        : this(
-            WellKnownScalarTypes.NonPositiveFloat,
-            ScalarResources.NonPositiveFloatType_Description)
+    public NonPositiveFloatType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, double.MinValue, 0, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of <see cref="NonPositiveFloatType"/>
     /// </summary>
-    public NonPositiveFloatType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, double.MinValue, 0, bind)
+    [ActivatorUtilitiesConstructor]
+    public NonPositiveFloatType()
+        : this(
+            WellKnownScalarTypes.NonPositiveFloat,
+            ScalarResources.NonPositiveFloatType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/NonPositiveIntType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/NonPositiveIntType.cs
@@ -11,22 +11,22 @@ public class NonPositiveIntType : IntType
     /// <summary>
     /// Initializes a new instance of <see cref="NonPositiveIntType"/>
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public NonPositiveIntType()
-        : this(
-            WellKnownScalarTypes.NonPositiveInt,
-            ScalarResources.NonPositiveIntType_Description)
+    public NonPositiveIntType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, int.MinValue, 0, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of <see cref="NonPositiveIntType"/>
     /// </summary>
-    public NonPositiveIntType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, int.MinValue, 0, bind)
+    [ActivatorUtilitiesConstructor]
+    public NonPositiveIntType()
+        : this(
+            WellKnownScalarTypes.NonPositiveInt,
+            ScalarResources.NonPositiveIntType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/PhoneNumberType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/PhoneNumberType.cs
@@ -31,17 +31,6 @@ public class PhoneNumberType : RegexType
 #endif
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PhoneNumberType"/> class.
-    /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public PhoneNumberType()
-        : this(
-            WellKnownScalarTypes.PhoneNumber,
-            ScalarResources.PhoneNumberType_Description)
-    {
-    }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="PhoneNumberType"/>
     /// </summary>
     public PhoneNumberType(
@@ -53,6 +42,17 @@ public class PhoneNumberType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PhoneNumberType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public PhoneNumberType()
+        : this(
+            WellKnownScalarTypes.PhoneNumber,
+            ScalarResources.PhoneNumberType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/PortType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/PortType.cs
@@ -14,22 +14,22 @@ public class PortType : IntType
     /// <summary>
     /// Initializes a new instance of the <see cref="PortType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public PortType()
-        : this(
-            WellKnownScalarTypes.Port,
-            ScalarResources.PortType_Description)
+    public PortType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, 0, 65535, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PortType"/> class.
     /// </summary>
-    public PortType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, 0, 65535, bind)
+    [ActivatorUtilitiesConstructor]
+    public PortType()
+        : this(
+            WellKnownScalarTypes.Port,
+            ScalarResources.PortType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/PositiveIntType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/PositiveIntType.cs
@@ -11,22 +11,22 @@ public class PositiveIntType : IntType
     /// <summary>
     /// Initializes a new instance of the <see cref="PositiveIntType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public PositiveIntType()
-        : this(
-            WellKnownScalarTypes.PositiveInt,
-            ScalarResources.PositiveIntType_Description)
+    public PositiveIntType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, min: 1, bind: bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PositiveIntType"/> class.
     /// </summary>
-    public PositiveIntType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, min: 1, bind: bind)
+    [ActivatorUtilitiesConstructor]
+    public PositiveIntType()
+        : this(
+            WellKnownScalarTypes.PositiveInt,
+            ScalarResources.PositiveIntType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/PostalCodeType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/PostalCodeType.cs
@@ -152,22 +152,22 @@ public class PostalCodeType : StringType
     /// <summary>
     /// Initializes a new instance of the <see cref="PostalCodeType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public PostalCodeType()
-        : this(
-            WellKnownScalarTypes.PostalCode,
-            ScalarResources.PostalCodeType_Description)
+    public PostalCodeType(
+        string name,
+        string? description = null,
+        BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, description, bind)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PostalCodeType"/> class.
     /// </summary>
-    public PostalCodeType(
-        string name,
-        string? description = null,
-        BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, description, bind)
+    [ActivatorUtilitiesConstructor]
+    public PostalCodeType()
+        : this(
+            WellKnownScalarTypes.PostalCode,
+            ScalarResources.PostalCodeType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/RgbType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/RgbType.cs
@@ -31,17 +31,6 @@ public class RgbType : RegexType
 #endif
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IPv6Type"/> class.
-    /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public RgbType()
-        : this(
-            WellKnownScalarTypes.Rgb,
-            ScalarResources.RgbType_Description)
-    {
-    }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="RgbType"/> class.
     /// </summary>
     public RgbType(
@@ -53,6 +42,17 @@ public class RgbType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IPv6Type"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public RgbType()
+        : this(
+            WellKnownScalarTypes.Rgb,
+            ScalarResources.RgbType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/RgbaType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/RgbaType.cs
@@ -31,17 +31,6 @@ public class RgbaType : RegexType
     /// <summary>
     /// Initializes a new instance of the <see cref="RgbaType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public RgbaType()
-        : this(
-            WellKnownScalarTypes.Rgba,
-            ScalarResources.RgbaType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RgbaType"/> class.
-    /// </summary>
     public RgbaType(
         string name,
         string? description = null,
@@ -51,6 +40,17 @@ public class RgbaType : RegexType
             CreateRegex(),
             description,
             bind)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RgbaType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public RgbaType()
+        : this(
+            WellKnownScalarTypes.Rgba,
+            ScalarResources.RgbaType_Description)
     {
     }
 

--- a/src/HotChocolate/Core/src/Types.Scalars/SignedByteType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/SignedByteType.cs
@@ -8,14 +8,6 @@ namespace HotChocolate.Types;
 /// </summary>
 public class SignedByteType : IntegerTypeBase<sbyte>
 {
-    [ActivatorUtilitiesConstructor]
-    public SignedByteType()
-        : this(
-            WellKnownScalarTypes.SignedByte,
-            ScalarResources.SignedByteType_Description)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SignedByteType"/> class.
     /// </summary>
@@ -26,6 +18,17 @@ public class SignedByteType : IntegerTypeBase<sbyte>
         : base(name, sbyte.MinValue, sbyte.MaxValue, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SignedByteType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public SignedByteType()
+        : this(
+            WellKnownScalarTypes.SignedByte,
+            ScalarResources.SignedByteType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/UnsignedIntType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/UnsignedIntType.cs
@@ -8,14 +8,6 @@ namespace HotChocolate.Types;
 /// </summary>
 public class UnsignedIntType : IntegerTypeBase<uint>
 {
-    [ActivatorUtilitiesConstructor]
-    public UnsignedIntType()
-        : this(
-            WellKnownScalarTypes.UnsignedInt,
-            ScalarResources.UnsignedIntType_Description)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="UnsignedIntType"/> class.
     /// </summary>
@@ -26,6 +18,17 @@ public class UnsignedIntType : IntegerTypeBase<uint>
         : base(name, uint.MinValue, uint.MaxValue, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsignedIntType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UnsignedIntType()
+        : this(
+            WellKnownScalarTypes.UnsignedInt,
+            ScalarResources.UnsignedIntType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/UnsignedLongType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/UnsignedLongType.cs
@@ -11,17 +11,6 @@ public class UnsignedLongType : IntegerTypeBase<ulong>
     /// <summary>
     /// Initializes a new instance of the <see cref="UnsignedLongType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public UnsignedLongType()
-        : this(
-            WellKnownScalarTypes.UnsignedLong,
-            ScalarResources.UnsignedLongType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UnsignedLongType"/> class.
-    /// </summary>
     public UnsignedLongType(
         string name,
         string? description = null,
@@ -29,6 +18,17 @@ public class UnsignedLongType : IntegerTypeBase<ulong>
         : base(name, ulong.MinValue, ulong.MaxValue, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsignedLongType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UnsignedLongType()
+        : this(
+            WellKnownScalarTypes.UnsignedLong,
+            ScalarResources.UnsignedLongType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/UnsignedShortType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/UnsignedShortType.cs
@@ -8,14 +8,6 @@ namespace HotChocolate.Types;
 /// </summary>
 public class UnsignedShortType : IntegerTypeBase<ushort>
 {
-    [ActivatorUtilitiesConstructor]
-    public UnsignedShortType()
-        : this(
-            WellKnownScalarTypes.UnsignedShort,
-            ScalarResources.UnsignedShortType_Description)
-    {
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="UnsignedShortType"/> class.
     /// </summary>
@@ -26,6 +18,17 @@ public class UnsignedShortType : IntegerTypeBase<ushort>
         : base(name, ushort.MinValue, ushort.MaxValue, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsignedShortType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UnsignedShortType()
+        : this(
+            WellKnownScalarTypes.UnsignedShort,
+            ScalarResources.UnsignedShortType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types.Scalars/UtcOffsetType.cs
+++ b/src/HotChocolate/Core/src/Types.Scalars/UtcOffsetType.cs
@@ -14,17 +14,6 @@ public class UtcOffsetType : ScalarType<TimeSpan, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="UtcOffsetType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public UtcOffsetType()
-        : this(
-            WellKnownScalarTypes.UtcOffset,
-            ScalarResources.UtcOffsetType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UtcOffsetType"/> class.
-    /// </summary>
     public UtcOffsetType(
         string name,
         string? description = null,
@@ -32,6 +21,17 @@ public class UtcOffsetType : ScalarType<TimeSpan, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UtcOffsetType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UtcOffsetType()
+        : this(
+            WellKnownScalarTypes.UtcOffset,
+            ScalarResources.UtcOffsetType_Description)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types/Types/DirectiveType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/DirectiveType~1.cs
@@ -12,15 +12,15 @@ public class DirectiveType<TDirective> : DirectiveType where TDirective : class
 {
     private Action<IDirectiveTypeDescriptor<TDirective>>? _configure;
 
+    public DirectiveType(Action<IDirectiveTypeDescriptor<TDirective>> configure)
+    {
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
     [ActivatorUtilitiesConstructor]
     public DirectiveType()
     {
         _configure = Configure;
-    }
-
-    public DirectiveType(Action<IDirectiveTypeDescriptor<TDirective>> configure)
-    {
-        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
     }
 
     protected override DirectiveTypeDefinition CreateDefinition(

--- a/src/HotChocolate/Core/src/Types/Types/EnumType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/EnumType~1.cs
@@ -33,15 +33,6 @@ public class EnumType<T> : EnumType, IEnumType<T>
     /// <summary>
     /// Initializes a new instance of <see cref="EnumType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public EnumType()
-    {
-        _configure = Configure;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="EnumType"/>.
-    /// </summary>
     /// <param name="configure">
     /// A delegate defining the configuration.
     /// </param>
@@ -49,6 +40,15 @@ public class EnumType<T> : EnumType, IEnumType<T>
     {
         _configure = configure
             ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EnumType"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public EnumType()
+    {
+        _configure = Configure;
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Core/src/Types/Types/InputObjectType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputObjectType~1.cs
@@ -11,15 +11,15 @@ public class InputObjectType<T> : InputObjectType
 {
     private Action<IInputObjectTypeDescriptor<T>>? _configure;
 
+    public InputObjectType(Action<IInputObjectTypeDescriptor<T>> configure)
+    {
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    }
+
     [ActivatorUtilitiesConstructor]
     public InputObjectType()
     {
         _configure = Configure;
-    }
-
-    public InputObjectType(Action<IInputObjectTypeDescriptor<T>> configure)
-    {
-        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
     }
 
     protected override InputObjectTypeDefinition CreateDefinition(

--- a/src/HotChocolate/Core/src/Types/Types/InterfaceType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InterfaceType~1.cs
@@ -11,12 +11,12 @@ public class InterfaceType<T> : InterfaceType
 {
     private Action<IInterfaceTypeDescriptor<T>>? _configure;
 
+    public InterfaceType(Action<IInterfaceTypeDescriptor<T>> configure) =>
+        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+
     [ActivatorUtilitiesConstructor]
     public InterfaceType() =>
         _configure = Configure;
-
-    public InterfaceType(Action<IInterfaceTypeDescriptor<T>> configure) =>
-        _configure = configure ?? throw new ArgumentNullException(nameof(configure));
 
     protected override InterfaceTypeDefinition CreateDefinition(ITypeDiscoveryContext context)
     {

--- a/src/HotChocolate/Core/src/Types/Types/ObjectTypeExtension~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectTypeExtension~1.cs
@@ -22,21 +22,21 @@ public class ObjectTypeExtension<T> : ObjectTypeExtension
     private Action<IObjectTypeDescriptor<T>>? _configure;
 
     /// <summary>
-    /// Initializes a new  instance of <see cref="ObjectType{T}"/>.
-    /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ObjectTypeExtension()
-    {
-        _configure = Configure;
-    }
-
-    /// <summary>
     /// Initializes a new  instance of <see cref="ObjectTypeExtension{T}"/>.
     /// </summary>
     public ObjectTypeExtension(Action<IObjectTypeDescriptor<T>> configure)
     {
         _configure = configure
             ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    /// <summary>
+    /// Initializes a new  instance of <see cref="ObjectType{T}"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public ObjectTypeExtension()
+    {
+        _configure = Configure;
     }
 
     protected override ObjectTypeDefinition CreateDefinition(

--- a/src/HotChocolate/Core/src/Types/Types/ObjectType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/ObjectType~1.cs
@@ -32,15 +32,15 @@ public class ObjectType<T> : ObjectType
     /// <summary>
     /// Initializes a new  instance of <see cref="ObjectType{T}"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ObjectType()
-        => _configure = Configure;
+    public ObjectType(Action<IObjectTypeDescriptor<T>> configure)
+        => _configure = configure ?? throw new ArgumentNullException(nameof(configure));
 
     /// <summary>
     /// Initializes a new  instance of <see cref="ObjectType{T}"/>.
     /// </summary>
-    public ObjectType(Action<IObjectTypeDescriptor<T>> configure)
-        => _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+    [ActivatorUtilitiesConstructor]
+    public ObjectType()
+        => _configure = Configure;
 
     protected override ObjectTypeDefinition CreateDefinition(
         ITypeDiscoveryContext context)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/AnyType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/AnyType.cs
@@ -20,14 +20,6 @@ public class AnyType : ScalarType
     /// <summary>
     /// Initializes a new instance of the <see cref="AnyType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public AnyType() : this(ScalarNames.Any)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AnyType"/> class.
-    /// </summary>
     public AnyType(
         string name,
         string? description = null,
@@ -35,6 +27,14 @@ public class AnyType : ScalarType
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnyType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public AnyType() : this(ScalarNames.Any)
+    {
     }
 
     public override Type RuntimeType => typeof(object);

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/BooleanType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/BooleanType.cs
@@ -16,18 +16,6 @@ public class BooleanType : ScalarType<bool, BooleanValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="BooleanType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public BooleanType()
-        : this(
-            ScalarNames.Boolean,
-            TypeResources.BooleanType_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BooleanType"/> class.
-    /// </summary>
     public BooleanType(
         string name,
         string? description = null,
@@ -35,6 +23,18 @@ public class BooleanType : ScalarType<bool, BooleanValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BooleanType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public BooleanType()
+        : this(
+            ScalarNames.Boolean,
+            TypeResources.BooleanType_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     protected override bool ParseLiteral(BooleanValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ByteArrayType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ByteArrayType.cs
@@ -11,15 +11,6 @@ public class ByteArrayType : ScalarType<byte[], StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="ByteArrayType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ByteArrayType()
-        : this(ScalarNames.ByteArray, bind: BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ByteArrayType"/> class.
-    /// </summary>
     public ByteArrayType(
         string name,
         string? description = null,
@@ -27,6 +18,15 @@ public class ByteArrayType : ScalarType<byte[], StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByteArrayType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public ByteArrayType()
+        : this(ScalarNames.ByteArray, bind: BindingBehavior.Implicit)
+    {
     }
 
     protected override byte[] ParseLiteral(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ByteType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ByteType.cs
@@ -10,15 +10,6 @@ public class ByteType : IntegerTypeBase<byte>
     /// <summary>
     /// Initializes a new instance of the <see cref="ByteType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ByteType()
-        : this(byte.MinValue, byte.MaxValue)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ByteType"/> class.
-    /// </summary>
     public ByteType(byte min, byte max)
         : this(
             ScalarNames.Byte,
@@ -41,6 +32,15 @@ public class ByteType : IntegerTypeBase<byte>
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByteType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public ByteType()
+        : this(byte.MinValue, byte.MaxValue)
+    {
     }
 
     protected override byte ParseLiteral(IntValueNode valueSyntax) =>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DateTimeType.cs
@@ -23,18 +23,6 @@ public class DateTimeType : ScalarType<DateTimeOffset, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="DateTimeType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public DateTimeType()
-        : this(
-            ScalarNames.DateTime,
-            TypeResources.DateTimeType_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DateTimeType"/> class.
-    /// </summary>
     public DateTimeType(
         string name,
         string? description = null,
@@ -43,6 +31,18 @@ public class DateTimeType : ScalarType<DateTimeOffset, StringValueNode>
     {
         Description = description;
         SpecifiedBy = new Uri(_specifiedBy);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DateTimeType()
+        : this(
+            ScalarNames.DateTime,
+            TypeResources.DateTimeType_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     protected override DateTimeOffset ParseLiteral(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DateType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DateType.cs
@@ -15,14 +15,6 @@ public class DateType : ScalarType<DateTime, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="DateTimeType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public DateType() : this(ScalarNames.Date, TypeResources.DateType_Description)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DateTimeType"/> class.
-    /// </summary>
     public DateType(
         string name,
         string? description = null,
@@ -30,6 +22,14 @@ public class DateType : ScalarType<DateTime, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DateType() : this(ScalarNames.Date, TypeResources.DateType_Description)
+    {
     }
 
     protected override DateTime ParseLiteral(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/DecimalType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/DecimalType.cs
@@ -10,15 +10,6 @@ public class DecimalType : FloatTypeBase<decimal>
     /// <summary>
     /// Initializes a new instance of the <see cref="DecimalType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public DecimalType()
-        : this(decimal.MinValue, decimal.MaxValue)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DecimalType"/> class.
-    /// </summary>
     public DecimalType(decimal min, decimal max)
         : this(
             ScalarNames.Decimal,
@@ -41,6 +32,15 @@ public class DecimalType : FloatTypeBase<decimal>
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DecimalType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DecimalType()
+        : this(decimal.MinValue, decimal.MaxValue)
+    {
     }
 
     protected override decimal ParseLiteral(IFloatValueLiteral valueSyntax) =>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/FloatType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/FloatType.cs
@@ -19,16 +19,6 @@ public class FloatType : FloatTypeBase<double>
     /// <summary>
     /// Initializes a new instance of the <see cref="FloatType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public FloatType()
-        : this(double.MinValue, double.MaxValue)
-    {
-
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="FloatType"/> class.
-    /// </summary>
     public FloatType(double min, double max)
         : this(
             ScalarNames.Float,
@@ -51,6 +41,16 @@ public class FloatType : FloatTypeBase<double>
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FloatType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public FloatType()
+        : this(double.MinValue, double.MaxValue)
+    {
+
     }
 
     protected override double ParseLiteral(IFloatValueLiteral valueSyntax) =>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IdType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IdType.cs
@@ -21,15 +21,6 @@ public class IdType : ScalarType<string>
     /// <summary>
     /// Initializes a new instance of the <see cref="IdType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public IdType() : this(ScalarNames.ID, TypeResources.IdType_Description)
-    {
-
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IdType"/> class.
-    /// </summary>
     public IdType(
         string name,
         string? description = null,
@@ -37,6 +28,15 @@ public class IdType : ScalarType<string>
         : base(name, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IdType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public IdType() : this(ScalarNames.ID, TypeResources.IdType_Description)
+    {
+
     }
 
     public override bool IsInstanceOfType(IValueNode literal)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/IntType.cs
@@ -18,15 +18,6 @@ public class IntType : IntegerTypeBase<int>
     /// <summary>
     /// Initializes a new instance of the <see cref="IntType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public IntType()
-        : this(int.MinValue, int.MaxValue)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IntType"/> class.
-    /// </summary>
     public IntType(int min, int max)
         : this(
             ScalarNames.Int,
@@ -49,6 +40,15 @@ public class IntType : IntegerTypeBase<int>
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public IntType()
+        : this(int.MinValue, int.MaxValue)
+    {
     }
 
     protected override int ParseLiteral(IntValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
@@ -21,15 +21,15 @@ public sealed class JsonType : ScalarType<JsonElement>
     /// <summary>
     /// Initializes a new instance of <see cref="JsonType"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public JsonType()
-        : base(ScalarNames.JSON, BindingBehavior.Implicit) { }
-
+    public JsonType(string name, BindingBehavior bind = BindingBehavior.Explicit)
+        : base(name, bind) { }
+    
     /// <summary>
     /// Initializes a new instance of <see cref="JsonType"/>.
     /// </summary>
-    public JsonType(string name, BindingBehavior bind = BindingBehavior.Explicit)
-        : base(name, bind) { }
+    [ActivatorUtilitiesConstructor]
+    public JsonType()
+        : base(ScalarNames.JSON, BindingBehavior.Implicit) { }
 
     /// <summary>
     /// Defines if the specified <paramref name="valueSyntax"/> can be handled by the JSON scalar.

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/LongType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/LongType.cs
@@ -11,15 +11,6 @@ public class LongType
     /// <summary>
     /// Initializes a new instance of the <see cref="LongType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public LongType()
-        : this(long.MinValue, long.MaxValue)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LongType"/> class.
-    /// </summary>
     public LongType(long min, long max)
         : this(
             ScalarNames.Long,
@@ -42,6 +33,15 @@ public class LongType
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LongType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public LongType()
+        : this(long.MinValue, long.MaxValue)
+    {
     }
 
     protected override long ParseLiteral(IntValueNode valueSyntax) =>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/MultiplierPathType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/MultiplierPathType.cs
@@ -15,18 +15,6 @@ public class MultiplierPathType
     /// <summary>
     /// Initializes a new instance of the <see cref="MultiplierPathType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public MultiplierPathType()
-        : this(
-            ScalarNames.MultiplierPath,
-            TypeResources.MultiplierPathType_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MultiplierPathType"/> class.
-    /// </summary>
     public MultiplierPathType(
         string name,
         string? description = null,
@@ -34,6 +22,18 @@ public class MultiplierPathType
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiplierPathType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public MultiplierPathType()
+        : this(
+            ScalarNames.MultiplierPath,
+            TypeResources.MultiplierPathType_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     protected override bool IsInstanceOfType(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/ShortType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/ShortType.cs
@@ -10,14 +10,6 @@ public class ShortType : IntegerTypeBase<short>
     /// <summary>
     /// Initializes a new instance of the <see cref="ShortType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public ShortType() : this(short.MinValue, short.MaxValue)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ShortType"/> class.
-    /// </summary>
     public ShortType(short min, short max)
         : this(
             ScalarNames.Short,
@@ -40,6 +32,14 @@ public class ShortType : IntegerTypeBase<short>
         : base(name, min, max, bind)
     {
         Description = description;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShortType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public ShortType() : this(short.MinValue, short.MaxValue)
+    {
     }
 
     protected override short ParseLiteral(IntValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/StringType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/StringType.cs
@@ -18,18 +18,6 @@ public class StringType : ScalarType<string, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="StringType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public StringType()
-        : this(
-            ScalarNames.String,
-            TypeResources.StringType_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="StringType"/> class.
-    /// </summary>
     public StringType(
         string name,
         string? description = null,
@@ -37,6 +25,18 @@ public class StringType : ScalarType<string, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public StringType()
+        : this(
+            ScalarNames.String,
+            TypeResources.StringType_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     protected override string ParseLiteral(StringValueNode valueSyntax) =>

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/TimeSpanType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/TimeSpanType.cs
@@ -16,12 +16,6 @@ public class TimeSpanType
 {
     private readonly TimeSpanFormat _format;
 
-    [ActivatorUtilitiesConstructor]
-    public TimeSpanType()
-        : this(ScalarNames.TimeSpan, TypeResources.TimeSpanType_Description)
-    {
-    }
-
     public TimeSpanType(
         TimeSpanFormat format = TimeSpanFormat.Iso8601,
         BindingBehavior bind = BindingBehavior.Implicit)
@@ -38,6 +32,12 @@ public class TimeSpanType
     {
         _format = format;
         Description = description;
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public TimeSpanType()
+        : this(ScalarNames.TimeSpan, TypeResources.TimeSpanType_Description)
+    {
     }
 
     protected override TimeSpan ParseLiteral(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UrlType.cs
@@ -14,16 +14,6 @@ public class UrlType : ScalarType<Uri, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="UrlType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public UrlType()
-        : this(ScalarNames.URL, bind: BindingBehavior.Implicit)
-    {
-        SpecifiedBy = new Uri(_specifiedBy);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UrlType"/> class.
-    /// </summary>
     public UrlType(
         string name,
         string? description = null,
@@ -31,6 +21,16 @@ public class UrlType : ScalarType<Uri, StringValueNode>
         : base(name, bind)
     {
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UrlType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UrlType()
+        : this(ScalarNames.URL, bind: BindingBehavior.Implicit)
+    {
+        SpecifiedBy = new Uri(_specifiedBy);
     }
 
     protected override bool IsInstanceOfType(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/Scalars/UuidType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/UuidType.cs
@@ -17,14 +17,6 @@ public class UuidType : ScalarType<Guid, StringValueNode>
     /// <summary>
     /// Initializes a new instance of the <see cref="UuidType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public UuidType() : this('\0')
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UuidType"/> class.
-    /// </summary>
     /// <param name="defaultFormat">
     /// The expected format of GUID strings by this scalar.
     /// <c>'N'</c>: nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
@@ -85,6 +77,14 @@ public class UuidType : ScalarType<Guid, StringValueNode>
         Description = description;
         _format = CreateFormatString(defaultFormat);
         _enforceFormat = enforceFormat;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UuidType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public UuidType() : this('\0')
+    {
     }
 
     protected override bool IsInstanceOfType(StringValueNode valueSyntax)

--- a/src/HotChocolate/Core/src/Types/Types/UnionType~1.cs
+++ b/src/HotChocolate/Core/src/Types/Types/UnionType~1.cs
@@ -11,16 +11,16 @@ public class UnionType<T> : UnionType
 {
     private Action<IUnionTypeDescriptor>? _configure;
 
-    [ActivatorUtilitiesConstructor]
-    public UnionType()
-    {
-        _configure = Configure;
-    }
-
     public UnionType(Action<IUnionTypeDescriptor> configure)
     {
         _configure = configure
             ?? throw new ArgumentNullException(nameof(configure));
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public UnionType()
+    {
+        _configure = Configure;
     }
 
     protected override UnionTypeDefinition CreateDefinition(ITypeDiscoveryContext context)

--- a/src/HotChocolate/Data/src/Data/Filters/FilterInputType`1.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/FilterInputType`1.cs
@@ -9,16 +9,16 @@ public class FilterInputType<T> : FilterInputType
 {
     private Action<IFilterInputTypeDescriptor<T>>? _configure;
 
-    [ActivatorUtilitiesConstructor]
-    public FilterInputType()
-    {
-        _configure = Configure;
-    }
-
     public FilterInputType(Action<IFilterInputTypeDescriptor<T>> configure)
     {
         _configure = configure ??
             throw new ArgumentNullException(nameof(configure));
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public FilterInputType()
+    {
+        _configure = Configure;
     }
 
     protected override InputObjectTypeDefinition CreateDefinition(

--- a/src/HotChocolate/Data/src/Data/Filters/Types/IdOperationFilterInputType.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Types/IdOperationFilterInputType.cs
@@ -8,13 +8,13 @@ public class IdOperationFilterInputType
     : FilterInputType
     , IComparableOperationFilterInputType
 {
-    [ActivatorUtilitiesConstructor]
-    public IdOperationFilterInputType()
+    public IdOperationFilterInputType(Action<IFilterInputTypeDescriptor> configure)
+        : base(configure)
     {
     }
 
-    public IdOperationFilterInputType(Action<IFilterInputTypeDescriptor> configure)
-        : base(configure)
+    [ActivatorUtilitiesConstructor]
+    public IdOperationFilterInputType()
     {
     }
 

--- a/src/HotChocolate/Data/src/Data/Sorting/SortInputType`1.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/SortInputType`1.cs
@@ -9,16 +9,16 @@ public class SortInputType<T> : SortInputType
 {
     private Action<ISortInputTypeDescriptor<T>>? _configure;
 
-    [ActivatorUtilitiesConstructor]
-    public SortInputType()
-    {
-        _configure = Configure;
-    }
-
     public SortInputType(Action<ISortInputTypeDescriptor<T>> configure)
     {
         _configure = configure ??
             throw new ArgumentNullException(nameof(configure));
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public SortInputType()
+    {
+        _configure = Configure;
     }
 
     protected override InputObjectTypeDefinition CreateDefinition(

--- a/src/HotChocolate/Marten/src/Data/Filtering/MartenQueryableFilterProvider.cs
+++ b/src/HotChocolate/Marten/src/Data/Filtering/MartenQueryableFilterProvider.cs
@@ -13,20 +13,20 @@ public class MartenQueryableFilterProvider : QueryableFilterProvider
     /// <summary>
     /// Initializes a new instance of <see cref="MartenQueryableFilterProvider"/>.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public MartenQueryableFilterProvider()
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="MartenQueryableFilterProvider"/>.
-    /// </summary>
     /// <param name="configure">
     /// A delegate to configure this provider.
     /// </param>
     public MartenQueryableFilterProvider(
         Action<IFilterProviderDescriptor<QueryableFilterContext>> configure)
         : base(configure)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="MartenQueryableFilterProvider"/>.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public MartenQueryableFilterProvider()
     {
     }
 

--- a/src/HotChocolate/MongoDb/src/Types/BsonType.cs
+++ b/src/HotChocolate/MongoDb/src/Types/BsonType.cs
@@ -18,18 +18,6 @@ public class BsonType : ScalarType
     /// <summary>
     /// Initializes a new instance of the <see cref="BsonType"/> class.
     /// </summary>
-    [ActivatorUtilitiesConstructor]
-    public BsonType()
-        : this(
-            MongoDbScalarNames.Bson,
-            MongoDbTypesResources.Bson_Type_Description,
-            BindingBehavior.Implicit)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BsonType"/> class.
-    /// </summary>
     public BsonType(
         string name,
         string? description = null,
@@ -38,6 +26,18 @@ public class BsonType : ScalarType
     {
         SpecifiedBy = new Uri("https://bsonspec.org/spec.html");
         Description = description;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BsonType"/> class.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public BsonType()
+        : this(
+            MongoDbScalarNames.Bson,
+            MongoDbTypesResources.Bson_Type_Description,
+            BindingBehavior.Implicit)
+    {
     }
 
     /// <inheritdoc />

--- a/src/HotChocolate/Spatial/src/Types/GeometryType.cs
+++ b/src/HotChocolate/Spatial/src/Types/GeometryType.cs
@@ -11,15 +11,15 @@ public sealed class GeometryType
     , IGeoJsonObjectType
     , IGeoJsonInputType
 {
-    [ActivatorUtilitiesConstructor]
-    public GeometryType() : base(GeometryTypeName)
-    {
-    }
-
     public GeometryType(
         string name,
         BindingBehavior bind = BindingBehavior.Explicit)
         : base(name, bind)
+    {
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public GeometryType() : base(GeometryTypeName)
     {
     }
 


### PR DESCRIPTION
In order for the `[ActivatorUtilitiesConstructor]` attribute to work correctly, if there are less parameters than the other constructors on the class, the constructor decorated with the `[ActivatorUtilitiesConstructor]` attribute must be the last constructor defined.


See [this issue](https://github.com/dotnet/runtime/issues/98959) (https://github.com/dotnet/runtime/issues/98959) and [this pr comment](https://github.com/dotnet/runtime/pull/99175#discussion_r1509615389) (https://github.com/dotnet/runtime/pull/99175#discussion_r1509615389) 