### PR TITLE
Run tests on net8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Run Build
         id: run-build
-        run: dotnet build ${{ matrix.path }} --framework net7.0 --verbosity q --property WarningLevel=0
+        run: dotnet build ${{ matrix.path }} --framework net8.0 --verbosity q --property WarningLevel=0
         timeout-minutes: 5
 
       - name: Create directory for test results
@@ -205,7 +205,7 @@ jobs:
         timeout-minutes: 15
         continue-on-error: true
         run: |
-          dotnet test ${{ matrix.path }} --no-build --framework net7.0 --verbosity q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./.coverage/${{ matrix.name }}.xml --logger "trx;LogFileName=./.test-results/${{ matrix.name }}.trx" /p:ExcludeByFile="**/test/**" 2>&1 | tee test_output.txt
+          dotnet test ${{ matrix.path }} --no-build --framework net8.0 --verbosity q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=./.coverage/${{ matrix.name }}.xml --logger "trx;LogFileName=./.test-results/${{ matrix.name }}.trx" /p:ExcludeByFile="**/test/**" 2>&1 | tee test_output.txt
           if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
             exit 1
           fi


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated `ci.yml` to build and run tests on `net8.0`.

Fix:

> Error: /usr/share/dotnet/sdk/8.0.204/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1005: Assets file '/home/runner/work/graphql-platform/graphql-platform/src/HotChocolate/Fusion/test/Aspire.Analyzers.Tests/obj/project.assets.json' doesn't have a target for 'net7.0'. Ensure that restore has run and that you have included 'net7.0' in the TargetFrameworks for your project. [/home/runner/work/graphql-platform/graphql-platform/src/HotChocolate/Fusion/test/Aspire.Analyzers.Tests/HotChocolate.Fusion.Aspire.Analyzers.Tests.csproj::TargetFramework=net7.0]

.NET 7 is EOL on May 14th anyway.