### PR TITLE
Fix test target frameworks

### DIFF
--- a/src/HotChocolate/AzureFunctions/test/Directory.Build.props
+++ b/src/HotChocolate/AzureFunctions/test/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/HotChocolate/Core/test/Subscriptions.RabbitMQ.Tests/HotChocolate.Subscriptions.RabbitMQ.Tests.csproj
+++ b/src/HotChocolate/Core/test/Subscriptions.RabbitMQ.Tests/HotChocolate.Subscriptions.RabbitMQ.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <AssemblyName>HotChocolate.Subscriptions.RabbitMQ.Tests</AssemblyName>
     <RootNamespace>HotChocolate.Subscriptions.RabbitMQ</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed test target frameworks (two test projects were not targeting .NET 8).