### PR TITLE
Fixed Fusion compose of object beneath shared field in non-null violation case

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Execution/ExecutionUtils.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/ExecutionUtils.cs
@@ -390,7 +390,8 @@ internal static class ExecutionUtils
 
             while (Unsafe.IsAddressLessThan(ref selection, ref endSelection))
             {
-                if (data.TryGetProperty(selection.ResponseName, out var value))
+                if (data.ValueKind is not JsonValueKind.Null &&
+                    data.TryGetProperty(selection.ResponseName, out var value))
                 {
                     selectionData = selectionData.AddResult(new JsonResult(schemaName, value));
                 }
@@ -412,7 +413,8 @@ internal static class ExecutionUtils
 
                 while (Unsafe.IsAddressLessThan(ref selection, ref endSelection))
                 {
-                    if (element.TryGetProperty(selection.ResponseName, out var value))
+                    if (element.ValueKind is not JsonValueKind.Null &&
+                        element.TryGetProperty(selection.ResponseName, out var value))
                     {
                         selectionData = selectionData.AddResult(new JsonResult(schemaName, value));
                     }

--- a/src/HotChocolate/Fusion/src/Core/Execution/ExecutionUtils.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/ExecutionUtils.cs
@@ -121,6 +121,10 @@ internal static class ExecutionUtils
                 {
                     if (!result.IsInitialized)
                     {
+                        // we add a placeholder here so if the ComposeObject propagates an error
+                        // there is a value here.
+                        result.Set(responseName, null, nullable);
+
                         var value = ComposeObject(
                             context,
                             selectionSetResult,

--- a/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
@@ -99,7 +99,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -143,7 +143,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -187,7 +187,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -231,7 +231,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -319,7 +319,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField()
     {
         // arrange
@@ -419,7 +419,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -475,7 +475,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -535,7 +535,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
 
     #region Parallel, No Shared Entry Field
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_Nullable_EntryField_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -581,7 +581,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_EntryField_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -673,7 +673,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_EntryField_Nullable_One_Service_Errors_EntryField()
     {
         // arrange
@@ -719,7 +719,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_EntryField_NonNull_One_Service_Errors_EntryField()
     {
         // arrange
@@ -883,7 +883,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
 
     #region Entity Resolver
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_SubField()
     {
         // arrange
@@ -932,7 +932,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_SubField()
     {
         // arrange
@@ -1030,7 +1030,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_SubField()
     {
         // arrange
@@ -1079,7 +1079,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_SubField()
     {
         // arrange
@@ -1128,7 +1128,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_SubField()
     {
         // arrange
@@ -1177,7 +1177,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField()
     {
         // arrange
@@ -1324,7 +1324,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -1471,7 +1471,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_EntryField_Nullable_Both_Services_Error_EntryField()
     {
         // arrange
@@ -1520,7 +1520,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_EntryField_NonNull_Both_Services_Error_EntryField()
     {
         // arrange
@@ -2101,7 +2101,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact]
+    [Fact(Skip = "errors are wrong")]
     public async Task Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField()
     {
         // arrange

--- a/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
@@ -99,7 +99,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -143,7 +143,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -187,7 +187,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -275,7 +275,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -319,7 +319,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField()
     {
         // arrange
@@ -419,7 +419,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -475,7 +475,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1177,7 +1177,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField()
     {
         // arrange
@@ -1324,7 +1324,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "data is wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -1942,7 +1942,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
 
     #region Resolve Sequence
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -1995,7 +1995,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_SubField()
     {
         // arrange
@@ -2048,7 +2048,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_SubField()
     {
         // arrange
@@ -2101,7 +2101,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField()
     {
         // arrange

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
@@ -19,9 +19,6 @@
       "extensions": {
         "code": "HC0018"
       }
-    },
-    {
-      "message": "Internal Execution Error"
     }
   ],
   "data": null


### PR DESCRIPTION
Previously, if a subfield would have produced a non-null violation during composition of an object, the path creation for the non-null violation error would've run into an exception, because the parent field of the to-be composed object has not yet been initialized. This caused unexpected behavior and a weird, half-initialized data portion in the response.

This PR initializes the parent field of the to-be-composed object, so error paths can be created during composition of the object.

You don't see any changes in the snapshots here and many tests still have to be skipped, because the error portion of the response is incorrect. This is unfortunate and and I'll try to change it in a later PR.
You can see the effective difference here though for the moment: https://github.com/ChilliCream/graphql-platform/commit/6d7300b2c891322b73f1f136a569d5effadf70d2

With this change the data portion is now correct in each error case we have tests for 🎉