### PR TITLE
Add issue labeler workflow/job

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,11 @@
+🌶️ hot chocolate:
+  - "### Product\n\nHot Chocolate"
+
+🌶️ strawberry shake:
+  - "### Product\n\nStrawberry Shake"
+
+🌶️ banana cake pop:
+  - "### Product\n\nBanana Cake Pop"
+
+🌶️ green donut:
+  - "### Product\n\nGreen Donut"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,20 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  issue-labeler:
+    name: Apply Issue Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: 0
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added issue labeler workflow/job.

See https://github.com/marketplace/actions/regex-issue-labeler.

Tested here: https://github.com/glen-84/test-issue-labeler/issues/

⚠️ Avoid enabling the `sync-labels` option unless you also configure `not-before` and/or `enable-versioned-regex`.