### PR TITLE
Updated node ID serializers to allow internal IDs to be empty strings

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/LegacyNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/LegacyNodeIdSerializer.cs
@@ -240,6 +240,11 @@ internal sealed class LegacyNodeIdSerializer : INodeIdSerializer
 
     private static unsafe string CreateString(ReadOnlySpan<byte> serialized)
     {
+        if (serialized.Length == 0)
+        {
+            return "";
+        }
+
         fixed (byte* bytePtr = serialized)
         {
             return _utf8.GetString(bytePtr, serialized.Length);

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -216,14 +216,7 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
             throw SerializerMissing(typeName, rentedBuffer);
         }
 
-        var valueSpan = span.Slice(index + 1);
-        if (valueSpan.IsEmpty)
-        {
-            Clear(rentedBuffer);
-            throw new NodeIdInvalidFormatException(formattedId);
-        }
-
-        var value = ParseValue(valueSerializer, serializer.TypeName, valueSpan);
+        var value = ParseValue(valueSerializer, serializer.TypeName, span.Slice(index + 1));
         Clear(rentedBuffer);
         return value;
     }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -118,14 +118,7 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
             throw new NodeIdMissingSerializerException(typeNameString);
         }
 
-        var valueSpan = span.Slice(index + 1);
-        if (valueSpan.IsEmpty)
-        {
-            Clear(rentedBuffer);
-            throw new NodeIdInvalidFormatException(formattedId);
-        }
-
-        var value = serializer.Parse(valueSpan);
+        var value = serializer.Parse(span.Slice(index + 1));
         Clear(rentedBuffer);
         return value;
     }

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/StringNodeIdValueSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/StringNodeIdValueSerializer.cs
@@ -36,7 +36,7 @@ internal sealed class StringNodeIdValueSerializer : INodeIdValueSerializer
     {
         if (buffer.Length == 0)
         {
-            value = "";
+            value = string.Empty;
             return true;
         }
 

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/StringNodeIdValueSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/StringNodeIdValueSerializer.cs
@@ -34,6 +34,12 @@ internal sealed class StringNodeIdValueSerializer : INodeIdValueSerializer
 
     public unsafe bool TryParse(ReadOnlySpan<byte> buffer, [NotNullWhen(true)] out object? value)
     {
+        if (buffer.Length == 0)
+        {
+            value = "";
+            return true;
+        }
+
         fixed (byte* b = buffer)
         {
             value = _utf8.GetString(b, buffer.Length);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -136,16 +136,6 @@ public class DefaultNodeIdSerializerTests
     }
 
     [Fact]
-    public void Serialize_TypeName_Not_Registered()
-    {
-        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
-
-        void Error() => serializer.Format("Baz", "abc");
-
-        Assert.Throws<NodeIdMissingSerializerException>(Error);
-    }
-
-    [Fact]
     public void Serialize_Int16Id()
     {
         var serializer = CreateSerializer(new Int16NodeIdValueSerializer());
@@ -209,13 +199,25 @@ public class DefaultNodeIdSerializerTests
     public void Parse_CompositeId()
     {
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
-        lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
+        lookup.Setup(t => t.GetNodeIdRuntimeType(It.IsAny<string>())).Returns(typeof(CompositeId));
 
         var compositeId = new CompositeId("foo", 42, Guid.Empty, true);
         var serializer = CreateSerializer(new CompositeIdNodeIdValueSerializer());
         var id = serializer.Format("Foo", compositeId);
 
         var parsed = serializer.Parse(id, lookup.Object);
+
+        Assert.Equal(compositeId, parsed.InternalId);
+    }
+
+    [Fact]
+    public void Parse_CompositeId2()
+    {
+        var compositeId = new CompositeId("foo", 42, Guid.Empty, true);
+        var serializer = CreateSerializer(new CompositeIdNodeIdValueSerializer());
+        var id = serializer.Format("Foo", compositeId);
+
+        var parsed = serializer.Parse(id, typeof(CompositeId));
 
         Assert.Equal(compositeId, parsed.InternalId);
     }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -7,12 +7,12 @@ using Moq;
 
 namespace HotChocolate.Types.Relay;
 
-public class OptimizedNodeIdSerializerTests
+public class DefaultNodeIdSerializerTests
 {
     [Fact]
     public void Format_Empty_StringId()
     {
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Format("Foo", "");
 
@@ -23,7 +23,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Format_Small_StringId()
     {
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Format("Foo", "abc");
 
@@ -36,7 +36,7 @@ public class OptimizedNodeIdSerializerTests
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
         lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
 
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Parse("Rm9vOmFiYw==", lookup.Object);
 
@@ -50,7 +50,7 @@ public class OptimizedNodeIdSerializerTests
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
         lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
 
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Parse("Rm9vOg==", lookup.Object);
 
@@ -61,7 +61,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Parse_Empty_StringId2()
     {
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Parse("Rm9vOg==", typeof(string));
 
@@ -75,7 +75,7 @@ public class OptimizedNodeIdSerializerTests
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
         lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
 
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Parse("Rm9vCmRhYmM=", lookup.Object);
 
@@ -86,7 +86,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Format_480_Byte_Long_StringId()
     {
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Format("Foo", new string('a', 480));
 
@@ -113,7 +113,7 @@ public class OptimizedNodeIdSerializerTests
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
         lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
 
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         var id = serializer.Parse(
             "Rm9vOmFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh" +
@@ -138,7 +138,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_TypeName_Not_Registered()
     {
-        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         void Error() => serializer.Format("Baz", "abc");
 
@@ -148,7 +148,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_Int16Id()
     {
-        var serializer = CreateSerializer("Foo", new Int16NodeIdValueSerializer());
+        var serializer = CreateSerializer(new Int16NodeIdValueSerializer());
 
         var id = serializer.Format("Foo", (short)6);
 
@@ -158,7 +158,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_Int32Id()
     {
-        var serializer = CreateSerializer("Foo", new Int32NodeIdValueSerializer());
+        var serializer = CreateSerializer(new Int32NodeIdValueSerializer());
 
         var id = serializer.Format("Foo", 32);
 
@@ -168,7 +168,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_Int64Id()
     {
-        var serializer = CreateSerializer("Foo", new Int64NodeIdValueSerializer());
+        var serializer = CreateSerializer(new Int64NodeIdValueSerializer());
 
         var id = serializer.Format("Foo", (long)64);
 
@@ -178,7 +178,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_Guid()
     {
-        var serializer = CreateSerializer("Foo", new GuidNodeIdValueSerializer());
+        var serializer = CreateSerializer(new GuidNodeIdValueSerializer());
 
         var id = serializer.Format("Foo", Guid.Empty);
 
@@ -188,7 +188,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Serialize_Guid_Normal()
     {
-        var serializer = CreateSerializer("Foo", new GuidNodeIdValueSerializer(false));
+        var serializer = CreateSerializer(new GuidNodeIdValueSerializer(false));
 
         var id = serializer.Format("Foo", Guid.Empty);
 
@@ -198,7 +198,7 @@ public class OptimizedNodeIdSerializerTests
     [Fact]
     public void Format_CompositeId()
     {
-        var serializer = CreateSerializer("Foo", new CompositeIdNodeIdValueSerializer());
+        var serializer = CreateSerializer(new CompositeIdNodeIdValueSerializer());
 
         var id = serializer.Format("Foo", new CompositeId("foo", 42, Guid.Empty, true));
 
@@ -212,7 +212,7 @@ public class OptimizedNodeIdSerializerTests
         lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
 
         var compositeId = new CompositeId("foo", 42, Guid.Empty, true);
-        var serializer = CreateSerializer("Foo", new CompositeIdNodeIdValueSerializer());
+        var serializer = CreateSerializer(new CompositeIdNodeIdValueSerializer());
         var id = serializer.Format("Foo", compositeId);
 
         var parsed = serializer.Parse(id, lookup.Object);
@@ -309,11 +309,10 @@ public class OptimizedNodeIdSerializerTests
         snapshot.MatchMarkdownSnapshot();
     }
 
-    private static OptimizedNodeIdSerializer CreateSerializer(string typeName, INodeIdValueSerializer serializer)
+    private static DefaultNodeIdSerializer CreateSerializer(INodeIdValueSerializer serializer)
     {
-        return new OptimizedNodeIdSerializer(
-            [new BoundNodeIdValueSerializer(typeName, serializer)],
-            [serializer]);
+        return new DefaultNodeIdSerializer(
+            serializers: [serializer]);
     }
 
     private sealed class CompositeIdNodeIdValueSerializer : CompositeNodeIdValueSerializer<CompositeId>

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/LegacyNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/LegacyNodeIdSerializerTests.cs
@@ -6,6 +6,16 @@ namespace HotChocolate.Types.Relay;
 public class LegacyNodeIdSerializerTests
 {
     [Fact]
+    public void Format_Empty_StringId()
+    {
+        var serializer = CreateSerializer();
+
+        var id = serializer.Format("Foo", "");
+
+        Assert.Equal("Rm9vCmQ=", id);
+    }
+
+    [Fact]
     public void Format_Small_StringId()
     {
         var serializer = CreateSerializer();
@@ -38,6 +48,17 @@ public class LegacyNodeIdSerializerTests
         var serializer = CreateSerializer();
 
         var id = serializer.Parse("Rm9vCmQ=", lookup.Object);
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("", id.InternalId);
+    }
+
+    [Fact]
+    public void Parse_Empty_StringId2()
+    {
+        var serializer = CreateSerializer();
+
+        var id = serializer.Parse("Rm9vCmQ=", typeof(string));
 
         Assert.Equal("Foo", id.TypeName);
         Assert.Equal("", id.InternalId);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/LegacyNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/LegacyNodeIdSerializerTests.cs
@@ -30,6 +30,20 @@ public class LegacyNodeIdSerializerTests
     }
 
     [Fact]
+    public void Parse_Empty_StringId()
+    {
+        var lookup = new Mock<INodeIdRuntimeTypeLookup>();
+        lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
+
+        var serializer = CreateSerializer();
+
+        var id = serializer.Parse("Rm9vCmQ=", lookup.Object);
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("", id.InternalId);
+    }
+
+    [Fact]
     public void Format_480_Byte_Long_StringId()
     {
         var serializer = CreateSerializer();

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
@@ -34,6 +34,20 @@ public class OptimizedNodeIdSerializerTests
     }
 
     [Fact]
+    public void Parse_Empty_StringId()
+    {
+        var lookup = new Mock<INodeIdRuntimeTypeLookup>();
+        lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
+
+        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+
+        var id = serializer.Parse("Rm9vOg==", lookup.Object);
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("", id.InternalId);
+    }
+
+    [Fact]
     public void Parse_Small_Legacy_StringId()
     {
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated node ID serializers to allow internal IDs to be empty strings.

Closes #5090