### PR TITLE
Removed `--property WarningLevel=0` in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Run Build
         id: run-build
-        run: dotnet build ${{ matrix.path }} --framework net8.0 --verbosity q --property WarningLevel=0
+        run: dotnet build ${{ matrix.path }} --framework net8.0 --verbosity q
         timeout-minutes: 5
 
       - name: Create directory for test results
@@ -257,7 +257,7 @@ jobs:
 
       - name: Run Build
         id: run-build
-        run: dotnet build ${{ matrix.path }} --framework net8.0 --verbosity q --property WarningLevel=0
+        run: dotnet build ${{ matrix.path }} --framework net8.0 --verbosity q
         timeout-minutes: 5
 
       - name: Create directory for test results

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Build
         id: run-build
-        run: dotnet build ${{ matrix.path }} --framework net7.0 --verbosity q --property WarningLevel=0
+        run: dotnet build ${{ matrix.path }} --framework net7.0 --verbosity q
         timeout-minutes: 5
 
       - name: Run tests


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Removed `--property WarningLevel=0` in CI builds.

---

The build should fail until #7297 is merged.
