### PR TITLE
Add VariableDefinition directive location to DirectiveTypeFactory

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Factories/DirectiveTypeFactory.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Factories/DirectiveTypeFactory.cs
@@ -87,6 +87,10 @@ internal sealed class DirectiveTypeFactory
                 Language.DirectiveLocation.InputFieldDefinition,
                 DirectiveLocation.InputFieldDefinition
             },
+            {
+                Language.DirectiveLocation.VariableDefinition,
+                DirectiveLocation.VariableDefinition
+            }
         };
 
     public DirectiveType Create(IDescriptorContext context, DirectiveDefinitionNode node)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added `VariableDefinition` directive location to `DirectiveTypeFactory`.

Closes #7025

⚠️ This is targeting the `main-version-13` branch.