### PR TITLE
Removed code related to legacy stitching

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/ErrorCodes.cs
+++ b/src/HotChocolate/Core/src/Abstractions/ErrorCodes.cs
@@ -270,20 +270,6 @@ public static class ErrorCodes
         public const string FilterFieldDescriptorType = "FILTER_FIELD_DESCRIPTOR_TYPE";
     }
 
-    public static class Stitching
-    {
-        public const string HttpRequestException = "HC0006";
-
-        public const string UnknownRequestException = "HC0007";
-
-        public const string ArgumentNotDefined = "STITCHING_ARG_NOT_DEFINED";
-        public const string FieldNotDefined = "STITCHING_FLD_NOT_DEFINED";
-        public const string VariableNotDefined = "STITCHING_VAR_NOT_DEFINED";
-        public const string ScopeNotDefined = "STITCHING_SCOPE_NOT_DEFINED";
-        public const string TypeNotDefined = "STITCHING_TYPE_NOT_DEFINED";
-        public const string ArgumentNotFound = "STITCHING_DEL_ARGUMENT_NOT_FOUND";
-    }
-
     public static class Spatial
     {
         /// <summary>

--- a/src/HotChocolate/Core/src/Abstractions/Properties/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Properties/InternalsVisibleTo.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("HotChocolate.Types")]
 [assembly: InternalsVisibleTo("HotChocolate.Execution")]
 [assembly: InternalsVisibleTo("HotChocolate.Validation")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 
 // tests
 [assembly: InternalsVisibleTo("HotChocolate.Abstractions.Tests")]

--- a/src/HotChocolate/Core/src/Execution/Instrumentation/IExecutionDiagnosticEvents.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/IExecutionDiagnosticEvents.cs
@@ -383,9 +383,9 @@ public interface IExecutionDiagnosticEvents
     void RetrievedOperationFromCache(IRequestContext context);
 
     /// <summary>
-    /// During execution we allow components like the DataLoader or schema stitching to
-    /// defer execution of data resolvers to be executed in batches. If the execution engine
-    /// has nothing to execute anymore these batches will be dispatched for execution.
+    /// During execution we allow components like the DataLoader to defer execution of data
+    /// resolvers to be executed in batches. If the execution engine has nothing to execute anymore
+    /// these batches will be dispatched for execution.
     /// </summary>
     /// <param name="context">
     /// The request context encapsulates all GraphQL-specific information about an

--- a/src/HotChocolate/Core/src/Execution/Properties/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Core/src/Execution/Properties/InternalsVisibleTo.cs
@@ -2,5 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.Execution.Tests")]
 [assembly: InternalsVisibleTo("HotChocolate.Execution.Benchmarks")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/HotChocolate/Core/src/Types/HotChocolate.Types.csproj
+++ b/src/HotChocolate/Core/src/Types/HotChocolate.Types.csproj
@@ -38,7 +38,6 @@
     <InternalsVisibleTo Include="HotChocolate.Types.Filters" />
     <InternalsVisibleTo Include="HotChocolate.Types.Sorting" />
     <InternalsVisibleTo Include="HotChocolate.Types.Selections" />
-    <InternalsVisibleTo Include="HotChocolate.Stitching" />
 
     <!--Tests-->
     <InternalsVisibleTo Include="HotChocolate.Types.Filters.Tests" />

--- a/src/HotChocolate/Language/src/Language.Utf8/Properties/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Properties/InternalsVisibleTo.cs
@@ -1,7 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.Types")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 [assembly: InternalsVisibleTo("HotChocolate.Subscriptions")]
 [assembly: InternalsVisibleTo("HotChocolate.AspNetCore")]
 [assembly: InternalsVisibleTo("HotChocolate.Utilities.Introspection")]

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Utilities.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Utilities.cs
@@ -7,9 +7,8 @@ namespace HotChocolate.Language;
 
 public ref partial struct Utf8GraphQLParser
 {
-    // note: this is internal for legacy stitching
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal NameNode ParseName()
+    private NameNode ParseName()
     {
         var start = Start();
         var name = ExpectName();
@@ -22,9 +21,8 @@ public ref partial struct Utf8GraphQLParser
         );
     }
 
-    // note: this is internal for legacy stitching
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool MoveNext() => _reader.MoveNext();
+    private bool MoveNext() => _reader.MoveNext();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private TokenInfo Start()
@@ -70,13 +68,11 @@ public ref partial struct Utf8GraphQLParser
         throw new SyntaxException(_reader, Parser_InvalidToken, TokenKind.Name, _reader.Kind);
     }
 
-    // note: this is internal for legacy stitching
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ExpectColon() => Expect(TokenKind.Colon);
+    private void ExpectColon() => Expect(TokenKind.Colon);
 
-    // note: this is internal for the stitching legacy layer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ExpectDollar() => Expect(TokenKind.Dollar);
+    private void ExpectDollar() => Expect(TokenKind.Dollar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ExpectAt() => Expect(TokenKind.At);
@@ -100,9 +96,8 @@ public ref partial struct Utf8GraphQLParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ExpectSpread() => Expect(TokenKind.Spread);
 
-    // note: this is internal for legacy stitching
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ExpectRightParenthesis() => Expect(TokenKind.RightParenthesis);
+    private void ExpectRightParenthesis() => Expect(TokenKind.RightParenthesis);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ExpectRightBrace() => Expect(TokenKind.RightBrace);

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Values.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Values.cs
@@ -7,7 +7,6 @@ namespace HotChocolate.Language;
 // Implements the parsing rules in the Values section.
 public ref partial struct Utf8GraphQLParser
 {
-    // note: this is internal for the stitching legacy layer
     /// <summary>
     /// Parses a value.
     /// <see cref="IValueNode" />:
@@ -28,7 +27,7 @@ public ref partial struct Utf8GraphQLParser
     /// Defines if only constant values are allowed;
     /// otherwise, variables are allowed.
     /// </param>
-    internal IValueNode ParseValueLiteral(bool isConstant)
+    private IValueNode ParseValueLiteral(bool isConstant)
     {
         if (_reader.Kind == TokenKind.LeftBracket)
         {

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.cs
@@ -61,12 +61,6 @@ public ref partial struct Utf8GraphQLParser
     /// </summary>
     public bool IsEndOfFile => _reader.Kind is TokenKind.EndOfFile;
 
-    // note: we added this internal access for legacy stitching.
-    /// <summary>
-    /// Provides internal access to the underlying GraphQL reader.
-    /// </summary>
-    internal Utf8GraphQLReader Reader => _reader;
-
     public DocumentNode Parse()
     {
         _parsedNodes = 0;

--- a/src/HotChocolate/Language/src/Language.Web/Properties/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Properties/InternalsVisibleTo.cs
@@ -1,7 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.Types")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 [assembly: InternalsVisibleTo("HotChocolate.Subscriptions")]
 [assembly: InternalsVisibleTo("HotChocolate.Utilities.Introspection")]
 [assembly: InternalsVisibleTo("HotChocolate.Language")]

--- a/src/HotChocolate/Language/src/Language/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Language/src/Language/InternalsVisibleTo.cs
@@ -1,7 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("HotChocolate.Language.Tests")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
 [assembly: InternalsVisibleTo("HotChocolate.Core")]
 [assembly: InternalsVisibleTo("HotChocolate.Types")]
 [assembly: InternalsVisibleTo("HotChocolate.Subscriptions")]

--- a/src/HotChocolate/Utilities/src/Utilities/Properties/InternalsVisibleTo.cs
+++ b/src/HotChocolate/Utilities/src/Utilities/Properties/InternalsVisibleTo.cs
@@ -4,7 +4,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("HotChocolate.Language")]
 [assembly: InternalsVisibleTo("HotChocolate.Core")]
 [assembly: InternalsVisibleTo("HotChocolate.Types")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching")]
-[assembly: InternalsVisibleTo("HotChocolate.Stitching.Redis")]
 [assembly: InternalsVisibleTo("HotChocolate.Execution")]
 [assembly: InternalsVisibleTo("HotChocolate.Utilities.Tests")]

--- a/src/StrawberryShake/Client/src/Transport.WebSockets/StrawberryShake.Transport.WebSockets.csproj
+++ b/src/StrawberryShake/Client/src/Transport.WebSockets/StrawberryShake.Transport.WebSockets.csproj
@@ -8,10 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="HotChocolate.Stitching.Tests" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Removed code related to legacy stitching.

---

ℹ️ There's one final reference to stitching [here](https://github.com/ChilliCream/graphql-platform/blob/dafee6fb004f1f2eba9974962174ca34185f35ef/src/HotChocolate/Core/src/Types/Types/Scalars/AnyType.cs#L271-L275), but removing it breaks some tests and Pascal isn't sure why it was added.
