### PR TITLE
Fixed issue with case sensitivity in SS OperationDescriptorMapper

### DIFF
--- a/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Mappers/OperationDescriptorMapper.cs
+++ b/src/StrawberryShake/CodeGeneration/src/CodeGeneration/Mappers/OperationDescriptorMapper.cs
@@ -23,7 +23,8 @@ public static class OperationDescriptorMapper
                         var typeName = arg.Type.TypeName();
 
                         var namedTypeDescriptor =
-                            context.Types.Single(type => type.Name.EqualsOrdinal(typeName));
+                            context.Types.Single(
+                                type => type.Name.EqualsInvariantIgnoreCase(typeName));
 
                         hasUpload = hasUpload || namedTypeDescriptor.HasUpload();
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Mappers/OperationDescriptorMapperTests.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/Mappers/OperationDescriptorMapperTests.cs
@@ -63,4 +63,30 @@ public class OperationDescriptorMapperTests
                 Assert.Equal("OnReview", operation.Name);
             });
     }
+
+    [Fact]
+    public void MapOperationTypeDescriptors_SchemaWithLowercaseEnumName()
+    {
+        // arrange
+        var clientModel = CreateClientModelAsync(
+            "simple.mutation.graphql",
+            "simple.schema2.graphql");
+
+        // act
+        var context = new MapperContext(
+            "Foo.Bar",
+            "FooClient",
+            new Sha1DocumentHashProvider(),
+            RequestStrategyGen.Default,
+            new[]
+            {
+                TransportProfile.Default,
+            });
+        TypeDescriptorMapper.Map(clientModel, context);
+
+        var exception = Record.Exception(() => OperationDescriptorMapper.Map(clientModel, context));
+
+        // assert
+        Assert.Null(exception);
+    }
 }

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/__resources__/simple.mutation.graphql
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/__resources__/simple.mutation.graphql
@@ -1,0 +1,7 @@
+# Intentionally-lowercased name for "gender" type.
+mutation CreateUser($id: ID! $gender: gender!) {
+  createUser(id: $id, gender: $gender){
+    id,
+    gender
+  }
+}

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/__resources__/simple.schema2.graphql
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.Tests/__resources__/simple.schema2.graphql
@@ -1,0 +1,18 @@
+type Query {
+  user(id: ID!): User!
+}
+
+type Mutation {
+  createUser(id: ID! gender: gender!): User!
+}
+
+type User {
+  id: ID!
+  gender: gender!
+}
+
+# Intentionally-lowercased name.
+enum gender {
+  Male
+  Female
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed issue with case sensitivity in SS OperationDescriptorMapper by using `EqualsInvariantIgnoreCase` instead of `EqualsOrdinal`.

Closes #3704