### PR TITLE
Updated more code to use C# collection expressions (IDE0300)

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/Apollo/Utf8MessageProperties.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/Apollo/Utf8MessageProperties.cs
@@ -6,8 +6,8 @@ internal static class Utf8MessageProperties
     // This uses C# compiler's ability to refer to static data directly.
     // For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
     public static ReadOnlySpan<byte> Id
-        => new[] { (byte)'i', (byte)'d', };
+        => [(byte)'i', (byte)'d',];
 
     public static ReadOnlySpan<byte> Type
-        => new[] { (byte)'t', (byte)'y', (byte)'p', (byte)'e', };
+        => [(byte)'t', (byte)'y', (byte)'p', (byte)'e',];
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/Apollo/Utf8Messages.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/Apollo/Utf8Messages.cs
@@ -4,8 +4,7 @@ internal static class Utf8Messages
 {
     // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
     public static ReadOnlySpan<byte> ConnectionInitialize =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -21,11 +20,10 @@ internal static class Utf8Messages
             (byte)'n',
             (byte)'i',
             (byte)'t',
-        };
+        ];
 
     public static ReadOnlySpan<byte> ConnectionAccept =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -40,11 +38,10 @@ internal static class Utf8Messages
             (byte)'a',
             (byte)'c',
             (byte)'k',
-        };
+        ];
 
     public static ReadOnlySpan<byte> ConnectionError =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -61,11 +58,10 @@ internal static class Utf8Messages
             (byte)'r',
             (byte)'o',
             (byte)'r',
-        };
+        ];
 
     public static ReadOnlySpan<byte> ConnectionTerminate =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -86,49 +82,44 @@ internal static class Utf8Messages
             (byte)'a',
             (byte)'t',
             (byte)'e',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Start =>
-        new[]
-        {
+        [
             (byte)'s',
             (byte)'t',
             (byte)'a',
             (byte)'r',
             (byte)'t',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Stop =>
-        new[]
-        {
+        [
             (byte)'s',
             (byte)'t',
             (byte)'o',
             (byte)'p',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Data =>
-        new[]
-        {
+        [
             (byte)'d',
             (byte)'a',
             (byte)'t',
             (byte)'a',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Error =>
-        new[]
-        {
+        [
             (byte)'e',
             (byte)'r',
             (byte)'r',
             (byte)'o',
             (byte)'r',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Complete =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'m',
@@ -137,5 +128,5 @@ internal static class Utf8Messages
             (byte)'e',
             (byte)'t',
             (byte)'e',
-        };
+        ];
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/GraphQLOverWebSocket/Utf8MessageProperties.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/GraphQLOverWebSocket/Utf8MessageProperties.cs
@@ -6,8 +6,8 @@ internal static class Utf8MessageProperties
     // This uses C# compiler's ability to refer to static data directly.
     // For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
     public static ReadOnlySpan<byte> Type
-        => new[] { (byte)'t', (byte)'y', (byte)'p', (byte)'e', };
+        => [(byte)'t', (byte)'y', (byte)'p', (byte)'e',];
 
     public static ReadOnlySpan<byte> Payload
-        => new[] { (byte)'p', (byte)'a', (byte)'y', (byte)'l', (byte)'o', (byte)'a', (byte)'d', };
+        => [(byte)'p', (byte)'a', (byte)'y', (byte)'l', (byte)'o', (byte)'a', (byte)'d',];
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/GraphQLOverWebSocket/Utf8Messages.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Subscriptions/Protocols/GraphQLOverWebSocket/Utf8Messages.cs
@@ -4,8 +4,7 @@ internal static class Utf8Messages
 {
     // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
     public static ReadOnlySpan<byte> ConnectionInitialize =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -21,11 +20,10 @@ internal static class Utf8Messages
             (byte)'n',
             (byte)'i',
             (byte)'t',
-        };
+        ];
 
     public static ReadOnlySpan<byte> ConnectionAccept =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'n',
@@ -40,11 +38,10 @@ internal static class Utf8Messages
             (byte)'a',
             (byte)'c',
             (byte)'k',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Subscribe =>
-        new[]
-        {
+        [
             (byte)'s',
             (byte)'u',
             (byte)'b',
@@ -54,30 +51,27 @@ internal static class Utf8Messages
             (byte)'i',
             (byte)'b',
             (byte)'e',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Next =>
-        new[]
-        {
+        [
             (byte)'n',
             (byte)'e',
             (byte)'x',
             (byte)'t',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Error =>
-        new[]
-        {
+        [
             (byte)'e',
             (byte)'r',
             (byte)'r',
             (byte)'o',
             (byte)'r',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Complete =>
-        new[]
-        {
+        [
             (byte)'c',
             (byte)'o',
             (byte)'m',
@@ -86,23 +80,21 @@ internal static class Utf8Messages
             (byte)'e',
             (byte)'t',
             (byte)'e',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Ping =>
-        new[]
-        {
+        [
             (byte)'p',
             (byte)'i',
             (byte)'n',
             (byte)'g',
-        };
+        ];
 
     public static ReadOnlySpan<byte> Pong =>
-        new[]
-        {
+        [
             (byte)'p',
             (byte)'o',
             (byte)'n',
             (byte)'g',
-        };
+        ];
 }

--- a/src/HotChocolate/Core/src/Types/Internal/TypeInfo.RuntimeType.cs
+++ b/src/HotChocolate/Core/src/Types/Internal/TypeInfo.RuntimeType.cs
@@ -66,7 +66,7 @@ internal sealed partial class TypeInfo
                         ? current
                         : ExtendedType.Tools.ChangeNullability(
                             current,
-                            new bool?[] { true, },
+                            [true,],
                             cache);
 
                     list.Add((TypeComponentKind.List, rewritten));
@@ -78,7 +78,7 @@ internal sealed partial class TypeInfo
                         ? current
                         : ExtendedType.Tools.ChangeNullability(
                             current,
-                            new bool?[] { true, },
+                            [true,],
                             cache);
 
                     list.Add((TypeComponentKind.Named, rewritten));

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/BindableList.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Definitions/BindableList.cs
@@ -11,7 +11,7 @@ namespace HotChocolate.Types.Descriptors.Definitions;
 public sealed class BindableList<T> : IBindableList<T>
 {
 #if NET6_0_OR_GREATER
-    private static readonly T[] _empty = new T[0];
+    private static readonly T[] _empty = [];
 #endif
 
     private List<T>? _list;

--- a/src/HotChocolate/Core/test/Types.Tests/Internal/ExtendedTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Internal/ExtendedTypeTests.cs
@@ -37,7 +37,7 @@ public class ExtendedTypeTests
             typeof(NativeType<List<byte?>>),
             _cache);
         list = ExtendedType.Tools.ChangeNullability(
-            list, new bool?[] { false, }, _cache);
+            list, [false,], _cache);
 
         var nullableList = ExtendedType.FromType(
             typeof(List<byte?>),
@@ -337,7 +337,7 @@ public class ExtendedTypeTests
         // act
         IExtendedType list = ExtendedType.FromType(listType, _cache);
         list = ExtendedType.Tools.ChangeNullability(
-            list, new bool?[] { null, false, }, _cache);
+            list, [null, false,], _cache);
 
         // assert
         Assert.False(list.ElementType!.IsNullable);

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
@@ -281,7 +281,7 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
         var a = new Bar { Foo = new Foo { ScalarArray = ["c", "d", "a",], }, };
         Assert.True(func(a));
 
-        var b = new Bar { Foo = new Foo { ScalarArray = new string[0], }, };
+        var b = new Bar { Foo = new Foo { ScalarArray = [], }, };
         Assert.False(func(b));
 
         var c = new Bar { Foo = new Foo { ScalarArray = null, }, };
@@ -369,7 +369,7 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
                 [
                     new Bar {
                             Foo = new Foo {
-                                ScalarArray = new string[0],
+                                ScalarArray = [],
                             },
                         },
                 ],

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ListFilterInputTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Types/ListFilterInputTests.cs
@@ -61,41 +61,41 @@ public class ListFilterInputTests
 
     public class Foo
     {
-        public Baz[] Baz { get; set; } = new Baz[0];
+        public Baz[] Baz { get; set; } = [];
 
-        public string[] StringArray { get; set; } = new string[0];
+        public string[] StringArray { get; set; } = [];
 
-        public string?[] StringNullableArray { get; set; } = new string?[0];
+        public string?[] StringNullableArray { get; set; } = [];
 
-        public bool[] BooleanArray { get; set; } = new bool[0];
+        public bool[] BooleanArray { get; set; } = [];
 
-        public bool?[] BooleanNullableArray { get; set; } = new bool?[0];
+        public bool?[] BooleanNullableArray { get; set; } = [];
 
-        public short[] BarShortArray { get; set; } = new short[0];
+        public short[] BarShortArray { get; set; } = [];
 
-        public int[] BarIntArray { get; set; } = new int[0];
+        public int[] BarIntArray { get; set; } = [];
 
-        public long[] BarLongArray { get; set; } = new long[0];
+        public long[] BarLongArray { get; set; } = [];
 
-        public float[] BarFloatArray { get; set; } = new float[0];
+        public float[] BarFloatArray { get; set; } = [];
 
-        public double[] BarDoubleArray { get; set; } = new double[0];
+        public double[] BarDoubleArray { get; set; } = [];
 
-        public decimal[] BarDecimalArray { get; set; } = new decimal[0];
+        public decimal[] BarDecimalArray { get; set; } = [];
 
-        public short?[] BarShortNullableArray { get; set; } = new short?[0];
+        public short?[] BarShortNullableArray { get; set; } = [];
 
-        public int?[] BarIntNullableArray { get; set; } = new int?[0];
+        public int?[] BarIntNullableArray { get; set; } = [];
 
-        public long?[] BarLongNullableArray { get; set; } = new long?[0];
+        public long?[] BarLongNullableArray { get; set; } = [];
 
-        public float?[] BarFloatNullableArray { get; set; } = new float?[0];
+        public float?[] BarFloatNullableArray { get; set; } = [];
 
-        public double?[] BarDoubleNullableArray { get; set; } = new double?[0];
+        public double?[] BarDoubleNullableArray { get; set; } = [];
 
-        public decimal?[] BarDecimalNullableArray { get; set; } = new decimal?[0];
+        public decimal?[] BarDecimalNullableArray { get; set; } = [];
 
-        public FooBar[] FooBarArray { get; set; } = new FooBar[0];
+        public FooBar[] FooBarArray { get; set; } = [];
     }
 
     public class Baz

--- a/src/HotChocolate/Language/src/Language.Utf8/GraphQLKeywords.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/GraphQLKeywords.cs
@@ -3,36 +3,36 @@ namespace HotChocolate.Language;
 internal static class GraphQLKeywords
 {
     // type system
-    public static ReadOnlySpan<byte> Schema => new[]
-    {
+    public static ReadOnlySpan<byte> Schema =>
+    [
         (byte)'s',
         (byte)'c',
         (byte)'h',
         (byte)'e',
         (byte)'m',
         (byte)'a',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Scalar => new[]
-    {
+    public static ReadOnlySpan<byte> Scalar =>
+    [
         (byte)'s',
         (byte)'c',
         (byte)'a',
         (byte)'l',
         (byte)'a',
         (byte)'r',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Type => new[]
-    {
+    public static ReadOnlySpan<byte> Type =>
+    [
         (byte)'t',
         (byte)'y',
         (byte)'p',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Interface => new[]
-    {
+    public static ReadOnlySpan<byte> Interface =>
+    [
         (byte)'i',
         (byte)'n',
         (byte)'t',
@@ -42,46 +42,46 @@ internal static class GraphQLKeywords
         (byte)'a',
         (byte)'c',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Union => new[]
-    {
+    public static ReadOnlySpan<byte> Union =>
+    [
         (byte)'u',
         (byte)'n',
         (byte)'i',
         (byte)'o',
         (byte)'n',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Enum => new[]
-    {
+    public static ReadOnlySpan<byte> Enum =>
+    [
         (byte)'e',
         (byte)'n',
         (byte)'u',
         (byte)'m',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Input => new[]
-    {
+    public static ReadOnlySpan<byte> Input =>
+    [
         (byte)'i',
         (byte)'n',
         (byte)'p',
         (byte)'u',
         (byte)'t',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Extend => new[]
-    {
+    public static ReadOnlySpan<byte> Extend =>
+    [
         (byte)'e',
         (byte)'x',
         (byte)'t',
         (byte)'e',
         (byte)'n',
         (byte)'d',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Implements => new[]
-    {
+    public static ReadOnlySpan<byte> Implements =>
+    [
         (byte)'i',
         (byte)'m',
         (byte)'p',
@@ -92,10 +92,10 @@ internal static class GraphQLKeywords
         (byte)'n',
         (byte)'t',
         (byte)'s',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Repeatable => new[]
-    {
+    public static ReadOnlySpan<byte> Repeatable =>
+    [
         (byte)'r',
         (byte)'e',
         (byte)'p',
@@ -106,10 +106,10 @@ internal static class GraphQLKeywords
         (byte)'b',
         (byte)'l',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Directive => new[]
-    {
+    public static ReadOnlySpan<byte> Directive =>
+    [
         (byte)'d',
         (byte)'i',
         (byte)'r',
@@ -119,20 +119,20 @@ internal static class GraphQLKeywords
         (byte)'i',
         (byte)'v',
         (byte)'e',
-    };
+    ];
 
     // query
-    public static ReadOnlySpan<byte> Query => new[]
-    {
+    public static ReadOnlySpan<byte> Query =>
+    [
         (byte)'q',
         (byte)'u',
         (byte)'e',
         (byte)'r',
         (byte)'y',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Mutation => new[]
-    {
+    public static ReadOnlySpan<byte> Mutation =>
+    [
         (byte)'m',
         (byte)'u',
         (byte)'t',
@@ -141,10 +141,10 @@ internal static class GraphQLKeywords
         (byte)'i',
         (byte)'o',
         (byte)'n',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Subscription => new[]
-    {
+    public static ReadOnlySpan<byte> Subscription =>
+    [
         (byte)'s',
         (byte)'u',
         (byte)'b',
@@ -157,10 +157,10 @@ internal static class GraphQLKeywords
         (byte)'i',
         (byte)'o',
         (byte)'n',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Fragment => new[]
-    {
+    public static ReadOnlySpan<byte> Fragment =>
+    [
         (byte)'f',
         (byte)'r',
         (byte)'a',
@@ -169,37 +169,37 @@ internal static class GraphQLKeywords
         (byte)'e',
         (byte)'n',
         (byte)'t',
-    };
+    ];
 
     // general
-    public static ReadOnlySpan<byte> On => new[]
-    {
+    public static ReadOnlySpan<byte> On =>
+    [
         (byte)'o',
         (byte)'n',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> True => new[]
-    {
+    public static ReadOnlySpan<byte> True =>
+    [
         (byte)'t',
         (byte)'r',
         (byte)'u',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> False => new[]
-    {
+    public static ReadOnlySpan<byte> False =>
+    [
         (byte)'f',
         (byte)'a',
         (byte)'l',
         (byte)'s',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Null => new[]
-    {
+    public static ReadOnlySpan<byte> Null =>
+    [
         (byte)'n',
         (byte)'u',
         (byte)'l',
         (byte)'l',
-    };
+    ];
 }

--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Constants.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Constants.cs
@@ -12,8 +12,8 @@ public ref partial struct Utf8GraphQLRequestParser
     private const byte _p = (byte)'p';
 
     // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
-    private static ReadOnlySpan<byte> OperationName => new[]
-    {
+    private static ReadOnlySpan<byte> OperationName =>
+    [
         (byte)'o',
         (byte)'p',
         (byte)'e',
@@ -27,19 +27,19 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'a',
         (byte)'m',
         (byte)'e',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Query => new[]
-    {
+    private static ReadOnlySpan<byte> Query =>
+    [
         (byte)'q',
         (byte)'u',
         (byte)'e',
         (byte)'r',
         (byte)'y',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Variables => new[]
-    {
+    private static ReadOnlySpan<byte> Variables =>
+    [
             (byte)'v',
             (byte)'a',
             (byte)'r',
@@ -49,10 +49,10 @@ public ref partial struct Utf8GraphQLRequestParser
             (byte)'l',
             (byte)'e',
             (byte)'s',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Extensions => new[]
-    {
+    private static ReadOnlySpan<byte> Extensions =>
+    [
         (byte)'e',
         (byte)'x',
         (byte)'t',
@@ -63,24 +63,24 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'o',
         (byte)'n',
         (byte)'s',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Type => new[]
-    {
+    private static ReadOnlySpan<byte> Type =>
+    [
         (byte)'t',
         (byte)'y',
         (byte)'p',
         (byte)'e',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Id => new[]
-    {
+    private static ReadOnlySpan<byte> Id =>
+    [
         (byte)'i',
         (byte)'d',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Payload => new[]
-    {
+    private static ReadOnlySpan<byte> Payload =>
+    [
         (byte)'p',
         (byte)'a',
         (byte)'y',
@@ -88,5 +88,5 @@ public ref partial struct Utf8GraphQLRequestParser
         (byte)'o',
         (byte)'a',
         (byte)'d',
-    };
+    ];
 }

--- a/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageParser.cs
+++ b/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageParser.cs
@@ -23,22 +23,22 @@ internal ref struct GraphQLWebSocketMessageParser
     private const byte _s = (byte)'s';
     private const byte _t = (byte)'t';
 
-    private static ReadOnlySpan<byte> Type => new[]
-    {
+    private static ReadOnlySpan<byte> Type =>
+    [
         (byte)'t',
         (byte)'y',
         (byte)'p',
         (byte)'e',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Id => new[]
-    {
+    private static ReadOnlySpan<byte> Id =>
+    [
         (byte)'i',
         (byte)'d',
-    };
+    ];
 
-    private static ReadOnlySpan<byte> Payload => new[]
-    {
+    private static ReadOnlySpan<byte> Payload =>
+    [
         (byte)'p',
         (byte)'a',
         (byte)'y',
@@ -46,7 +46,7 @@ internal ref struct GraphQLWebSocketMessageParser
         (byte)'o',
         (byte)'a',
         (byte)'d',
-    };
+    ];
 
     private Utf8JsonReader _reader;
 

--- a/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageTypeSpans.cs
+++ b/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageTypeSpans.cs
@@ -4,8 +4,8 @@ namespace StrawberryShake.Transport.WebSockets.Protocols;
 
 public static class GraphQLWebSocketMessageTypeSpans
 {
-    public static ReadOnlySpan<byte> ConnectionInitialize => new[]
-    {
+    public static ReadOnlySpan<byte> ConnectionInitialize =>
+    [
         (byte)'c',
         (byte)'o',
         (byte)'n',
@@ -21,10 +21,10 @@ public static class GraphQLWebSocketMessageTypeSpans
         (byte)'n',
         (byte)'i',
         (byte)'t',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> ConnectionAccept => new[]
-    {
+    public static ReadOnlySpan<byte> ConnectionAccept =>
+    [
         (byte)'c',
         (byte)'o',
         (byte)'n',
@@ -39,10 +39,10 @@ public static class GraphQLWebSocketMessageTypeSpans
         (byte)'a',
         (byte)'c',
         (byte)'k',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> ConnectionError => new[]
-    {
+    public static ReadOnlySpan<byte> ConnectionError =>
+    [
         (byte)'c',
         (byte)'o',
         (byte)'n',
@@ -59,16 +59,16 @@ public static class GraphQLWebSocketMessageTypeSpans
         (byte)'r',
         (byte)'o',
         (byte)'r',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> KeepAlive => new[]
-    {
+    public static ReadOnlySpan<byte> KeepAlive =>
+    [
         (byte)'k',
         (byte)'a',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> ConnectionTerminate => new[]
-    {
+    public static ReadOnlySpan<byte> ConnectionTerminate =>
+    [
         (byte)'c',
         (byte)'o',
         (byte)'n',
@@ -89,36 +89,36 @@ public static class GraphQLWebSocketMessageTypeSpans
         (byte)'a',
         (byte)'t',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Start => new[]
-    {
+    public static ReadOnlySpan<byte> Start =>
+    [
         (byte)'s',
         (byte)'t',
         (byte)'a',
         (byte)'r',
         (byte)'t',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Data => new[]
-    {
+    public static ReadOnlySpan<byte> Data =>
+    [
         (byte)'d',
         (byte)'a',
         (byte)'t',
         (byte)'a',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Error => new[]
-    {
+    public static ReadOnlySpan<byte> Error =>
+    [
         (byte)'e',
         (byte)'r',
         (byte)'r',
         (byte)'o',
         (byte)'r',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Complete => new[]
-    {
+    public static ReadOnlySpan<byte> Complete =>
+    [
         (byte)'c',
         (byte)'o',
         (byte)'m',
@@ -127,13 +127,13 @@ public static class GraphQLWebSocketMessageTypeSpans
         (byte)'e',
         (byte)'t',
         (byte)'e',
-    };
+    ];
 
-    public static ReadOnlySpan<byte> Stop => new[]
-    {
+    public static ReadOnlySpan<byte> Stop =>
+    [
         (byte)'s',
         (byte)'t',
         (byte)'o',
         (byte)'p',
-    };
+    ];
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated more code to use C# collection expressions (IDE0300).

---

ℹ️ I used the `when_types_exactly_match` option. The `when_types_loosely_match` option can change semantics (see [here](https://github.com/dotnet/roslyn/issues/72532#issuecomment-2185026497)).

When using the latter option:

```ini
dotnet_diagnostic.ide0300.severity = warning
dotnet_style_prefer_collection_expression = when_types_loosely_match
```

There are another 10-20 warnings. You might want to change all or some of these as well, but be careful regarding the change in semantics.