### PR TITLE
Return false when not found for TryGetValue

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectResult.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectResult.cs
@@ -222,7 +222,7 @@ public sealed class ObjectResult
         }
 
         value = null;
-        return true;
+        return false;
     }
 
     public IEnumerator<ObjectFieldResult> GetEnumerator()

--- a/src/HotChocolate/Core/test/Execution.Tests/Processing/Result/ObjectResultTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Processing/Result/ObjectResultTests.cs
@@ -95,6 +95,32 @@ namespace HotChocolate.Execution.Processing
         [InlineData(4)]
         [InlineData(3)]
         [Theory]
+        public void TryGetValue_ValueIsNotFound(int capacity)
+        {
+            // arrange
+            var objectResult = new ObjectResult();
+            objectResult.EnsureCapacity(capacity);
+            objectResult.SetValueUnsafe(0, "abc", "def");
+            objectResult.SetValueUnsafe(capacity / 2, "def", "def");
+            objectResult.SetValueUnsafe(capacity - 1, "ghi", "def");
+
+            IReadOnlyDictionary<string, object> dict = objectResult;
+
+            // act
+            var found = dict.TryGetValue("jkl", out var value);
+
+            // assert
+            Assert.False(found);
+            Assert.Null(value);
+        }
+
+        [InlineData(9)]
+        [InlineData(8)]
+        [InlineData(7)]
+        [InlineData(5)]
+        [InlineData(4)]
+        [InlineData(3)]
+        [Theory]
         public void ContainsKey(int capacity)
         {
             // arrange


### PR DESCRIPTION
Return false when not found for `ObjectResult` `IReadOnlyDictionary.TryGetValue`

- `ObjectResult`'s explicit implementation of `IReadOnlyDictionary.TryGetValue` returns `true` when it should be `false`
- Adding a new set of tests in the image of `ObjectResultTests.TryGetValue_ValueIsFound`
