### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,18 @@
 "🌶️ green donut":
-  - "src/GreenDonut/**/*"
+  - changed-files:
+    - any-glob-to-any-file: "src/GreenDonut/**"
 "🌶️ hot chocolate":
-  - "src/HotChocolate/**/*"
+  - changed-files:
+    - any-glob-to-any-file: "src/HotChocolate/**"
 "🌶️ strawberry shake":
-  - "src/StrawberryShake/**/*"
+  - changed-files:
+    - any-glob-to-any-file: "src/StrawberryShake/**"
 "🌶️ website":
-  - any: ['website/**/*', '!website/src/docs/**/*.md']
+  - changed-files:
+    - all-globs-to-any-file: ["website/**", "!website/src/docs/**/*.md"]
 "📚 documentation":
-  - "website/src/docs/**/*.md"
+  - changed-files:
+    - any-glob-to-any-file: "website/src/docs/**/*.md"
 "🧰 maintenance":
-  - ".build/**/*"
-  - ".github/**/*"
-  - ".devops/**/*"
+  - changed-files:
+    - any-glob-to-any-file: [".build/**", ".github/**", ".devops/**"]

--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Cleanup
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
       src_changes: ${{ steps.check-src.outputs.src_changes }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        show-progress: false
 
     - name: Check for changes in website directory
       id: check-website
@@ -61,9 +62,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v3
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v5
 
   spellcheck:
     name: "Spellcheck Documentation"
@@ -71,11 +70,13 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.website_changes == 'true'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       name: Check out the code
+      with:
+        show-progress: false
 
     - name: Install Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'yarn'
@@ -92,6 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Check out the code
+        with:
+          show-progress: false
       - uses: actions/setup-node@v4
         name: Setup node
         with:
@@ -107,17 +110,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14.x'
         cache: 'yarn'
         cache-dependency-path: 'website/yarn.lock'
 
     - name: Cache Yarn Packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           website/.yarn/cache
@@ -145,10 +150,12 @@ jobs:
 
     steps:
       - name: Checkout to repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             7.x
@@ -173,10 +180,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.x
@@ -205,7 +214,7 @@ jobs:
 
       - name: Upload test_output.txt for debugging
         if: steps.run-tests.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-output
           path: test_output.txt
@@ -255,21 +264,21 @@ jobs:
 
       - name: Upload Test Results as Artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.name }}
           path: ./output/test-results/*.trx
 
       - name: Upload Coverage Files as Artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.name }}
           path: ./output/coverage/*.xml
 
       - name: Upload mismatch files as Artifacts
         if: steps.run-tests.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mismatch-files-${{ matrix.name }}
           path: |
@@ -290,10 +299,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x
@@ -304,7 +315,7 @@ jobs:
       run: ./build.sh restore
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: csharp
 
@@ -312,7 +323,7 @@ jobs:
       run: dotnet build ./src/All.sln --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 
   merge-coverage:
     name: Merge and Upload Coverage
@@ -321,11 +332,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install .NET
       if: ${{ !cancelled() }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x
@@ -342,7 +355,7 @@ jobs:
 
     - name: Download all coverage artifacts
       if: ${{ !cancelled() }}
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         path: ./output/download
 
@@ -357,7 +370,7 @@ jobs:
 
     - name: Upload Combined Coverage to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       timeout-minutes: 10
       with:
         file: ./output/coverage/merged/OpenCover.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,10 +21,12 @@ jobs:
 
     steps:
       - name: Checkout to repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             7.x
@@ -48,10 +50,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.x
@@ -73,14 +77,14 @@ jobs:
 
       - name: Upload Test Results as Artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.name }}
           path: ./.test-results/*.trx
 
       - name: Upload mismatch files as Artifacts
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mismatch-files-${{ matrix.name }}
           path: |
@@ -93,7 +97,7 @@ jobs:
           cp "${{ matrix.directoryPath }}/.coverage/${{ matrix.name }}.net7.0.xml" ./output/coverage/
 
       - name: Upload Individual Coverage Files as Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.name }}
           path: ./output/coverage/*.xml
@@ -111,10 +115,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x
@@ -130,7 +136,7 @@ jobs:
       run: dotnet build ./src/All.sln
 
     - name: Download all coverage artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         path: ./output/download
 
@@ -145,7 +151,7 @@ jobs:
 
     - name: Upload Combined Coverage to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       timeout-minutes: 10
       with:
         file: ./output/coverage/merged/OpenCover.xml

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -16,10 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Docker Login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ secrets.CONTAINER_REG_URL }}
           username: ${{ secrets.CONTAINER_REG_USERNAME }}
@@ -28,14 +30,14 @@ jobs:
       - run: echo ${{ secrets.CONTAINER_REG_URL }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
           cache: "yarn"
           cache-dependency-path: "website/yarn.lock"
 
       - name: Cache Yarn Packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             website/.yarn/cache
@@ -53,7 +55,7 @@ jobs:
         working-directory: website
 
       - name: Build WebSite Container
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: .docker/website/dockerfile
@@ -61,7 +63,7 @@ jobs:
           tags: ${{ secrets.CONTAINER_REG_DOMAIN }}/ccc-website-${{ github.ref_name }}:${{ github.run_id }}
 
       - name: Deploy to Azure WebApp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: ccc-p-us1-website
           slot-name: "production"

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -11,11 +11,12 @@ jobs:
   qodana:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@v2023.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Install .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.x


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated GitHub actions.

---

- `actions/checkout@3`
    - ℹ️ Adds support for sparse checkouts.
- `actions/checkout@4`
    - Supports fetching without the --progress option.
        - ✅ I've enabled this.
    - ️ℹ️ Adds support for partial checkout filters.
- `actions/labeler@v4`
    - `repo-token` input is optional.
        - ✅ I've removed it.
- `actions/labeler@v5`
    - New ([over-engineered](https://github.com/actions/labeler/issues/715#issuecomment-1948350333)) configuration format.
        - ✅ I've updated the configuration. I hope it's correct. 🤞
- `actions/setup-node@3`
    - Adds support for reading from `engines.node`.
        - ℹ️ Could be useful.
- `docker/build-push-action@4`
    - > Buildx v0.10 enables support for a minimal SLSA Provenance attestation, which requires support for OCI-compliant multi-platform images. This may introduce issues with registry and runtime support (e.g. Google Cloud Run and AWS Lambda). You can optionally disable the default provenance attestation functionality using provenance: false.
        - ⚠️ Potential issue. Unlikely.