### PR TITLE
Do not emit `"query": ""` for Strawberry Shake persisted queries

### DIFF
--- a/src/StrawberryShake/Client/src/Core/RequestStrategy.cs
+++ b/src/StrawberryShake/Client/src/Core/RequestStrategy.cs
@@ -14,10 +14,4 @@ public enum RequestStrategy
     /// An id is send representing the query that is stored on the server.
     /// </summary>
     PersistedQuery,
-
-    /// <summary>
-    /// The full GraphQL query is only send if the server has not yet stored the
-    /// persisted query.
-    /// </summary>
-    AutomaticPersistedQuery,
 }

--- a/src/StrawberryShake/Client/src/Transport.Http/HttpConnection.cs
+++ b/src/StrawberryShake/Client/src/Transport.Http/HttpConnection.cs
@@ -23,13 +23,7 @@ public sealed class HttpConnection : IHttpConnection
 
     private static GraphQLHttpRequest MapRequest(OperationRequest request)
     {
-        var (id, name, document, variables, extensions, _, files, _) = request;
-
-#if NETSTANDARD2_0
-        var body = Encoding.UTF8.GetString(document.Body.ToArray());
-#else
-        var body = Encoding.UTF8.GetString(document.Body);
-#endif
+        var (id, name, document, variables, extensions, _, files, strategy) = request;
 
         var hasFiles = files is { Count: > 0, };
 
@@ -39,8 +33,22 @@ public sealed class HttpConnection : IHttpConnection
             variables = MapFilesToVariables(variables, files!);
         }
 
-        var operation =
-            new HotChocolate.Transport.OperationRequest(body, id, name, variables, extensions);
+        HotChocolate.Transport.OperationRequest operation;
+
+        if (strategy == RequestStrategy.PersistedQuery)
+        {
+            operation = new HotChocolate.Transport.OperationRequest(null, id, name, variables, extensions);
+        }
+        else
+        {
+#if NETSTANDARD2_0
+            var body = Encoding.UTF8.GetString(document.Body.ToArray());
+#else
+            var body = Encoding.UTF8.GetString(document.Body);
+#endif
+
+            operation = new HotChocolate.Transport.OperationRequest(body, null, name, variables, extensions);
+        }
 
         return new GraphQLHttpRequest(operation) { EnableFileUploads = hasFiles, };
     }

--- a/src/StrawberryShake/Client/test/Core.Tests/Json/__snapshots__/JsonOperationRequestSerializerTests.Serialize_Request_With_Id_And_Empty_Query.snap
+++ b/src/StrawberryShake/Client/test/Core.Tests/Json/__snapshots__/JsonOperationRequestSerializerTests.Serialize_Request_With_Id_And_Empty_Query.snap
@@ -1,0 +1,11 @@
+{
+  "id": "123",
+  "operationName": "abc",
+  "variables": {
+    "abc": {
+      "abc": {
+        "def": "def"
+      }
+    }
+  }
+}


### PR DESCRIPTION
When activating persisted queries with Strawberry Shake, it currently produces the following POST body:

```json
{
  "id":"692cb0da9a40c00ced7bba7463391db7",
  "query":"",
  "operationName":"BlogPagesById",
  "variables": { /* Omitted */ }
}
```

The `"query": ""` part is problematic, since a Hot Chocolate server with the `UseOnlyPersistedQueriesAllowed` middleware will now reject the request.

I fixed this by setting the query on `OperationRequest` explicitly to `null`, so it will be correctly omitted when building the JSON payload.
I also removed the unreferenced and unsupported `RequestStrategy.AutomaticPersistedQuery` to avoid confusion.