### PR TITLE
Fix incorrect cache control maxAge documentations

### DIFF
--- a/src/HotChocolate/Caching/src/Caching/CacheControlAttribute.cs
+++ b/src/HotChocolate/Caching/src/Caching/CacheControlAttribute.cs
@@ -24,7 +24,7 @@ public sealed class CacheControlAttribute : DescriptorAttribute
     }
 
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, the resource can be cached.
+    /// The maximum time, in seconds, the resource can be cached.
     /// </param>
     public CacheControlAttribute(int maxAge)
     {
@@ -54,7 +54,7 @@ public sealed class CacheControlAttribute : DescriptorAttribute
     }
 
     /// <summary>
-    /// The maximum time, in Milliseconds, this resource can be cached.
+    /// The maximum time, in seconds, this resource can be cached.
     /// </summary>
     public int MaxAge { get => _maxAge ?? 0; set => _maxAge = value; }
 

--- a/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlInterfaceTypeDescriptorExtensions.cs
+++ b/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlInterfaceTypeDescriptorExtensions.cs
@@ -12,7 +12,7 @@ public static class CacheControlInterfaceTypeDescriptorExtensions
     /// The <see cref="IInterfaceTypeDescriptor"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">
@@ -37,7 +37,7 @@ public static class CacheControlInterfaceTypeDescriptorExtensions
     /// The <see cref="IInterfaceTypeDescriptor{T}"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">

--- a/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlObjectFieldDescriptorExtensions.cs
@@ -12,7 +12,7 @@ public static class CacheControlObjectFieldDescriptorExtensions
     /// The <see cref="IObjectFieldDescriptor"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">

--- a/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlObjectTypeDescriptorExtensions.cs
+++ b/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlObjectTypeDescriptorExtensions.cs
@@ -12,7 +12,7 @@ public static class CacheControlObjectTypeDescriptorExtensions
     /// The <see cref="IObjectTypeDescriptor"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">
@@ -38,7 +38,7 @@ public static class CacheControlObjectTypeDescriptorExtensions
     /// The <see cref="IObjectTypeDescriptor{T}"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">

--- a/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlUnionTypeDescriptorExtensions.cs
+++ b/src/HotChocolate/Caching/src/Caching/Extensions/CacheControlUnionTypeDescriptorExtensions.cs
@@ -12,7 +12,7 @@ public static class CacheControlUnionTypeDescriptorExtensions
     /// The <see cref="IUnionTypeDescriptor"/>.
     /// </param>
     /// <param name="maxAge">
-    /// The maximum time, in Milliseconds, fields of this
+    /// The maximum time, in seconds, fields of this
     /// type should be cached.
     /// </param>
     /// <param name="scope">

--- a/src/HotChocolate/Caching/src/Caching/ICacheControlConstraints.cs
+++ b/src/HotChocolate/Caching/src/Caching/ICacheControlConstraints.cs
@@ -10,7 +10,7 @@ public interface ICacheConstraints
 {
     /// <summary>
     /// The maximum time the query result shall be cached,
-    /// in Milliseconds.
+    /// in seconds.
     /// </summary>
     int MaxAge { get; }
 

--- a/src/HotChocolate/Caching/src/Caching/Options/ICacheControlOptions.cs
+++ b/src/HotChocolate/Caching/src/Caching/Options/ICacheControlOptions.cs
@@ -11,7 +11,7 @@ public interface ICacheControlOptions
     bool Enable { get; }
 
     /// <summary>
-    /// The <c>MaxAge</c> that should be applied to fields,
+    /// The <c>MaxAge</c>, in seconds, that should be applied to fields,
     /// if <see cref="ApplyDefaults"/> is <c>true</c>.
     /// Defaults to <c>0</c>.
     /// </summary>


### PR DESCRIPTION
Fixes incorrect caching XML documentations to align with header cache-control max-age usage and code behaviour of using seconds instead of milliseconds.

Closes #7053