### PR TITLE
Check in current Fusion error snapshots and unskip tests

### DIFF
--- a/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SubgraphErrorTests.cs
@@ -99,7 +99,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -143,7 +143,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -187,7 +187,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField()
     {
         // arrange
@@ -319,7 +319,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField()
     {
         // arrange
@@ -363,7 +363,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -419,7 +419,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -475,7 +475,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -627,7 +627,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField()
     {
         // arrange
@@ -765,7 +765,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data()
     {
         // arrange
@@ -822,7 +822,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data()
     {
         // arrange
@@ -981,7 +981,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField()
     {
         // arrange
@@ -1177,7 +1177,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField()
     {
         // arrange
@@ -1226,7 +1226,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField()
     {
         // arrange
@@ -1275,7 +1275,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField()
     {
         // arrange
@@ -1324,7 +1324,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -1373,7 +1373,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -1422,7 +1422,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -1569,7 +1569,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1630,7 +1630,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1691,7 +1691,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1752,7 +1752,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1814,7 +1814,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -1876,7 +1876,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2101,7 +2101,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField()
     {
         // arrange
@@ -2154,7 +2154,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField()
     {
         // arrange
@@ -2207,7 +2207,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField()
     {
         // arrange
@@ -2260,7 +2260,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2325,7 +2325,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2390,7 +2390,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2459,7 +2459,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
 
     #region ResolveByKey
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField()
     {
         // arrange
@@ -2506,7 +2506,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField()
     {
         // arrange
@@ -2553,7 +2553,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField()
     {
         // arrange
@@ -2600,7 +2600,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -2647,7 +2647,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -2694,7 +2694,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField()
     {
         // arrange
@@ -2741,7 +2741,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2800,7 +2800,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data()
     {
@@ -2859,7 +2859,7 @@ public class SubgraphErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task
         ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data()
     {

--- a/src/HotChocolate/Fusion/test/Core.Tests/TransportErrorTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/TransportErrorTests.cs
@@ -9,7 +9,7 @@ public class TransportErrorTests(ITestOutputHelper output)
 {
     #region Parallel, Shared Entry Field
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable()
     {
         // arrange
@@ -54,7 +54,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable()
     {
         // arrange
@@ -99,7 +99,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull()
     {
         // arrange
@@ -144,7 +144,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable()
     {
         // arrange
@@ -190,7 +190,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull()
     {
         // arrange
@@ -240,7 +240,7 @@ public class TransportErrorTests(ITestOutputHelper output)
 
     #region Parallel, No Shared Entry Field
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_Single_Service_Offline_EntryField_Nullable()
     {
         // arrange
@@ -273,7 +273,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_Single_Service_Offline_EntryField_NonNull()
     {
         // arrange
@@ -306,7 +306,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_One_Service_Offline_EntryFields_Nullable()
     {
         // arrange
@@ -353,7 +353,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Parallel_One_Service_Offline_EntryFields_NonNull()
     {
         // arrange
@@ -404,7 +404,7 @@ public class TransportErrorTests(ITestOutputHelper output)
 
     #region Entity Resolver
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Single_Service_Offline_EntryField_Nullable()
     {
         // arrange
@@ -441,7 +441,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Single_Service_Offline_EntryField_NonNull()
     {
         // arrange
@@ -478,7 +478,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable()
     {
         // arrange
@@ -528,7 +528,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable()
     {
         // arrange
@@ -578,7 +578,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull()
     {
         // arrange
@@ -628,7 +628,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable()
     {
         // arrange
@@ -678,7 +678,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable()
     {
         // arrange
@@ -728,7 +728,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull()
     {
         // arrange
@@ -778,7 +778,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Both_Services_Offline_EntryField_Nullable()
     {
         // arrange
@@ -829,7 +829,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Entity_Resolver_Both_Services_Offline_EntryField_NonNull()
     {
         // arrange
@@ -884,7 +884,7 @@ public class TransportErrorTests(ITestOutputHelper output)
 
     #region Resolve Sequence
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_First_Service_Offline_EntryField_Nullable()
     {
         // arrange
@@ -938,7 +938,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_First_Service_Offline_EntryField_NonNull()
     {
         // arrange
@@ -992,7 +992,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable()
     {
         // arrange
@@ -1046,7 +1046,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable()
     {
         // arrange
@@ -1100,7 +1100,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull()
     {
         // arrange
@@ -1158,7 +1158,7 @@ public class TransportErrorTests(ITestOutputHelper output)
 
     #region ResolveByKey
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_Second_Service_Offline_SubField_Nullable()
     {
         // arrange
@@ -1206,7 +1206,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull()
     {
         // arrange
@@ -1254,7 +1254,7 @@ public class TransportErrorTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
 
-    [Fact(Skip = "errors are wrong")]
+    [Fact]
     public async Task ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable()
     {
         // arrange

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField.md
@@ -9,39 +9,12 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 3,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
+        "productById"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField.md
@@ -6,6 +6,21 @@
 {
   "errors": [
     {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
       "message": "Unexpected Execution Error",
       "locations": [
         {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,43 +6,22 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
-          "line": 3,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "productById",
-        "id"
-      ]
+        "productById"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField.md
@@ -9,6 +9,18 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 6,
           "column": 5
         }
@@ -16,7 +28,10 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -16,7 +16,13 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField.md
@@ -9,39 +9,12 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 3,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
+        "productById"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,43 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField.md
@@ -9,6 +9,18 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 6,
           "column": 5
         }
@@ -16,7 +28,10 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -16,7 +16,13 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField.md
@@ -9,39 +9,12 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 3,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
+        "productById"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,43 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField.md
@@ -9,13 +9,12 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 6,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "productById",
-        "score"
+        "productById"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,17 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 6,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "score"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField.md
@@ -9,6 +9,19 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "products",
+        0
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 5,
           "column": 5
         }
@@ -17,10 +30,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +47,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +64,10 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField.md
@@ -15,9 +15,26 @@
       ],
       "path": [
         "products",
-        1,
+        0,
         "price"
       ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -17,10 +17,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +34,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +51,13 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField.md
@@ -9,6 +9,19 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "products",
+        0
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 5,
           "column": 5
         }
@@ -17,10 +30,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +47,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +64,10 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField.md
@@ -15,9 +15,26 @@
       ],
       "path": [
         "products",
-        1,
+        0,
         "price"
       ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -17,10 +17,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +34,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +51,13 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField.md
@@ -9,42 +9,13 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 5,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
         "products",
-        2,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        1,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        0,
-        "price"
+        0
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField.md
@@ -15,7 +15,7 @@
       ],
       "path": [
         "products",
-        1,
+        0,
         "price"
       ]
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,46 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        2,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        1,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        0,
-        "price"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "other"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 3
-        }
-      ],
-      "path": [
-        "other"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField.md
@@ -6,6 +6,21 @@
 {
   "errors": [
     {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "other"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
       "message": "Unexpected Execution Error",
       "locations": [
         {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField.md
@@ -9,6 +9,18 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 4,
           "column": 5
         }
@@ -16,7 +28,10 @@
       "path": [
         "viewer",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField.md
@@ -6,6 +6,21 @@
 {
   "errors": [
     {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
       "message": "Unexpected Execution Error",
       "locations": [
         {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,22 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 3,
@@ -16,7 +31,13 @@
       "path": [
         "viewer",
         "userId"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
@@ -9,6 +9,18 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 4,
           "column": 5
         }
@@ -16,7 +28,10 @@
       "path": [
         "viewer",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 3,
@@ -16,7 +16,13 @@
       "path": [
         "viewer",
         "userId"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
@@ -9,13 +9,12 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 4,
-          "column": 5
+          "line": 2,
+          "column": 3
         }
       ],
       "path": [
-        "viewer",
-        "name"
+        "viewer"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,17 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "viewer",
-        "userId"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField.md
@@ -9,6 +9,19 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "product",
+        "brand"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 6,
           "column": 7
         }
@@ -17,7 +30,10 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -17,7 +17,13 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField.md
@@ -9,6 +9,19 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "product",
+        "brand"
+      ]
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
           "line": 6,
           "column": 7
         }
@@ -17,7 +30,10 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -17,7 +17,13 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
@@ -9,14 +9,13 @@
       "message": "Unexpected Execution Error",
       "locations": [
         {
-          "line": 6,
-          "column": 7
+          "line": 4,
+          "column": 5
         }
       ],
       "path": [
         "product",
-        "brand",
-        "name"
+        "brand"
       ]
     }
   ],

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -6,18 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 6,
-          "column": 7
-        }
-      ],
-      "path": [
-        "product",
-        "brand",
-        "name"
-      ]
+      "message": "Top Level Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "productById"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "productById"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
@@ -19,6 +19,9 @@
       "extensions": {
         "code": "HC0018"
       }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "productById"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
@@ -6,43 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "id"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "name"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "price"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -16,7 +16,13 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -16,7 +16,13 @@
       "path": [
         "productById",
         "score"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
@@ -6,17 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 6,
-          "column": 5
-        }
-      ],
-      "path": [
-        "productById",
-        "score"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "productById"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "productById"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -17,10 +17,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +34,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +51,13 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -17,10 +17,13 @@
         "products",
         2,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -31,10 +34,13 @@
         "products",
         1,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
     },
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 5,
@@ -45,7 +51,13 @@
         "products",
         0,
         "price"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_Nullable.md
@@ -6,46 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        2,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        1,
-        "price"
-      ]
-    },
-    {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 5,
-          "column": 5
-        }
-      ],
-      "path": [
-        "products",
-        0,
-        "price"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,16 @@
       ],
       "path": [
         "viewer"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable.md
@@ -6,16 +6,10 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "viewer"
-      ]
+      "message": "Internal Execution Error"
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "viewer"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "viewer"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull.md
@@ -6,7 +6,22 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 4,
@@ -16,7 +31,13 @@
       "path": [
         "viewer",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 4,
@@ -16,7 +16,13 @@
       "path": [
         "viewer",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable.md
@@ -6,17 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "viewer",
-        "name"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "viewer"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "viewer"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 2,
@@ -15,7 +15,13 @@
       ],
       "path": [
         "product"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": null

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_Nullable.md
@@ -6,16 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "product"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -17,7 +17,13 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable.md
@@ -6,7 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
+      "message": "Cannot return null for non-nullable field.",
       "locations": [
         {
           "line": 6,
@@ -17,7 +17,13 @@
         "product",
         "brand",
         "name"
-      ]
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
@@ -6,18 +6,7 @@
 {
   "errors": [
     {
-      "message": "Unexpected Execution Error",
-      "locations": [
-        {
-          "line": 6,
-          "column": 7
-        }
-      ],
-      "path": [
-        "product",
-        "brand",
-        "name"
-      ]
+      "message": "Internal Execution Error"
     }
   ],
   "data": {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField.md
@@ -1,0 +1,123 @@
+# Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField.md
@@ -1,0 +1,97 @@
+# Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,123 @@
+# Entity_Resolver_SubField_NonNull_EntryField_NonNull_First_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField.md
@@ -1,0 +1,97 @@
+# Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,97 @@
+# Entity_Resolver_SubField_NonNull_EntryField_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField.md
@@ -1,0 +1,125 @@
+# Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,125 @@
+# Entity_Resolver_SubField_NonNull_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField.md
@@ -1,0 +1,99 @@
+# Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,99 @@
+# Entity_Resolver_SubField_NonNull_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField.md
@@ -1,0 +1,113 @@
+# Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": null,
+      "name": null,
+      "price": null,
+      "score": 123
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1187C75DB20A2D54D1EDC1F31D46DA85C597E294
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_productById_2 { productById(id: \u00221\u0022) { score } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,113 @@
+# Entity_Resolver_SubField_Nullable_EntryField_Nullable_First_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": null,
+      "name": null,
+      "price": null,
+      "score": 123
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1187C75DB20A2D54D1EDC1F31D46DA85C597E294
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_productById_2 { productById(id: \u00221\u0022) { score } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField.md
@@ -1,0 +1,87 @@
+# Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string",
+      "price": 123.456,
+      "score": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1187C75DB20A2D54D1EDC1F31D46DA85C597E294
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_productById_2 { productById(id: \u00221\u0022) { score } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,104 @@
+# Entity_Resolver_SubField_Nullable_EntryField_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string",
+      "price": 123.456,
+      "score": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField.md
@@ -1,0 +1,127 @@
+# ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField.md
@@ -1,0 +1,99 @@
+# ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,127 @@
+# ResolveByKey_SubField_NonNull_ListItem_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField.md
@@ -1,0 +1,131 @@
+# ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      null,
+      null,
+      null
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField.md
@@ -1,0 +1,111 @@
+# ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123
+      },
+      null,
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,131 @@
+# ResolveByKey_SubField_NonNull_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      null,
+      null,
+      null
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField.md
@@ -1,0 +1,143 @@
+# ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": null
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField.md
@@ -1,0 +1,115 @@
+# ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,143 @@
+# ResolveByKey_SubField_Nullable_ListItem_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": null
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,79 @@
+# Resolve_Parallel_EntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "other"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1E9F0B5070B0EB2A79CBF03CDCC94C574189F814
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } other { userId } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_other_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_other_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,84 @@
+# Resolve_Parallel_EntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 3
+        }
+      ],
+      "path": [
+        "other"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1E9F0B5070B0EB2A79CBF03CDCC94C574189F814
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } other { userId } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_other_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_other_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField.md
@@ -1,0 +1,80 @@
+# Resolve_Parallel_SubField_NonNull_EntryField_NonNull_One_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "other",
+        "userId"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1E9F0B5070B0EB2A79CBF03CDCC94C574189F814
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } other { userId } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_other_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_other_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField.md
@@ -1,0 +1,78 @@
+# Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SharedEntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField.md
@@ -1,0 +1,78 @@
+# Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Errors_SubField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,78 @@
+# Resolve_Parallel_SubField_NonNull_SharedEntryField_NonNull_One_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "userId"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
@@ -1,0 +1,80 @@
+# Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,80 @@
+# Resolve_Parallel_SubField_NonNull_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "userId"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField.md
@@ -1,0 +1,83 @@
+# Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Errors_SharedEntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,83 @@
+# Resolve_Parallel_SubField_Nullable_SharedEntryField_Nullable_One_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "userId"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": {
+      "userId": null,
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField.md
@@ -1,0 +1,101 @@
+# Resolve_Sequence_SubField_NonNull_Parent_NonNull_One_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,101 @@
+# Resolve_Sequence_SubField_NonNull_Parent_NonNull_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField.md
@@ -1,0 +1,104 @@
+# Resolve_Sequence_SubField_NonNull_Parent_Nullable_One_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,104 @@
+# Resolve_Sequence_SubField_NonNull_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
@@ -1,0 +1,107 @@
+# Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": null
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -1,0 +1,107 @@
+# Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": null
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_NonNull.md
@@ -1,0 +1,96 @@
+# Entity_Resolver_Both_Services_Offline_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Both_Services_Offline_EntryField_Nullable.md
@@ -1,0 +1,98 @@
+# Entity_Resolver_Both_Services_Offline_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
@@ -1,0 +1,99 @@
+# Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
@@ -1,0 +1,98 @@
+# Entity_Resolver_First_Service_Offline_SubFields_NonNull_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
@@ -1,0 +1,113 @@
+# Entity_Resolver_First_Service_Offline_SubFields_Nullable_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "id"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "name"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": null,
+      "name": null,
+      "price": null,
+      "score": 123
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1187C75DB20A2D54D1EDC1F31D46DA85C597E294
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_productById_2 { productById(id: \u00221\u0022) { score } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull.md
@@ -1,0 +1,97 @@
+# Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable.md
@@ -1,0 +1,99 @@
+# Entity_Resolver_Second_Service_Offline_SubFields_NonNull_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A5FE502D9F6F0548B898BC17A33BC0F2A2A13AE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_productById_2($__fusion_exports__1: ID!) { productById(id: $__fusion_exports__1) { score } }",
+        "selectionSetId": 1,
+        "path": [
+          "productById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable.md
@@ -1,0 +1,87 @@
+# Entity_Resolver_Second_Service_Offline_SubFields_Nullable_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 5
+        }
+      ],
+      "path": [
+        "productById",
+        "score"
+      ]
+    }
+  ],
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string",
+      "price": 123.456,
+      "score": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+    score
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1187C75DB20A2D54D1EDC1F31D46DA85C597E294
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price score } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_productById_2 { productById(id: \u00221\u0022) { score } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_NonNull.md
@@ -1,0 +1,67 @@
+# Entity_Resolver_Single_Service_Offline_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+3E29A9FA134FCCF20127189A9DE1B4CFB4492EAE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Entity_Resolver_Single_Service_Offline_EntryField_Nullable.md
@@ -1,0 +1,69 @@
+# Entity_Resolver_Single_Service_Offline_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "productById"
+      ]
+    }
+  ],
+  "data": {
+    "productById": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  productById(id: "1") {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+3E29A9FA134FCCF20127189A9DE1B4CFB4492EAE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ productById(id: \u00221\u0022) { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_productById_1 { productById(id: \u00221\u0022) { id name price } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull.md
@@ -1,0 +1,125 @@
+# ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable.md
@@ -1,0 +1,131 @@
+# ResolveByKey_Second_Service_Offline_SubField_NonNull_ListItem_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      null,
+      null,
+      null
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.ResolveByKey_Second_Service_Offline_SubField_Nullable.md
@@ -1,0 +1,143 @@
+# ResolveByKey_Second_Service_Offline_SubField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        2,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        1,
+        "price"
+      ]
+    },
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 5,
+          "column": 5
+        }
+      ],
+      "path": [
+        "products",
+        0,
+        "price"
+      ]
+    }
+  ],
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": null
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": null
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  products {
+    id
+    name
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C991588ECF525B8EF311F2923FD2CEE9D7BE5B3A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ products { id name price } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_products_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_products_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull.md
@@ -1,0 +1,77 @@
+# Resolve_Parallel_Both_Services_Offline_SharedEntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable.md
@@ -1,0 +1,79 @@
+# Resolve_Parallel_Both_Services_Offline_SharedEntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_NonNull.md
@@ -1,0 +1,79 @@
+# Resolve_Parallel_One_Service_Offline_EntryFields_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1E9F0B5070B0EB2A79CBF03CDCC94C574189F814
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } other { userId } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_other_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_other_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_EntryFields_Nullable.md
@@ -1,0 +1,84 @@
+# Resolve_Parallel_One_Service_Offline_EntryFields_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null,
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1E9F0B5070B0EB2A79CBF03CDCC94C574189F814
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } other { userId } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_other_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_other_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull.md
@@ -1,0 +1,78 @@
+# Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable.md
@@ -1,0 +1,80 @@
+# Resolve_Parallel_One_Service_Offline_SubField_NonNull_SharedEntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable.md
@@ -1,0 +1,83 @@
+# Resolve_Parallel_One_Service_Offline_SubField_Nullable_SharedEntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+0728EE40A767B43E14FF62896779067DFF1C53FF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { userId name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query fetch_viewer_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query fetch_viewer_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_NonNull.md
@@ -1,0 +1,65 @@
+# Resolve_Parallel_Single_Service_Offline_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+8B6791F7C91D1B779FF099AD8C7FC0D5980195EF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_viewer_1 { viewer { name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Parallel_Single_Service_Offline_EntryField_Nullable.md
@@ -1,0 +1,67 @@
+# Resolve_Parallel_Single_Service_Offline_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ]
+    }
+  ],
+  "data": {
+    "viewer": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  viewer {
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+8B6791F7C91D1B779FF099AD8C7FC0D5980195EF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ viewer { name } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_viewer_1 { viewer { name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_NonNull.md
@@ -1,0 +1,97 @@
+# Resolve_Sequence_First_Service_Offline_EntryField_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "product"
+      ]
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_First_Service_Offline_EntryField_Nullable.md
@@ -1,0 +1,99 @@
+# Resolve_Sequence_First_Service_Offline_EntryField_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "product"
+      ]
+    }
+  ],
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull.md
@@ -1,0 +1,101 @@
+# Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_NonNull
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable.md
@@ -1,0 +1,104 @@
+# Resolve_Sequence_Second_Service_Offline_SubField_NonNull_Parent_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/__EXPECTED__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
@@ -1,0 +1,107 @@
+# Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Unexpected Execution Error",
+      "locations": [
+        {
+          "line": 6,
+          "column": 7
+        }
+      ],
+      "path": [
+        "product",
+        "brand",
+        "name"
+      ]
+    }
+  ],
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": null
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+{
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+10F6CB69F78A0E4FD176C0F4651E2E37CF47C9C5
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "{ product { id brand { id name } } }",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query fetch_product_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query fetch_product_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+


### PR DESCRIPTION
Checks in the currently wrong snapshots and keeps the correct snapshots around in a `__EXPECTED__` directory.
This will make it easier to iteratively address wrong snapshots, because the changes can be visualized via git diff.