### PR TITLE
Updated QueryCacheMiddleware to not cache query results with errors

### DIFF
--- a/src/HotChocolate/Caching/src/Caching/QueryCacheMiddleware.cs
+++ b/src/HotChocolate/Caching/src/Caching/QueryCacheMiddleware.cs
@@ -38,7 +38,7 @@ internal sealed class QueryCacheMiddleware
 
         var queryResult = context.Result?.ExpectQueryResult();
 
-        if (queryResult is not null)
+        if (queryResult is { Errors: null })
         {
             var contextData =
                 queryResult.ContextData is not null

--- a/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -179,6 +180,27 @@ public class HttpCachingTests : ServerTestBase
                     .Field("field")
                     .Resolve("")
                     .CacheControl(2000, CacheControlScope.Private));
+        });
+
+        var client = server.CreateClient();
+        var result = await client.PostQueryAsync("{ field }");
+
+        result.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task QueryError_Should_Not_Cache()
+    {
+        var server = CreateServer(services =>
+        {
+            services.AddGraphQLServer()
+                .UseQueryCachePipeline()
+                .AddCacheControl()
+                .AddQueryType(d =>
+                    d.Name("Query")
+                        .Field("field")
+                        .Type<StringType>()
+                        .Resolve(_ => throw new Exception()));
         });
 
         var client = server.CreateClient();

--- a/src/HotChocolate/Caching/test/Caching.Tests/__snapshots__/HttpCachingTests.QueryError_Should_Not_Cache.snap
+++ b/src/HotChocolate/Caching/test/Caching.Tests/__snapshots__/HttpCachingTests.QueryError_Should_Not_Cache.snap
@@ -1,0 +1,12 @@
+{
+  "Headers": [],
+  "ContentHeaders": [
+    {
+      "Key": "Content-Type",
+      "Value": [
+        "application/graphql-response+json; charset=utf-8"
+      ]
+    }
+  ],
+  "Body": "{\"errors\":[{\"message\":\"Unexpected Execution Error\",\"locations\":[{\"line\":1,\"column\":3}],\"path\":[\"field\"]}],\"data\":{\"field\":null}}"
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated `QueryCacheMiddleware` to not cache query results with errors.

Closes #7208