### PR TITLE
Allow for pattern matching with the IsSelectedAttribute.

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
+++ b/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
@@ -309,4 +309,9 @@ public static class WellKnownContextData
     /// Type key to access the node id result formatter on the descriptor context.
     /// </summary>
     public const string NodeIdResultFormatter = "HotChocolate.Relay.NodeIdResultFormatter";
+
+    /// <summary>
+    /// Type key to access the pattern validation tasks.
+    /// </summary>
+    public const string PatternValidationTasks = "HotChocolate.Validation.PatternValidationTasks";
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/EmptySelectionCollection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/EmptySelectionCollection.cs
@@ -17,10 +17,13 @@ internal sealed class EmptySelectionCollection : ISelectionCollection
 
     public ISelection this[int index] => throw new IndexOutOfRangeException();
 
-    public ISelectionCollection Select(string fieldName, INamedType? typeContext = default)
+    public ISelectionCollection Select(string fieldName)
         => Instance;
 
-    public ISelectionCollection Select(ReadOnlySpan<string> fieldNames, INamedType? typeContext = default)
+    public ISelectionCollection Select(ReadOnlySpan<string> fieldNames)
+        => Instance;
+
+    public ISelectionCollection Select(INamedType typeContext)
         => Instance;
 
     public bool IsSelected(string fieldName)

--- a/src/HotChocolate/Core/src/Execution/Processing/EmptySelectionCollection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/EmptySelectionCollection.cs
@@ -3,20 +3,24 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Resolvers;
+using HotChocolate.Types;
 
 namespace HotChocolate.Execution.Processing;
 
 internal sealed class EmptySelectionCollection : ISelectionCollection
 {
     private static readonly ISelection[] _empty = Array.Empty<ISelection>();
-    
+
     public static EmptySelectionCollection Instance { get; } = new();
 
     public int Count => 0;
 
     public ISelection this[int index] => throw new IndexOutOfRangeException();
 
-    public ISelectionCollection Select(string fieldName)
+    public ISelectionCollection Select(string fieldName, INamedType? typeContext = default)
+        => Instance;
+
+    public ISelectionCollection Select(ReadOnlySpan<string> fieldNames, INamedType? typeContext = default)
         => Instance;
 
     public bool IsSelected(string fieldName)
@@ -30,7 +34,7 @@ internal sealed class EmptySelectionCollection : ISelectionCollection
 
     public bool IsSelected(ISet<string> fieldNames)
         => false;
-    
+
     public IEnumerator<ISelection> GetEnumerator()
         => _empty.AsEnumerable().GetEnumerator();
 

--- a/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Selection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Selection.cs
@@ -85,11 +85,9 @@ internal partial class MiddlewareContext
         return selectionSet.Selections;
     }
 
+    public ISelectionCollection Select()
+        => new SelectionCollection(Schema, Operation, [Selection], _operationContext.IncludeFlags);
+
     public ISelectionCollection Select(string fieldName)
-        => new SelectionCollection(
-            Schema,
-            Operation,
-            [Selection,],
-            _operationContext.IncludeFlags)
-            .Select(fieldName);
+        => Select().Select(fieldName);
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/SelectionCollection.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/SelectionCollection.cs
@@ -479,10 +479,12 @@ internal sealed class SelectionCollection(
 
         while (Unsafe.IsAddressLessThan(ref start, ref end))
         {
-            if (typeContext.IsAssignableFrom(start.DeclaringType))
+            if (typeContext.IsAssignableFrom(start.Type.NamedType()))
             {
                 buffer[size++] = start;
             }
+
+            start = ref Unsafe.Add(ref start, 1)!;
         }
 
         if (size == 0)

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeInitializer.cs
@@ -110,14 +110,6 @@ internal sealed class TypeInitializer
         FinalizeTypes();
 
         // if we do not have any errors we will validate the types for spec violations.
-        if (_errors.Count == 0)
-        {
-            _errors.AddRange(
-                SchemaValidator.Validate(
-                    _typeRegistry.Types.Select(t => t.Type),
-                    _options));
-        }
-
         if (_errors.Count > 0)
         {
             throw new SchemaException(_errors);
@@ -663,25 +655,17 @@ internal sealed class TypeInitializer
         }
     }
 
-    private readonly struct RegisteredRootType
+    private readonly struct RegisteredRootType(
+        ITypeCompletionContext context,
+        RegisteredType type,
+        OperationType kind)
     {
-        public RegisteredRootType(
-            ITypeCompletionContext context,
-            RegisteredType type,
-            OperationType kind)
-        {
-            Context = context;
-            Type = type;
-            Kind = kind;
-            IsInitialized = true;
-        }
+        public ITypeCompletionContext Context { get; } = context;
 
-        public ITypeCompletionContext Context { get; }
+        public RegisteredType Type { get; } = type;
 
-        public RegisteredType Type { get; }
+        public OperationType Kind { get; } = kind;
 
-        public OperationType Kind { get; }
-
-        public bool IsInitialized { get; }
+        public bool IsInitialized { get; } = true;
     }
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/DirectiveValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/DirectiveValidationRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 using static HotChocolate.Configuration.Validation.TypeValidationHelper;
 using static HotChocolate.Utilities.ErrorHelper;
 
@@ -15,20 +16,17 @@ internal sealed class DirectiveValidationRule : ISchemaValidationRule
     private const char _prefixCharacter = '_';
 
     public void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors)
     {
-        if (options.StrictValidation)
+        if (context.Options.StrictValidation)
         {
-            foreach (var type in typeSystemObjects)
+            foreach (var directiveType in schema.DirectiveTypes)
             {
-                if (type is DirectiveType directiveType)
-                {
-                    EnsureDirectiveNameIsValid(directiveType, errors);
-                    EnsureArgumentNamesAreValid(directiveType, errors);
-                    EnsureArgumentDeprecationIsValid(directiveType, errors);
-                }
+                EnsureDirectiveNameIsValid(directiveType, errors);
+                EnsureArgumentNamesAreValid(directiveType, errors);
+                EnsureArgumentDeprecationIsValid(directiveType, errors);
             }
         }
     }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/ISchemaValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/ISchemaValidationRule.cs
@@ -1,15 +1,14 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
-using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Configuration.Validation;
 
 internal interface ISchemaValidationRule
 {
     void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors);
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/InputObjectTypeValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/InputObjectTypeValidationRule.cs
@@ -1,10 +1,10 @@
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Language;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 using static HotChocolate.Configuration.Validation.TypeValidationHelper;
 using static HotChocolate.Utilities.ErrorHelper;
 
@@ -13,11 +13,11 @@ namespace HotChocolate.Configuration.Validation;
 internal sealed class InputObjectTypeValidationRule : ISchemaValidationRule
 {
     public void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors)
     {
-        if (!options.StrictValidation)
+        if (!context.Options.StrictValidation)
         {
             return;
         }
@@ -26,12 +26,12 @@ internal sealed class InputObjectTypeValidationRule : ISchemaValidationRule
         CycleValidationContext cycleValidationContext = new()
         {
             Visited = [],
-            CycleStartIndex = new(),
+            CycleStartIndex = new Dictionary<InputObjectType, int>(),
             Errors = errors,
             FieldPath = [],
         };
-        
-        foreach (var type in typeSystemObjects)
+
+        foreach (var type in schema.Types)
         {
             if (type is not InputObjectType inputType)
             {
@@ -48,7 +48,7 @@ internal sealed class InputObjectTypeValidationRule : ISchemaValidationRule
         }
     }
 
-    private struct CycleValidationContext
+    private ref struct CycleValidationContext
     {
         public HashSet<InputObjectType> Visited { get; set; }
         public Dictionary<InputObjectType, int> CycleStartIndex { get; set; }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/InterfaceHasAtLeastOneImplementationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/InterfaceHasAtLeastOneImplementationRule.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 using HotChocolate.Utilities;
 
 namespace HotChocolate.Configuration.Validation;
@@ -8,11 +8,11 @@ namespace HotChocolate.Configuration.Validation;
 internal sealed class InterfaceHasAtLeastOneImplementationRule : ISchemaValidationRule
 {
     public void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors)
     {
-        if (!options.StrictValidation)
+        if (!context.Options.StrictValidation)
         {
             return;
         }
@@ -23,9 +23,9 @@ internal sealed class InterfaceHasAtLeastOneImplementationRule : ISchemaValidati
         // first we get all interface types and add them to the interface type list.
         // we will strike from this list all the items that we find being implemented by
         // object types.
-        for (var i = 0; i < typeSystemObjects.Length; i++)
+        foreach(var type in schema.Types)
         {
-            if (typeSystemObjects[i] is InterfaceType interfaceType)
+            if (type is InterfaceType interfaceType)
             {
                 interfaceTypes.Add(interfaceType);
             }
@@ -33,9 +33,9 @@ internal sealed class InterfaceHasAtLeastOneImplementationRule : ISchemaValidati
 
         // next we go through all the object types and strike the interfaces from the interface
         // list that we find being implemented.
-        for (var i = 0; i < typeSystemObjects.Length; i++)
+        foreach(var type in schema.Types)
         {
-            if (typeSystemObjects[i] is ObjectType objectType)
+            if (type is ObjectType objectType)
             {
                 // we strike the interfaces that are being implemented.
                 foreach (var interfaceType in objectType.Implements)
@@ -49,9 +49,9 @@ internal sealed class InterfaceHasAtLeastOneImplementationRule : ISchemaValidati
                 // these.
                 foreach (var field in objectType.Fields)
                 {
-                    if (field.Type.NamedType() is { Kind: TypeKind.Interface, } type)
+                    if (field.Type.NamedType() is { Kind: TypeKind.Interface, } namedType)
                     {
-                        fieldTypes.Add(type);
+                        fieldTypes.Add(namedType);
                     }
                 }
             }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/InterfaceTypeValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/InterfaceTypeValidationRule.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 using static HotChocolate.Configuration.Validation.TypeValidationHelper;
 
 #nullable enable
@@ -10,13 +10,13 @@ namespace HotChocolate.Configuration.Validation;
 internal sealed class InterfaceTypeValidationRule : ISchemaValidationRule
 {
     public void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors)
     {
-        if (options.StrictValidation)
+        if (context.Options.StrictValidation)
         {
-            foreach (var type in typeSystemObjects)
+            foreach (var type in schema.Types)
             {
                 if (type is InterfaceType interfaceType)
                 {

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/IsSelectedPatternValidation.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/IsSelectedPatternValidation.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using HotChocolate.Resolvers.Expressions.Parameters;
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.Configuration.Validation;
+
+internal sealed class IsSelectedPatternValidation : ISchemaValidationRule
+{
+    public void Validate(
+        IDescriptorContext context,
+        ISchema schema,
+        ICollection<ISchemaError> errors)
+    {
+        if (!context.ContextData.TryGetValue(WellKnownContextData.PatternValidationTasks, out var value))
+        {
+            return;
+        }
+
+        foreach (var pattern in (List<IsSelectedPattern>)value!)
+        {
+            var objectField = schema.QueryType.Fields[pattern.FieldName];
+            var validationContext = new ValidateIsSelectedPatternContext(schema, objectField);
+            ValidateIsSelectedPatternVisitor.Instance.Visit(pattern.Pattern, validationContext);
+
+            if (validationContext.Error is not null)
+            {
+                errors.Add(validationContext.Error);
+            }
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/IsSelectedPatternValidation.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/IsSelectedPatternValidation.cs
@@ -1,5 +1,12 @@
+#nullable enable
+
 using System.Collections.Generic;
+using System.Text;
+using HotChocolate.Language;
+using HotChocolate.Language.Visitors;
 using HotChocolate.Resolvers.Expressions.Parameters;
+using HotChocolate.Types;
+using HotChocolate.Types.Attributes;
 using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Configuration.Validation;
@@ -19,7 +26,7 @@ internal sealed class IsSelectedPatternValidation : ISchemaValidationRule
         foreach (var pattern in (List<IsSelectedPattern>)value!)
         {
             var objectField = schema.QueryType.Fields[pattern.FieldName];
-            var validationContext = new ValidateIsSelectedPatternContext(schema, objectField);
+            var validationContext = new ValidateIsSelectedPatternContext(schema, objectField, pattern.Pattern);
             ValidateIsSelectedPatternVisitor.Instance.Visit(pattern.Pattern, validationContext);
 
             if (validationContext.Error is not null)
@@ -27,5 +34,149 @@ internal sealed class IsSelectedPatternValidation : ISchemaValidationRule
                 errors.Add(validationContext.Error);
             }
         }
+    }
+
+    private sealed class ValidateIsSelectedPatternVisitor : SyntaxWalker<ValidateIsSelectedPatternContext>
+    {
+        protected override ISyntaxVisitorAction Enter(FieldNode node, ValidateIsSelectedPatternContext context)
+        {
+            var field = context.Field.Peek();
+            var typeContext = context.TypeContext.Peek() ?? field.Type.NamedType();
+
+            if (typeContext is IComplexOutputType complexOutputType)
+            {
+                if (complexOutputType.Fields.TryGetField(node.Name.Value, out var objectField))
+                {
+                    if (node.SelectionSet is not null)
+                    {
+                        context.TypeContext.Push(null);
+                        context.Field.Push(objectField);
+                    }
+
+                    return base.Enter(node, context);
+                }
+
+                var message = new StringBuilder();
+                message.Append("The specified pattern on field `");
+                message.Append(context.Root.Coordinate.ToString());
+                message.AppendLine("` is invalid:");
+                message.AppendLine($"`{context.Pattern}`");
+                message.AppendLine();
+                message.Append("The field ");
+                message.Append($"`{node.Name.Value}`");
+                message.Append(" does not exist on type ");
+                message.Append($"`{typeContext.Name}`.");
+
+                context.Error =
+                    SchemaErrorBuilder.New()
+                        .SetMessage(message.ToString())
+                        .AddSyntaxNode(node)
+                        .Build();
+                return Break;
+            }
+            else
+            {
+                var message = new StringBuilder();
+                message.Append("The specified pattern on field `");
+                message.Append(context.Root.Coordinate.ToString());
+                message.AppendLine("` is invalid:");
+                message.AppendLine($"`{context.Pattern}`");
+                message.AppendLine();
+                message.Append("The field declaring type ");
+                message.Append($"`{typeContext.Name}`");
+                message.Append(" must be a object type or interface type.");
+
+                context.Error =
+                    SchemaErrorBuilder.New()
+                        .SetMessage(message.ToString())
+                        .AddSyntaxNode(node)
+                        .Build();
+
+                return Break;
+            }
+        }
+
+        protected override ISyntaxVisitorAction Leave(FieldNode node, ValidateIsSelectedPatternContext context)
+        {
+            if (node.SelectionSet is not null)
+            {
+                context.TypeContext.Pop();
+                context.Field.Pop();
+            }
+
+            return base.Leave(node, context);
+        }
+
+        protected override ISyntaxVisitorAction Enter(InlineFragmentNode node, ValidateIsSelectedPatternContext context)
+        {
+            if (node.TypeCondition is not null)
+            {
+                var type = context.Schema.GetType<INamedType>(node.TypeCondition.Name.Value);
+                var field = context.Field.Peek();
+
+                if (!type.IsAssignableFrom(field.Type.NamedType()))
+                {
+                    var message = new StringBuilder();
+                    message.Append("The specified pattern on field `");
+                    message.Append(context.Root.Coordinate.ToString());
+                    message.AppendLine("` is invalid:");
+                    message.AppendLine($"`{context.Pattern}`");
+                    message.AppendLine();
+                    message.Append("The type condition ");
+                    message.Append($"`{type.Name}`");
+                    message.Append(" of the inline fragment is not assignable from the parent field type ");
+                    message.Append($"`{field.Type.NamedType().Name}`.");
+
+                    context.Error =
+                        SchemaErrorBuilder.New()
+                            .SetMessage(message.ToString())
+                            .AddSyntaxNode(node)
+                            .Build();
+                    return Break;
+                }
+
+                context.TypeContext.Push(type);
+            }
+
+            return base.Enter(node, context);
+        }
+
+
+        protected override ISyntaxVisitorAction Leave(InlineFragmentNode node, ValidateIsSelectedPatternContext context)
+        {
+            if (node.TypeCondition is not null)
+            {
+                context.TypeContext.Pop();
+            }
+
+            return base.Leave(node, context);
+        }
+
+        public static ValidateIsSelectedPatternVisitor Instance { get; } = new();
+    }
+
+    private sealed class ValidateIsSelectedPatternContext
+    {
+        public ValidateIsSelectedPatternContext(ISchema schema, IObjectField field, SelectionSetNode pattern)
+        {
+            Schema = schema;
+            Root = field;
+            Pattern = pattern;
+
+            Field.Push(field);
+            TypeContext.Push(null);
+        }
+
+        public ISchema Schema { get; }
+
+        public IObjectField Root { get; }
+
+        public SelectionSetNode Pattern { get; }
+
+        public Stack<IOutputField> Field { get; } = new();
+
+        public Stack<INamedType?> TypeContext { get; } = new();
+
+        public ISchemaError? Error { get; set; }
     }
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/ObjectTypeValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/ObjectTypeValidationRule.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 using HotChocolate.Types.Relay;
 using HotChocolate.Utilities;
 using static HotChocolate.Configuration.Validation.TypeValidationHelper;
@@ -17,17 +17,17 @@ namespace HotChocolate.Configuration.Validation;
 internal sealed class ObjectTypeValidationRule : ISchemaValidationRule
 {
     public void Validate(
-        ReadOnlySpan<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options,
+        IDescriptorContext context,
+        ISchema schema,
         ICollection<ISchemaError> errors)
     {
         NodeType? nodeType = null;
 
-        if (options.StrictValidation)
+        if (context.Options.StrictValidation)
         {
-            if (options.EnsureAllNodesCanBeResolved)
+            if (context.Options.EnsureAllNodesCanBeResolved)
             {
-                foreach (var type in typeSystemObjects)
+                foreach (var type in schema.Types)
                 {
                     if (type is NodeType nt)
                     {
@@ -37,7 +37,7 @@ internal sealed class ObjectTypeValidationRule : ISchemaValidationRule
                 }
             }
 
-            foreach (var type in typeSystemObjects)
+            foreach (var type in schema.Types)
             {
                 if (type is ObjectType objectType)
                 {

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
 
 namespace HotChocolate.Configuration.Validation;
 
@@ -14,28 +15,28 @@ internal static class SchemaValidator
         new InputObjectTypeValidationRule(),
         new DirectiveValidationRule(),
         new InterfaceHasAtLeastOneImplementationRule(),
+        new IsSelectedPatternValidation(),
     ];
 
-    public static IReadOnlyCollection<ISchemaError> Validate(
-        IEnumerable<ITypeSystemObject> typeSystemObjects,
-        IReadOnlySchemaOptions options)
+    public static IReadOnlyList<ISchemaError> Validate(
+        IDescriptorContext context,
+        ISchema schema)
     {
-        if (typeSystemObjects is null)
+        if (context == null)
         {
-            throw new ArgumentNullException(nameof(typeSystemObjects));
+            throw new ArgumentNullException(nameof(context));
         }
 
-        if (options is null)
+        if (schema == null)
         {
-            throw new ArgumentNullException(nameof(options));
+            throw new ArgumentNullException(nameof(schema));
         }
 
-        var types = typeSystemObjects.ToArray();
         var errors = new List<ISchemaError>();
 
         foreach (var rule in _rules)
         {
-            rule.Validate(types, options, errors);
+            rule.Validate(context, schema, errors);
         }
 
         return errors;

--- a/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/IResolverContext.cs
@@ -129,6 +129,16 @@ public interface IResolverContext : IPureResolverContext
         bool allowInternals = false);
 
     /// <summary>
+    /// Selects the current field and returns a <see cref="ISelectionCollection"/> containing
+    /// this selection.
+    /// </summary>
+    /// <returns>
+    /// Returns a <see cref="ISelectionCollection"/> containing
+    /// the selections that match the given field name.
+    /// </returns>
+    ISelectionCollection Select();
+
+    /// <summary>
     /// Selects all child fields that match the given field name and
     /// returns a <see cref="ISelectionCollection"/> containing
     /// these selections.
@@ -138,7 +148,7 @@ public interface IResolverContext : IPureResolverContext
     /// </param>
     /// <returns>
     /// Returns a <see cref="ISelectionCollection"/> containing
-    /// the selections that match the given field name. 
+    /// the selections that match the given field name.
     /// </returns>
     ISelectionCollection Select(string fieldName);
 

--- a/src/HotChocolate/Core/src/Types/Resolvers/ISelectionCollection.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/ISelectionCollection.cs
@@ -19,14 +19,11 @@ public interface ISelectionCollection : IReadOnlyList<ISelection>
     /// <param name="fieldName">
     /// The field name to select.
     /// </param>
-    /// <param name="typeContext">
-    /// The type from which the fields shall be selected.
-    /// </param>
     /// <returns>
     /// Returns a <see cref="ISelectionCollection"/> containing
     /// the selections that match the given field name.
     /// </returns>
-    ISelectionCollection Select(string fieldName, INamedType? typeContext = default);
+    ISelectionCollection Select(string fieldName);
 
     /// <summary>
     /// Selects all child fields that match the given field names and
@@ -36,14 +33,23 @@ public interface ISelectionCollection : IReadOnlyList<ISelection>
     /// <param name="fieldNames">
     /// The field names to select.
     /// </param>
-    /// <param name="typeContext">
-    /// The type from which the fields shall be selected.
-    /// </param>
     /// <returns>
     /// Returns a <see cref="ISelectionCollection"/> containing
     /// the selections that match the given field name.
     /// </returns>
-    ISelectionCollection Select(ReadOnlySpan<string> fieldNames, INamedType? typeContext = default);
+    ISelectionCollection Select(ReadOnlySpan<string> fieldNames);
+
+    /// <summary>
+    /// Selects all selections where the typeContext is assignable from the field`s declaring type.
+    /// </summary>
+    /// <param name="typeContext">
+    /// The type context to select.
+    /// </param>
+    /// <returns>
+    /// Returns a <see cref="ISelectionCollection"/> containing
+    /// the selections where the typeContext is assignable from the field`s declaring type.
+    /// </returns>
+    ISelectionCollection Select(INamedType typeContext);
 
     /// <summary>
     /// Specifies if a child field with the given field name is selected.

--- a/src/HotChocolate/Core/src/Types/Resolvers/ISelectionCollection.cs
+++ b/src/HotChocolate/Core/src/Types/Resolvers/ISelectionCollection.cs
@@ -1,6 +1,8 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using HotChocolate.Execution.Processing;
+using HotChocolate.Types;
 
 namespace HotChocolate.Resolvers;
 
@@ -17,11 +19,31 @@ public interface ISelectionCollection : IReadOnlyList<ISelection>
     /// <param name="fieldName">
     /// The field name to select.
     /// </param>
+    /// <param name="typeContext">
+    /// The type from which the fields shall be selected.
+    /// </param>
     /// <returns>
     /// Returns a <see cref="ISelectionCollection"/> containing
-    /// the selections that match the given field name. 
+    /// the selections that match the given field name.
     /// </returns>
-    ISelectionCollection Select(string fieldName);
+    ISelectionCollection Select(string fieldName, INamedType? typeContext = default);
+
+    /// <summary>
+    /// Selects all child fields that match the given field names and
+    /// returns a <see cref="ISelectionCollection"/> containing
+    /// these selections.
+    /// </summary>
+    /// <param name="fieldNames">
+    /// The field names to select.
+    /// </param>
+    /// <param name="typeContext">
+    /// The type from which the fields shall be selected.
+    /// </param>
+    /// <returns>
+    /// Returns a <see cref="ISelectionCollection"/> containing
+    /// the selections that match the given field name.
+    /// </returns>
+    ISelectionCollection Select(ReadOnlySpan<string> fieldNames, INamedType? typeContext = default);
 
     /// <summary>
     /// Specifies if a child field with the given field name is selected.

--- a/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaBuilder.Setup.cs
@@ -364,20 +364,20 @@ public partial class SchemaBuilder
             var definition = CreateSchemaDefinition(builder, context, typeRegistry);
             context.TypeInterceptor.OnBeforeRegisterSchemaTypes(context, definition);
 
-            if (definition.QueryType is null && builder._options.StrictValidation)
-            {
-                throw new SchemaException(
-                    SchemaErrorBuilder.New()
-                        .SetMessage(TypeResources.SchemaBuilder_NoQueryType)
-                        .Build());
-            }
-
             var schema = typeRegistry.Types.Select(t => t.Type).OfType<Schema>().First();
             schema.CompleteSchema(definition);
 
             if (SchemaValidator.Validate(context, schema) is { Count: > 0 } errors)
             {
                 throw new SchemaException(errors);
+            }
+
+            if (definition.QueryType is null && builder._options.StrictValidation)
+            {
+                throw new SchemaException(
+                    SchemaErrorBuilder.New()
+                        .SetMessage(TypeResources.SchemaBuilder_NoQueryType)
+                        .Build());
             }
 
             context.TypeInterceptor.OnAfterCreateSchemaInternal(context, schema);

--- a/src/HotChocolate/Core/src/Types/Types/Attributes/IsSelectedPattern.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Attributes/IsSelectedPattern.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using HotChocolate.Language;
+
+namespace HotChocolate.Types.Attributes;
+
+internal sealed class IsSelectedPattern(ObjectType type, string fieldName, SelectionSetNode pattern)
+{
+    public ObjectType Type { get; } = type;
+    public string FieldName { get; } = fieldName;
+    public SelectionSetNode Pattern { get; } = pattern;
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/Tag.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/Tag.cs
@@ -35,6 +35,19 @@ namespace HotChocolate.Types;
     DirectiveLocation.Schema,
     IsRepeatable = true)]
 [TagDirectiveConfig]
+[GraphQLDescription(
+    """
+    The @tag directive is used to apply arbitrary string
+    metadata to a schema location. Custom tooling can use
+    this metadata during any step of the schema delivery flow,
+    including composition, static analysis, and documentation.
+
+    interface Book {
+      id: ID! @tag(name: "your-value")
+      title: String!
+      author: String!
+    }
+    """)]
 public sealed class Tag
 {
     /// <summary>
@@ -61,5 +74,6 @@ public sealed class Tag
     /// <summary>
     /// The name of the tag.
     /// </summary>
+    [GraphQLDescription("The name of the tag.")]
     public string Name { get; }
 }

--- a/src/HotChocolate/Core/src/Types/Types/Directives/TagDirectiveConfigAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/TagDirectiveConfigAttribute.cs
@@ -7,29 +7,10 @@ namespace HotChocolate.Types;
 internal sealed class TagDirectiveConfigAttribute : DirectiveTypeDescriptorAttribute
 {
     protected override void OnConfigure(
-        IDescriptorContext context, 
-        IDirectiveTypeDescriptor descriptor, 
+        IDescriptorContext context,
+        IDirectiveTypeDescriptor descriptor,
         Type type)
     {
-        descriptor.Description(
-            """
-            The @tag directive is used to apply arbitrary string
-            metadata to a schema location. Custom tooling can use
-            this metadata during any step of the schema delivery flow,
-            including composition, static analysis, and documentation.
-
-            interface Book {
-              id: ID! @tag(name: "your-value")
-              title: String!
-              author: String!
-            }
-            """);
-
-        descriptor
-            .Argument("name")
-            .Type<NonNullType<StringType>>()
-            .Description("The name of the tag.");
-
         if (context.ContextData.TryGetValue(WellKnownContextData.TagOptions, out var value) &&
             value is TagOptions { Mode: TagMode.ApolloFederation, })
         {

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/QueryableCursorPagingProviderTests.cs
@@ -492,6 +492,11 @@ public class QueryableCursorPagingProviderTests
             throw new NotImplementedException();
         }
 
+        public ISelectionCollection Select()
+        {
+            throw new NotImplementedException();
+        }
+
         public ISelectionCollection Select(string fieldName)
         {
             throw new NotImplementedException();

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/IsSelectedTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/IsSelectedTests.cs
@@ -286,6 +286,98 @@ public class IsSelectedTests
     }
 
     [Fact]
+    public async Task IsSelected_Attribute_5_Selected()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    """
+                    query {
+                        user_Attribute_5 {
+                            email
+                            category {
+                                next {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                    """);
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
+    public async Task IsSelected_Attribute_5_Not_Selected()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    """
+                    query {
+                        user_Attribute_5 {
+                            email
+                            category {
+                                name
+                            }
+                        }
+                    }
+                    """);
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
+    public async Task IsSelected_Attribute_6_Selected()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    """
+                    query {
+                        user_Attribute_6 {
+                            email
+                            category {
+                                next {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                    """);
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
+    public async Task IsSelected_Attribute_6_Not_Selected()
+    {
+        var result =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<Query>()
+                .ExecuteRequestAsync(
+                    """
+                    query {
+                        user_Attribute_6 {
+                            email
+                            category {
+                                name
+                            }
+                        }
+                    }
+                    """);
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
     public async Task IsSelected_Context_1_Selected()
     {
         var result =
@@ -677,6 +769,23 @@ public class IsSelectedTests
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
             return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
         }
+
+        public User GetUser_Attribute_5(
+            [IsSelected("email category { next { name } }")] bool isSelected,
+            IResolverContext context)
+        {
+            ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
+            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+        }
+
+        public User GetUser_Attribute_6(
+            [IsSelected("email category { ... on Category { next { name } } }")] bool isSelected,
+            IResolverContext context)
+        {
+            ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
+            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+        }
+
 
         public User GetUser_Context_1(IResolverContext context)
         {

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/IsSelectedTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/IsSelectedTests.cs
@@ -378,6 +378,37 @@ public class IsSelectedTests
     }
 
     [Fact]
+    public async Task IsSelected_Pattern_Is_Invalid()
+    {
+        var snapshot = new Snapshot();
+
+        async Task Broken() =>
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<BrokenQuery>()
+                .ExecuteRequestAsync(
+                    """
+                    query {
+                        user_Attribute_6 {
+                            email
+                            category {
+                                name
+                            }
+                        }
+                    }
+                    """);
+
+        var ex = await Assert.ThrowsAsync<SchemaException>(Broken);
+
+        foreach (var error in ex.Errors)
+        {
+            snapshot.Add(error.Message);
+        }
+
+        await snapshot.MatchMarkdownAsync();
+    }
+
+    [Fact]
     public async Task IsSelected_Context_1_Selected()
     {
         var result =
@@ -745,52 +776,112 @@ public class IsSelectedTests
         public User GetUser_Attribute_1([IsSelected("email")] bool isSelected, IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Attribute_2([IsSelected("email", "password")] bool isSelected, IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Attribute_3(
-            [IsSelected("email", "password", "phoneNumber")] bool isSelected,
+            [IsSelected("email", "password", "phoneNumber")]
+            bool isSelected,
             IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Attribute_4(
-            [IsSelected("email", "password", "phoneNumber", "address")] bool isSelected,
+            [IsSelected("email", "password", "phoneNumber", "address")]
+            bool isSelected,
             IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Attribute_5(
-            [IsSelected("email category { next { name } }")] bool isSelected,
+            [IsSelected("email category { next { name } }")]
+            bool isSelected,
             IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Attribute_6(
-            [IsSelected("email category { ... on Category { next { name } } }")] bool isSelected,
+            [IsSelected("email category { ... on Category { next { name } } }")]
+            bool isSelected,
             IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
 
         public User GetUser_Context_1(IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", context.IsSelected("email"));
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Context_2(IResolverContext context)
@@ -798,7 +889,15 @@ public class IsSelectedTests
             ((IMiddlewareContext)context).OperationResult.SetExtension(
                 "isSelected",
                 context.IsSelected("email", "password"));
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Context_3(IResolverContext context)
@@ -806,15 +905,82 @@ public class IsSelectedTests
             ((IMiddlewareContext)context).OperationResult.SetExtension(
                 "isSelected",
                 context.IsSelected("email", "password", "phoneNumber"));
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
 
         public User GetUser_Context_4(IResolverContext context)
         {
             ((IMiddlewareContext)context).OperationResult.SetExtension(
                 "isSelected",
-                context.IsSelected(new HashSet<string> { "email", "password", "phoneNumber", "address", }));
-            return new User { Name = "a", Email = "b", Password = "c", PhoneNumber = "d", Address = "e", City = "f", };
+                context.IsSelected(new HashSet<string>
+                {
+                    "email", "password", "phoneNumber", "address",
+                }));
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
+        }
+    }
+
+    public class BrokenQuery
+    {
+        public static User DummyUser { get; } =
+            new()
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
+
+        public User GetUser_1(
+            [IsSelected("email category { next { bar } }")]
+            bool isSelected,
+            IResolverContext context)
+        {
+            ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
+        }
+
+        public User GetUser_2(
+            [IsSelected("email category { ... on String { next { name } } }")]
+            bool isSelected,
+            IResolverContext context)
+        {
+            ((IMiddlewareContext)context).OperationResult.SetExtension("isSelected", isSelected);
+            return new User
+            {
+                Name = "a",
+                Email = "b",
+                Password = "c",
+                PhoneNumber = "d",
+                Address = "e",
+                City = "f",
+            };
         }
     }
 

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_5_Not_Selected.md
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_5_Not_Selected.md
@@ -1,0 +1,15 @@
+# IsSelected_Attribute_5_Not_Selected
+
+```json
+{
+  "data": {
+    "user_Attribute_5": {
+      "email": "b",
+      "category": null
+    }
+  },
+  "extensions": {
+    "isSelected": false
+  }
+}
+```

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_5_Selected.md
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_5_Selected.md
@@ -1,0 +1,15 @@
+# IsSelected_Attribute_5_Selected
+
+```json
+{
+  "data": {
+    "user_Attribute_5": {
+      "email": "b",
+      "category": null
+    }
+  },
+  "extensions": {
+    "isSelected": true
+  }
+}
+```

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_6_Not_Selected.md
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_6_Not_Selected.md
@@ -1,0 +1,15 @@
+# IsSelected_Attribute_6_Not_Selected
+
+```json
+{
+  "data": {
+    "user_Attribute_6": {
+      "email": "b",
+      "category": null
+    }
+  },
+  "extensions": {
+    "isSelected": false
+  }
+}
+```

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_6_Selected.md
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Attribute_6_Selected.md
@@ -1,0 +1,15 @@
+# IsSelected_Attribute_6_Selected
+
+```json
+{
+  "data": {
+    "user_Attribute_6": {
+      "email": "b",
+      "category": null
+    }
+  },
+  "extensions": {
+    "isSelected": true
+  }
+}
+```

--- a/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Pattern_Is_Invalid.md
+++ b/src/HotChocolate/Core/test/Types.Tests/Resolvers/__snapshots__/IsSelectedTests.IsSelected_Pattern_Is_Invalid.md
@@ -1,0 +1,36 @@
+# IsSelected_Pattern_Is_Invalid
+
+## Result 1
+
+```text
+The specified pattern on field `BrokenQuery.user_1` is invalid:
+`{
+  email
+  category {
+    next {
+      bar
+    }
+  }
+}`
+
+The field `bar` does not exist on type `Category`.
+```
+
+## Result 2
+
+```text
+The specified pattern on field `BrokenQuery.user_2` is invalid:
+`{
+  email
+  category {
+    ... on String {
+      next {
+        name
+      }
+    }
+  }
+}`
+
+The type condition `String` of the inline fragment is not assignable from the parent field type `Category`.
+```
+

--- a/src/HotChocolate/Data/src/Data/Projections/Extensions/ProjectionObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Extensions/ProjectionObjectFieldDescriptorExtensions.cs
@@ -179,7 +179,7 @@ public static class ProjectionObjectFieldDescriptorExtensions
 
         var factory = _factoryTemplate.MakeGenericMethod(type);
         var middleware = CreateDataMiddleware((IQueryBuilder)factory.Invoke(null, [convention,])!);
-        
+
         var index = definition.MiddlewareDefinitions.IndexOf(placeholder);
         definition.MiddlewareDefinitions[index] = new(middleware, key: WellKnownMiddleware.Projection);
     }
@@ -198,7 +198,7 @@ public static class ProjectionObjectFieldDescriptorExtensions
             {
                 return selection;
             }
-            
+
             selection = ref Unsafe.Add(ref selection, 1)!;
         }
 
@@ -209,7 +209,7 @@ public static class ProjectionObjectFieldDescriptorExtensions
     private sealed class ProjectionQueryBuilder(IQueryBuilder innerBuilder) : IQueryBuilder
     {
         private const string _mockContext = "HotChocolate.Data.Projections.ProxyContext";
-        
+
         public void Prepare(IMiddlewareContext context)
         {
             // in case we are being called from the node/nodes field we need to enrich
@@ -222,10 +222,10 @@ public static class ProjectionObjectFieldDescriptorExtensions
                 var selection = CreateProxySelection(context.Selection, fieldProxy);
                 context = new MiddlewareContextProxy(context, selection, objectType);
             }
-            
+
             //for use case when projection is used with Mutation Conventions
-            else if (context.Operation.Type is OperationType.Mutation && 
-                context.Selection.Type.NamedType() is ObjectType mutationPayloadType && 
+            else if (context.Operation.Type is OperationType.Mutation &&
+                context.Selection.Type.NamedType() is ObjectType mutationPayloadType &&
                 mutationPayloadType.ContextData.GetValueOrDefault(MutationConventionDataField, null)
                     is string dataFieldName)
             {
@@ -234,7 +234,7 @@ public static class ProjectionObjectFieldDescriptorExtensions
                 var selection = UnwrapMutationPayloadSelection(payloadSelectionSet, dataField);
                 context = new MiddlewareContextProxy(context, selection, dataField.DeclaringType);
             }
-            
+
             context.SetLocalState(_mockContext, context);
             innerBuilder.Prepare(context);
         }
@@ -323,7 +323,7 @@ public static class ProjectionObjectFieldDescriptorExtensions
         public ValueKind ArgumentKind(string name) => _context.ArgumentKind(name);
 
         public T Service<T>() where T : notnull => _context.Service<T>();
-        
+
     #if NET8_0_OR_GREATER
         public T? Service<T>(object key) where T : notnull => _context.Service<T>(key);
     #endif
@@ -344,6 +344,9 @@ public static class ProjectionObjectFieldDescriptorExtensions
             ISelection? selection = null,
             bool allowInternals = false)
             => _context.GetSelections(typeContext, selection, allowInternals);
+
+        public ISelectionCollection Select()
+            => _context.Select();
 
         public ISelectionCollection Select(string fieldName)
             => _context.Select(fieldName);


### PR DESCRIPTION
This PR allows for more complex selection expressions with the is selected attribute. 
Now we can match for patterns instead of single fields.

```csharp
public User GetUser([IsSelected("email category { ... on Category { next { name } } }")] bool isSelected)
```