### PR TITLE
Use unique name for test-output artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
         if: steps.run-tests.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: test-output
+          name: test-output-${{ matrix.name }}
           path: test_output.txt
 
       - name: Post test results to PR


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Used a unique name for the test-output artifact.

This should fix the following error:

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

... which occurred as a result of the update to `upload-artifact@v4` in #7059. (see [migration docs](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact))