### PR TITLE
Improve postgres subscription provider when the npgsql connection is lost

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
@@ -126,7 +126,7 @@ internal sealed class PostgresChannelWriter : IAsyncDisposable
             // if we cannot send the message we put it back into the channel
             foreach (var message in messages)
             {
-                await _channel.Writer.WriteAsync(message, ct);
+                await _channel.Writer.WriteAsync(message, CancellationToken.None);
             }
         }
     }

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannelWriter.cs
@@ -120,7 +120,7 @@ internal sealed class PostgresChannelWriter : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            var msg = string.Format(ChannelWriter_FailedToSend, messages.Count, ex.Message);
+            var msg = string.Format(ChannelWriter_FailedToSend, messages.Count, ex.ToString());
             _diagnosticEvents.ProviderInfo(msg);
 
             // if we cannot send the message we put it back into the channel

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.Designer.cs
@@ -104,5 +104,11 @@ namespace HotChocolate.Subscriptions.Postgres {
                 return ResourceManager.GetString("PostgresMessageEnvelope_PayloadTooLarge", resourceCulture);
             }
         }
+
+        internal static string ChannelWriter_FailedToRequeueMessage {
+            get {
+                return ResourceManager.GetString("ChannelWriter_FailedToRequeueMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.resx
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/Properties/PostgresResources.resx
@@ -55,4 +55,7 @@
   <data name="PostgresMessageEnvelope_PayloadTooLarge" xml:space="preserve">
     <value>Payload is too long to we written to Postgres. Serialized message is {0} bytes but limit is {1} bytes</value>
   </data>
+  <data name="ChannelWriter_FailedToRequeueMessage" xml:space="preserve">
+    <value>The postgres writer was unable to requeue messages. {0} messages have been lost</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR addresses two issues

1. The cancelation token used to write back to the channel on message send failure should not be observed, if the exception was related to postgres or npgsql the connection is likely closed/closing and as such the cancellation token will be triggered.


2. Npgsql has an issue that affects prepared statements in batches in v8 (not affecting v7). This is hard to reproduce but i have created an issue for it https://github.com/npgsql/npgsql/issues/5748. As a work around for this i have reworked the command to not use a batch and instead run a single command with an unnest operation. This performs better than the batch so seems to be a win-win

The error observed from the diagnostic observer is 
`"The channel writer failed to send messages. Requeueing 1 messages. Error Message: Missing type info or binding info."`

`Missing type info or binding info.` is thrown by npgsql here
https://github.com/npgsql/npgsql/blob/d1c62a1eb3b5817dcbd5c755176fc600b1557626/src/Npgsql/NpgsqlParameter.cs#L704

This issue has also been discussed in [slack](https://hotchocolategraphql.slack.com/archives/CD9TNKT8T/p1716848107783739) 

Closes #7158 
