### PR TITLE
Support colons in legacy GIDs

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -256,7 +256,7 @@ public sealed class DefaultNodeIdSerializer(
 
 #if NET8_0_OR_GREATER
     private static readonly SearchValues<byte> _delimiterSearchValues = 
-    		SearchValues.Create([_delimiter, _legacyDelimiter]);
+        SearchValues.Create([_delimiter, _legacyDelimiter]);
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -255,8 +255,8 @@ public sealed class DefaultNodeIdSerializer(
     }
 
 #if NET8_0_OR_GREATER
-    private static readonly SearchValues<byte>
-        _delimiterSearchValues = SearchValues.Create([_delimiter, _legacyDelimiter]);
+    private static readonly SearchValues<byte> _delimiterSearchValues = 
+    		SearchValues.Create([_delimiter, _legacyDelimiter]);
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -150,22 +150,20 @@ public sealed class DefaultNodeIdSerializer(
         Base64.DecodeFromUtf8InPlace(span, out var written);
         span = span.Slice(0, written);
 
-        var index = span.IndexOf(_delimiter);
-        var delimiterOffset = 1;
-        if (index == -1)
+        var delimiterIndex = FindDelimiterIndex(span);
+        if (delimiterIndex == -1)
         {
-            index = span.IndexOf(_legacyDelimiter);
+            Clear(rentedBuffer);
+            throw new NodeIdInvalidFormatException(formattedId);
+        }
 
-            if (index < 0)
-            {
-                Clear(rentedBuffer);
-                throw new NodeIdInvalidFormatException(formattedId);
-            }
-
+        var delimiterOffset = 1;
+        if (span[delimiterIndex] == _legacyDelimiter)
+        {
             delimiterOffset = 2;
         }
 
-        var typeName = span.Slice(0, index);
+        var typeName = span.Slice(0, delimiterIndex);
         var typeNameString = ToString(typeName);
         var runtimeType = runtimeTypeLookup.GetNodeIdRuntimeType(typeNameString) ?? typeof(string);
         var serializer = TryResolveSerializer(runtimeType);
@@ -176,7 +174,7 @@ public sealed class DefaultNodeIdSerializer(
             throw new NodeIdInvalidFormatException(formattedId);
         }
 
-        if (serializer.TryParse(span.Slice(index + delimiterOffset), out var value))
+        if (serializer.TryParse(span.Slice(delimiterIndex + delimiterOffset), out var value))
         {
             return new NodeId(typeNameString, value);
         }
@@ -207,22 +205,20 @@ public sealed class DefaultNodeIdSerializer(
         Base64.DecodeFromUtf8InPlace(span, out var written);
         span = span.Slice(0, written);
 
-        var index = span.IndexOf(_delimiter);
-        var delimiterOffset = 1;
-        if (index == -1)
+        var delimiterIndex = FindDelimiterIndex(span);
+        if (delimiterIndex == -1)
         {
-            index = span.IndexOf(_legacyDelimiter);
+            Clear(rentedBuffer);
+            throw new NodeIdInvalidFormatException(formattedId);
+        }
 
-            if (index < 0)
-            {
-                Clear(rentedBuffer);
-                throw new NodeIdInvalidFormatException(formattedId);
-            }
-
+        var delimiterOffset = 1;
+        if (span[delimiterIndex] == _legacyDelimiter)
+        {
             delimiterOffset = 2;
         }
 
-        var typeName = span.Slice(0, index);
+        var typeName = span.Slice(0, delimiterIndex);
         var typeNameString = ToString(typeName);
         var serializer = TryResolveSerializer(runtimeType);
 
@@ -232,7 +228,7 @@ public sealed class DefaultNodeIdSerializer(
             throw new NodeIdInvalidFormatException(formattedId);
         }
 
-        if (serializer.TryParse(span.Slice(index + delimiterOffset), out var value))
+        if (serializer.TryParse(span.Slice(delimiterIndex + delimiterOffset), out var value))
         {
             return new NodeId(typeNameString, value);
         }
@@ -256,6 +252,21 @@ public sealed class DefaultNodeIdSerializer(
         }
 
         return null;
+    }
+
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<byte>
+        _delimiterSearchValues = SearchValues.Create([_delimiter, _legacyDelimiter]);
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int FindDelimiterIndex(ReadOnlySpan<byte> span)
+    {
+#if NET8_0_OR_GREATER
+        return span.IndexOfAny(_delimiterSearchValues);
+#else
+        return span.IndexOfAny([_delimiter, _legacyDelimiter]);
+#endif
     }
 
     private static void Clear(byte[]? rentedBuffer = null)

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -115,6 +115,17 @@ public class DefaultNodeIdSerializerTests
     }
 
     [Fact]
+    public void Parse_Legacy_StringId()
+    {
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
+
+        var id = serializer.Parse("Rm9vCmRhYmM=", typeof(string));
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("abc", id.InternalId);
+    }
+
+    [Fact]
     public void Parse_Small_Legacy_StringId()
     {
         var lookup = new Mock<INodeIdRuntimeTypeLookup>();
@@ -126,6 +137,28 @@ public class DefaultNodeIdSerializerTests
 
         Assert.Equal("Foo", id.TypeName);
         Assert.Equal("abc", id.InternalId);
+    }
+
+    [Fact]
+    public void Parse_StringId_With_Colons()
+    {
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
+
+        var id = serializer.Parse("Rm9vOjE6Mjoz", typeof(string));
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("1:2:3", id.InternalId);
+    }
+
+    [Fact]
+    public void Parse_Legacy_StringId_With_Colons()
+    {
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
+
+        var id = serializer.Parse("Rm9vCmQxOjI6Mw==", typeof(string));
+
+        Assert.Equal("Foo", id.TypeName);
+        Assert.Equal("1:2:3", id.InternalId);
     }
 
     [Fact]


### PR DESCRIPTION
While preparing our Framework code for Hot Chocolate v14, I noticed that we have some (strongly typed) Ids that contain colons (`:`). This is problematic with the current implementation of the new Node Id Serializer, as it looks for `:` as the separator between Type name and Id value and doesn't consider that it might be dealing with a legacy Id that contains a colon.

This PR adds support for colons in Id values by looking for both the new `:` and old `\n` delimiter.

This of course impacts the hot path, but I think it's warranted. If someone were to implement a custom Id format (doesn't even have to be strongly typed, it could just be a string with another dalimiter) I would assume that the delimiter being chosen would be `:` 95% of the time. I'd therefore assume that there is probably at least one such Id in each larger code base. I think it would be really nice, if the new solution would be a drop-in replacement and wouldn't require any migration effort.