### PR TITLE
Use SortedDictionary for consistent order of persisted queries when writing relay format

### DIFF
--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/GenerateCommand.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/GenerateCommand.cs
@@ -209,7 +209,7 @@ public static class GenerateCommand
         {
             if (relayFormat)
             {
-                var map = new Dictionary<string, string>();
+                var map = new SortedDictionary<string, string>();
 
                 foreach (var doc in result.Documents)
                 {


### PR DESCRIPTION
Deterministic order for persisted queries in relay format

- When writing persisted queries in relay format, the use of `SortedDictionary` ensures deterministic order of queries in the output

Closes #7075
