### PR TITLE
Fix off-by-one error in middleware cleanup tasks

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Global.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/MiddlewareContext.Global.cs
@@ -228,7 +228,7 @@ internal partial class MiddlewareContext : IMiddlewareContext
         {
             await _cleanupTasks[0].Invoke().ConfigureAwait(false);
             await _cleanupTasks[1].Invoke().ConfigureAwait(false);
-            await _cleanupTasks[3].Invoke().ConfigureAwait(false);
+            await _cleanupTasks[2].Invoke().ConfigureAwait(false);
             return;
         }
 


### PR DESCRIPTION
This fixes an obvious bug I found while reading some source code. 

`MiddlewareContext.ExecuteCleanupTasksAsync` has special cases for small task counts. When the count is exactly 3, the existing code tries to execute the task at index `3` (instead of `2`), which will always lead to an `ArgumentOutOfRangeException`.