### PR TITLE
Added Fusion tests for `@skip` and fixed some

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.FetchRewriterContext.cs
+++ b/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.FetchRewriterContext.cs
@@ -9,7 +9,8 @@ internal sealed partial class ResolverDefinition
         IReadOnlyDictionary<string, IValueNode> variables,
         SelectionSetNode? selectionSet,
         string? responseName,
-        IReadOnlyList<string>? unspecifiedArguments)
+        IReadOnlyList<string>? unspecifiedArguments,
+        IReadOnlyList<DirectiveNode>? directives)
     {
         public string? ResponseName { get; } = responseName;
 
@@ -25,6 +26,8 @@ internal sealed partial class ResolverDefinition
         /// An optional list of arguments that weren't explicitly specified in the original query.
         /// </summary>
         public IReadOnlyList<string>? UnspecifiedArguments { get; } = unspecifiedArguments;
+
+        public IReadOnlyList<DirectiveNode>? Directives { get; } = directives;
 
         public SelectionSetNode? SelectionSet { get; } = selectionSet;
 

--- a/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.ResolverRewriter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.ResolverRewriter.cs
@@ -17,6 +17,11 @@ internal sealed partial class ResolverDefinition
                 return null;
             }
 
+            if (context.Directives?.Count > 0)
+            {
+                result = result.WithDirectives(context.Directives);
+            }
+
             if (context.UnspecifiedArguments?.Count > 0)
             {
                 var explicitlyDefinedArguments = result.Arguments

--- a/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Core/Metadata/ResolverDefinition.cs
@@ -1,3 +1,4 @@
+using HotChocolate.Execution.Processing;
 using HotChocolate.Language;
 using static HotChocolate.Fusion.FusionResources;
 
@@ -48,15 +49,17 @@ internal sealed partial class ResolverDefinition
     /// <summary>
     /// Gets the argument target types of this resolver.
     /// </summary>
-    public IReadOnlyDictionary<string, ITypeNode> ArgumentTypes { get;  }
+    public IReadOnlyDictionary<string, ITypeNode> ArgumentTypes { get; }
 
     public (ISelectionNode selectionNode, IReadOnlyList<string> Path) CreateSelection(
         IReadOnlyDictionary<string, IValueNode> variables,
         SelectionSetNode? selectionSet,
         string? responseName,
-        IReadOnlyList<string>? unspecifiedArguments)
+        IReadOnlyList<string>? unspecifiedArguments,
+        IReadOnlyList<DirectiveNode>? directives)
     {
-        var context = new FetchRewriterContext(Placeholder, variables, selectionSet, responseName, unspecifiedArguments);
+        var context = new FetchRewriterContext(Placeholder, variables, selectionSet, responseName, unspecifiedArguments,
+            directives);
         var selection = _rewriter.Rewrite(_field ?? (ISyntaxNode)Select, context);
 
         if (Placeholder is null && selectionSet is not null)

--- a/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/NodeRequestDocumentFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/NodeRequestDocumentFormatter.cs
@@ -91,7 +91,8 @@ internal sealed class NodeRequestDocumentFormatter(
             context.VariableValues,
             selectionSetNode,
             nodeSelection.Selection.ResponseName,
-            null);
+            null,
+            nodeSelection.Selection.SyntaxNode.Directives);
 
         if (selectionNode is FieldNode fieldNode &&
             !nodeSelection.Selection.ResponseName.EqualsOrdinal(fieldNode.Name.Value))

--- a/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
@@ -51,7 +51,8 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
                     context.VariableValues,
                     rootSelectionSetNode,
                     null,
-                    unspecifiedArguments);
+                    unspecifiedArguments,
+                    null);
 
             rootSelectionSetNode = new SelectionSetNode(new[] { rootResolver, });
             path = p;
@@ -62,6 +63,7 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
             executionStep.ParentSelectionPath is not null)
         {
             rootSelectionSetNode = CreateRootLevelQuery(
+                context,
                 executionStep.ParentSelectionPath,
                 rootSelectionSetNode);
         }
@@ -83,6 +85,7 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
     }
 
     private SelectionSetNode CreateRootLevelQuery(
+        QueryPlanContext context,
         SelectionPath path,
         SelectionSetNode selectionSet)
     {
@@ -90,8 +93,29 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
 
         while (current is not null)
         {
-            selectionSet = new SelectionSetNode(
-                new[] { current.Selection.SyntaxNode.WithSelectionSet(selectionSet), });
+            var selectionNode = current.Selection.SyntaxNode.WithSelectionSet(selectionSet);
+
+            // TODO: this is not good but will fix the include issue ...
+            // we need to rework the operation compiler for a proper fix.
+            if (selectionNode.Directives.Count > 0)
+            {
+                foreach (var directive in selectionNode.Directives)
+                {
+                    foreach (var argument in directive.Arguments)
+                    {
+                        if (argument.Value is not VariableNode variable)
+                        {
+                            continue;
+                        }
+
+                        var originalVarDef = context.Operation.Definition.VariableDefinitions
+                            .First(t => t.Variable.Equals(variable, SyntaxComparison.Syntax));
+                        context.ForwardedVariables.Add(originalVarDef);
+                    }
+                }
+            }
+
+            selectionSet = new SelectionSetNode(new[] { selectionNode, });
 
             current = current.Parent;
         }
@@ -164,7 +188,8 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
                     context.VariableValues,
                     selectionSetNode,
                     rootSelection.Selection.ResponseName,
-                    unspecifiedArguments);
+                    unspecifiedArguments,
+                    rootSelection.Selection.SyntaxNode.Directives);
                 selectionNode = s;
             }
 
@@ -173,6 +198,26 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
             {
                 selectionNode = fieldNode.WithAlias(
                     new NameNode(rootSelection.Selection.ResponseName));
+            }
+
+            // TODO: this is not good but will fix the include issue ...
+            // we need to rework the operation compiler for a proper fix.
+            if (selectionNode.Directives.Count > 0)
+            {
+                foreach (var directive in selectionNode.Directives)
+                {
+                    foreach (var argument in directive.Arguments)
+                    {
+                        if (argument.Value is not VariableNode variable)
+                        {
+                            continue;
+                        }
+
+                        var originalVarDef = context.Operation.Definition.VariableDefinitions
+                            .First(t => t.Variable.Equals(variable, SyntaxComparison.Syntax));
+                        context.ForwardedVariables.Add(originalVarDef);
+                    }
+                }
             }
 
             selectionNodes.Add(selectionNode);

--- a/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
@@ -1,0 +1,2606 @@
+using HotChocolate.Execution;
+using HotChocolate.Fusion.Shared;
+using Xunit.Abstractions;
+using static HotChocolate.Fusion.TestHelper;
+
+namespace HotChocolate.Fusion;
+
+public class SkipTests(ITestOutputHelper output)
+{
+    #region EntityResolver
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_EntityResolver(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           productById(id: "1") @skip(if: $skip) {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraph.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+              other: String
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           productById(id: "1") @skip(if: $skip) {
+                             id
+                             name
+                           }
+                           other
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_EntityResolver_Fragment(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                         }
+
+                         fragment Test on Query {
+                           productById(id: "1") {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraph.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+              other: String
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           other
+                         }
+
+                         fragment Test on Query {
+                           productById(id: "1") {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_EntityResolver_Fragment_EntityResolver_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           productById(id: "1") {
+                             id
+                             name
+                           }
+                         }
+
+                         fragment Test on Query {
+                           productById(id: "1") {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_SubField(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+              price: Float!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           productById(id: "1") {
+                             name @skip(if: $skip)
+                             price
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_SubField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+              price: Float!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           productById(id: "1") {
+                             ...Test @skip(if: $skip)
+                             price
+                           }
+                         }
+
+                         fragment Test on Product {
+                           name
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EntityResolver_Skip_On_SubField_Fragment_SubField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraph = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+              price: Float!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraph]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           productById(id: "1") {
+                             ...Test @skip(if: $skip)
+                             name
+                             price
+                           }
+                         }
+
+                         fragment Test on Product {
+                           name
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    #endregion
+
+    #region Parallel Resolve
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_EntryField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other @skip(if: $skip) {
+                             userId
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+              another: String
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other @skip(if: $skip) {
+                             userId
+                           }
+                           another
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_EntryField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           ...Test @skip(if: $skip)
+                         }
+
+                         fragment Test on Query {
+                           other {
+                             userId
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+              another: String
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           ...Test @skip(if: $skip)
+                           another
+                         }
+
+                         fragment Test on Query {
+                           other {
+                             userId
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other {
+                             userId
+                           }
+                           ...Test @skip(if: $skip)
+                         }
+
+                         fragment Test on Query {
+                           other {
+                             userId
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_SubField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other {
+                             userId @skip(if: $skip)
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_SubField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other {
+                             ...Test @skip(if: $skip)
+                           }
+                         }
+
+                         fragment Test on Other {
+                           userId
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_Skip_On_SubField_Fragment_SubField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              other: Other!
+            }
+
+            type Other {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             name
+                           }
+                           other {
+                             userId
+                             ...Test @skip(if: $skip)
+                           }
+                         }
+
+                         fragment Test on Other {
+                           userId
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    #endregion
+
+    #region Parallel Resolve - Shared Entry Field
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_EntryField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer @skip(if: $skip) {
+                             userId
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+              other: String
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer @skip(if: $skip) {
+                             userId
+                             name
+                           }
+                           other
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                         }
+
+                         fragment Test on Query {
+                           viewer {
+                             userId
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+              other: String
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           other
+                         }
+
+                         fragment Test on Query {
+                           viewer {
+                             userId
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task
+        Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           viewer {
+                             userId
+                             name
+                           }
+                         }
+
+                         fragment Test on Query {
+                           viewer {
+                             userId
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task
+        Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately(
+            bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           viewer {
+                             name
+                           }
+                         }
+
+                         fragment Test on Query {
+                           viewer {
+                             userId
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_SubField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             userId @skip(if: $skip)
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             ...Test @skip(if: $skip)
+                             name
+                           }
+                         }
+
+                         fragment Test on Viewer {
+                           userId
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_SubField_Selected_Separately(
+        bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer!
+            }
+
+            type Viewer {
+              userId: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           viewer {
+                             ...Test @skip(if: $skip)
+                             userId
+                             name
+                           }
+                         }
+
+                         fragment Test on Viewer {
+                           userId
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    #endregion
+
+    #region Resolve Sequence
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_RootField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product @skip(if: $skip) {
+                             id
+                             brand {
+                               id
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_RootField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                         }
+
+                         fragment Test on Query {
+                           product {
+                             id
+                             brand {
+                               id
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphA.HasReceivedRequest);
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+              other: String
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product @skip(if: $skip) {
+                             id
+                             brand {
+                               id
+                               name
+                             }
+                           }
+                           other
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+              other: String
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           ...Test @skip(if: $skip)
+                           other
+                         }
+
+                         fragment Test on Query {
+                           product {
+                             id
+                             brand {
+                               id
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_EntryField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand @skip(if: $skip) {
+                               id
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_EntryField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             ...Test @skip(if: $skip)
+                           }
+                         }
+
+                         fragment Test on Product {
+                           brand {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              other: String!
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand @skip(if: $skip) {
+                               id
+                               name
+                             }
+                             other
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+              productById(id: ID!): Product
+            }
+
+            type Product implements Node {
+              id: ID!
+              other: String!
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             ...Test @skip(if: $skip)
+                             other
+                           }
+                         }
+
+                         fragment Test on Product {
+                           brand {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             ...Test @skip(if: $skip)
+                             brand {
+                               id
+                               name
+                             }
+                           }
+                         }
+
+                         fragment Test on Product {
+                           brand {
+                             id
+                             name
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_SubField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand {
+                               id
+                               name @skip(if: $skip)
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_SubField_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+              other: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand {
+                               id
+                               name @skip(if: $skip)
+                               other
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_SubField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand {
+                               id
+                               ...Test @skip(if: $skip)
+                             }
+                           }
+                         }
+
+                         fragment Test on Brand {
+                           name
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+              other: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand {
+                               id
+                               ...Test @skip(if: $skip)
+                               other
+                             }
+                           }
+                         }
+
+                         fragment Test on Brand {
+                           name
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              brand: Brand!
+            }
+
+            type Brand {
+              id: ID!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              brandById(id: ID!): Brand
+            }
+
+            type Brand implements Node {
+              id: ID!
+              name: String!
+            }
+
+            interface Node {
+              id: ID!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             id
+                             brand {
+                               id
+                               ...Test @skip(if: $skip)
+                               name
+                             }
+                           }
+                         }
+
+                         fragment Test on Brand {
+                           name
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    #endregion
+
+    #region ResolveByKey
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResolveByKey_Skip_On_SubField(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              products: [Product!]
+            }
+
+            type Product {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productsById(ids: [ID!]!): [Product]
+            }
+
+            type Product {
+              id: ID!
+              price: Int!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           products {
+                             id
+                             name
+                             price @skip(if: $skip)
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResolveByKey_Skip_On_SubField_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              products: [Product!]
+            }
+
+            type Product {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productsById(ids: [ID!]!): [Product]
+            }
+
+            type Product {
+              id: ID!
+              price: Int!
+              other: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           products {
+                             id
+                             name
+                             price @skip(if: $skip)
+                             other
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResolveByKey_Skip_On_SubField_Fragment(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              products: [Product!]
+            }
+
+            type Product {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productsById(ids: [ID!]!): [Product]
+            }
+
+            type Product {
+              id: ID!
+              price: Int!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           products {
+                             id
+                             name
+                             ...Test @skip(if: $skip)
+                           }
+                         }
+
+                         fragment Test on Product {
+                           price
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              products: [Product!]
+            }
+
+            type Product {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productsById(ids: [ID!]!): [Product]
+            }
+
+            type Product {
+              id: ID!
+              price: Int!
+              other: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           products {
+                             id
+                             name
+                             ...Test @skip(if: $skip)
+                             other
+                           }
+                         }
+
+                         fragment Test on Product {
+                           price
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result, postFix: skip);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResolveByKey_Skip_On_SubField_Fragment_SubField_Selected_Separately(bool skip)
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              products: [Product!]
+            }
+
+            type Product {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              productsById(ids: [ID!]!): [Product]
+            }
+
+            type Product {
+              id: ID!
+              price: Int!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           products {
+                             id
+                             name
+                             ...Test @skip(if: $skip)
+                             price
+                           }
+                         }
+
+                         fragment Test on Product {
+                           price
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = skip })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    #endregion
+}

--- a/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
@@ -153,7 +153,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected(bool skip)
     {
@@ -297,7 +297,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task EntityResolver_Skip_On_SubField_Fragment(bool skip)
     {
@@ -398,7 +398,7 @@ public class SkipTests(ITestOutputHelper output)
     #region Parallel Resolve
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Parallel_Resolve_Skip_On_EntryField(bool skip)
     {
@@ -506,7 +506,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Parallel_Resolve_Skip_On_EntryField_Fragment(bool skip)
     {
@@ -565,7 +565,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected(bool skip)
     {
@@ -731,7 +731,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Parallel_Resolve_Skip_On_SubField_Fragment(bool skip)
     {
@@ -1130,7 +1130,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Not sure what correct behavior would be")]
     [InlineData(false)]
     public async Task
         Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately(
@@ -1241,7 +1241,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Not sure what correct behavior would be")]
     [InlineData(false)]
     public async Task Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment(bool skip)
     {
@@ -1291,6 +1291,10 @@ public class SkipTests(ITestOutputHelper output)
 
         // assert
         MatchMarkdownSnapshot(request, result, postFix: skip);
+        if (skip)
+        {
+            Assert.False(subgraphB.HasReceivedRequest);
+        }
     }
 
     [Theory]
@@ -1353,7 +1357,7 @@ public class SkipTests(ITestOutputHelper output)
     #region Resolve Sequence
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_RootField(bool skip)
     {
@@ -1420,7 +1424,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_RootField_Fragment(bool skip)
     {
@@ -1559,7 +1563,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected(bool skip)
     {
@@ -1697,7 +1701,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_EntryField_Fragment(bool skip)
     {
@@ -1791,7 +1795,7 @@ public class SkipTests(ITestOutputHelper output)
         var subgraphB = await TestSubgraph.CreateAsync(
             """
             type Query {
-              brandById(id: ID!): Brand
+              brandById(id: ID!): Bran
               productById(id: ID!): Product
             }
 
@@ -1836,7 +1840,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected(bool skip)
     {
@@ -1979,7 +1983,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_SubField(bool skip)
     {
@@ -2109,7 +2113,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_SubField_Fragment(bool skip)
     {
@@ -2179,7 +2183,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected(bool skip)
     {
@@ -2318,7 +2322,7 @@ public class SkipTests(ITestOutputHelper output)
     #region ResolveByKey
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task ResolveByKey_Skip_On_SubField(bool skip)
     {
@@ -2428,7 +2432,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "Subgraph unnecessarily called")]
     [InlineData(false)]
     public async Task ResolveByKey_Skip_On_SubField_Fragment(bool skip)
     {
@@ -2488,7 +2492,7 @@ public class SkipTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [InlineData(true)]
+    [InlineData(true, Skip = "@skip isn't forwarded correctly")]
     [InlineData(false)]
     public async Task ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected(bool skip)
     {

--- a/src/HotChocolate/Fusion/test/Core.Tests/TestHelper.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/TestHelper.cs
@@ -11,23 +11,21 @@ namespace HotChocolate.Fusion;
 
 internal static class TestHelper
 {
-    // TODO: Temporary
-    public static async Task<IExecutionResult> ProduceProperError(string schemaText, string request)
-    {
-        var subgraph = await TestSubgraph.CreateAsync(schemaText);
-        var executor = await subgraph.TestServer.Services.GetRequestExecutorAsync();
-
-        return await executor.ExecuteAsync(request);
-    }
+    public static void MatchMarkdownSnapshot(
+        IOperationRequest request,
+        IExecutionResult result,
+        object? postFix = null)
+        => MatchMarkdownSnapshot(request.Document?.ToString() ?? string.Empty, result, postFix);
 
     public static void MatchMarkdownSnapshot(
         string requestText,
-        IExecutionResult result)
+        IExecutionResult result,
+        object? postFix = null)
     {
-        var snapshot = new Snapshot();
-        var request = Utf8GraphQLParser.Parse(requestText);
+        var snapshot = new Snapshot(postFix?.ToString());
+        var requestDocument = Utf8GraphQLParser.Parse(requestText);
 
-        CollectSnapshotData(snapshot, request, result);
+        CollectSnapshotData(snapshot, requestDocument, result);
         snapshot.MatchMarkdownSnapshot();
     }
 

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_False.md
@@ -27,7 +27,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-120894E3876F3FBD797F056121AA37C7EB234DA8
+349C194994A0E867AC52596C3042DCA90B529A8B
 ```
 
 ## QueryPlan
@@ -42,8 +42,13 @@ query Test($skip: Boolean!) {
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
-        "selectionSetId": 0
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
       },
       {
         "type": "Compose",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_False.md
@@ -1,0 +1,58 @@
+# EntityResolver_Skip_On_EntityResolver
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") @skip(if: $skip) {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+120894E3876F3FBD797F056121AA37C7EB234DA8
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_EntityResolver_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_EntityResolver_Selected_Separately.md
@@ -1,0 +1,66 @@
+# EntityResolver_Skip_On_EntityResolver_Fragment_EntityResolver_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  productById(id: "1") {
+    id
+    name
+  }
+}
+
+fragment Test on Query {
+  productById(id: "1") {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+FD8123BBA58871A09E0E6F6C118EE453FBD7046F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) productById(id: \u00221\u0022) { id name } } fragment Test on Query { productById(id: \u00221\u0022) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_False.md
@@ -1,0 +1,62 @@
+# EntityResolver_Skip_On_EntityResolver_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  productById(id: "1") {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+299C3A16E021343840D26468051FDFFA6D9D7878
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { productById(id: \u00221\u0022) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected_False.md
@@ -1,0 +1,64 @@
+# EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string"
+    },
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  productById(id: "1") {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+82F401D4DDCF4CA99A4426A0DBAB4D69CD3F13A2
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { productById(id: \u00221\u0022) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected_True.md
@@ -1,0 +1,60 @@
+# EntityResolver_Skip_On_EntityResolver_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  productById(id: "1") {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+82F401D4DDCF4CA99A4426A0DBAB4D69CD3F13A2
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { productById(id: \u00221\u0022) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Fragment_True.md
@@ -1,0 +1,57 @@
+# EntityResolver_Skip_On_EntityResolver_Fragment
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  productById(id: "1") {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+299C3A16E021343840D26468051FDFFA6D9D7878
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { productById(id: \u00221\u0022) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_False.md
@@ -29,7 +29,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-FD935DE55C30F33FFEE00968D558446067817DE3
+9C12237B1A40129B239D76EA6B2F29D0D1305240
 ```
 
 ## QueryPlan
@@ -44,8 +44,13 @@ FD935DE55C30F33FFEE00968D558446067817DE3
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
-        "selectionSetId": 0
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } other }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
       },
       {
         "type": "Compose",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_False.md
@@ -1,0 +1,60 @@
+# EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "id": "1",
+      "name": "string"
+    },
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") @skip(if: $skip) {
+    id
+    name
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+FD935DE55C30F33FFEE00968D558446067817DE3
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_True.md
@@ -25,7 +25,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-FD935DE55C30F33FFEE00968D558446067817DE3
+9C12237B1A40129B239D76EA6B2F29D0D1305240
 ```
 
 ## QueryPlan
@@ -40,8 +40,13 @@ FD935DE55C30F33FFEE00968D558446067817DE3
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
-        "selectionSetId": 0
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } other }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
       },
       {
         "type": "Compose",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected_True.md
@@ -1,0 +1,56 @@
+# EntityResolver_Skip_On_EntityResolver_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") @skip(if: $skip) {
+    id
+    name
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+FD935DE55C30F33FFEE00968D558446067817DE3
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } other }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_True.md
@@ -22,7 +22,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-120894E3876F3FBD797F056121AA37C7EB234DA8
+349C194994A0E867AC52596C3042DCA90B529A8B
 ```
 
 ## QueryPlan
@@ -37,8 +37,13 @@ query Test($skip: Boolean!) {
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
-        "selectionSetId": 0
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
       },
       {
         "type": "Compose",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_EntityResolver_True.md
@@ -1,0 +1,53 @@
+# EntityResolver_Skip_On_EntityResolver
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") @skip(if: $skip) {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+120894E3876F3FBD797F056121AA37C7EB234DA8
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) @skip(if: $skip) { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { id name } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_False.md
@@ -1,0 +1,63 @@
+# EntityResolver_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "name": "string",
+      "price": 123.456
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") {
+    name @skip(if: $skip)
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+38DB93D5058D1661AB219912CD754C469DB36C49
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) { name @skip(if: $skip) price } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) { name @skip(if: $skip) price } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_False.md
@@ -1,0 +1,62 @@
+# EntityResolver_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "name": "string",
+      "price": 123.456
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") {
+    ... Test @skip(if: $skip)
+    price
+  }
+}
+
+fragment Test on Product {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+F70E2C57BE7C90427FF9E449DE7F1251066313CE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) { ... Test @skip(if: $skip) price } } fragment Test on Product { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { name price } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -1,0 +1,63 @@
+# EntityResolver_Skip_On_SubField_Fragment_SubField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "name": "string",
+      "price": 123.456
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") {
+    ... Test @skip(if: $skip)
+    name
+    price
+  }
+}
+
+fragment Test on Product {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+CE8F8A324258B4FB0800D2D67B1B7582688DA221
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) { ... Test @skip(if: $skip) name price } } fragment Test on Product { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { name price } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_Fragment_True.md
@@ -1,0 +1,61 @@
+# EntityResolver_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "price": 123.456
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") {
+    ... Test @skip(if: $skip)
+    price
+  }
+}
+
+fragment Test on Product {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+F70E2C57BE7C90427FF9E449DE7F1251066313CE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) { ... Test @skip(if: $skip) price } } fragment Test on Product { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { productById(id: \u00221\u0022) { name price } }",
+        "selectionSetId": 0
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.EntityResolver_Skip_On_SubField_True.md
@@ -1,0 +1,62 @@
+# EntityResolver_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "productById": {
+      "price": 123.456
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  productById(id: "1") {
+    name @skip(if: $skip)
+    price
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+38DB93D5058D1661AB219912CD754C469DB36C49
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { productById(id: \u00221\u0022) { name @skip(if: $skip) price } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { productById(id: \u00221\u0022) { name @skip(if: $skip) price } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_False.md
@@ -4,52 +4,12 @@
 
 ```json
 {
-  "errors": [
-    {
-      "message": "The following variables were not declared: skip.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 1
-        }
-      ],
-      "extensions": {
-        "specifiedBy": "https://spec.graphql.org/October2021/#sec-All-Variable-Uses-Defined"
-      }
-    },
-    {
-      "message": "Cannot return null for non-nullable field.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "viewer"
-      ],
-      "extensions": {
-        "code": "HC0018"
-      }
-    },
-    {
-      "message": "Cannot return null for non-nullable field.",
-      "locations": [
-        {
-          "line": 3,
-          "column": 5
-        }
-      ],
-      "path": [
-        "viewer",
-        "userId"
-      ],
-      "extensions": {
-        "code": "HC0018"
-      }
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
     }
-  ],
-  "data": null
+  }
 }
 ```
 
@@ -67,7 +27,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-7F12D99D8CEC526D1D2BED58DFDC912E7AEE17BF
+9B94B894786FE90D76FAB8290F12CD0CBE51C564
 ```
 
 ## QueryPlan
@@ -85,14 +45,24 @@ query Test($skip: Boolean!) {
           {
             "type": "Resolve",
             "subgraph": "Subgraph_1",
-            "document": "query Test_1 { viewer { name } }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_2 { viewer @skip(if: $skip) { userId } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { viewer @skip(if: $skip) { userId } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_False.md
@@ -1,0 +1,109 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "The following variables were not declared: skip.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 1
+        }
+      ],
+      "extensions": {
+        "specifiedBy": "https://spec.graphql.org/October2021/#sec-All-Variable-Uses-Defined"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "userId"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer @skip(if: $skip) {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+7F12D99D8CEC526D1D2BED58DFDC912E7AEE17BF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer @skip(if: $skip) { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer @skip(if: $skip) { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately_False.md
@@ -1,0 +1,76 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  viewer {
+    name
+  }
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+DE7FCDAA96445C4383E2C3A94814FD94461B9E3E
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) viewer { name } } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately_True.md
@@ -1,0 +1,75 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Partially_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  viewer {
+    name
+  }
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+DE7FCDAA96445C4383E2C3A94814FD94461B9E3E
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) viewer { name } } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
@@ -1,0 +1,77 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_EntryField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  viewer {
+    userId
+    name
+  }
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+EC537BBD29F26377D1FE5B7E20A94C4A1038A483
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) viewer { userId name } } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_False.md
@@ -1,0 +1,73 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A8CB83116739564244E01F56F4419A743BABD3B4
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected_False.md
@@ -1,0 +1,75 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    },
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+52DDC1FC3CEEDF059D4A4A9B40B5682AD44360F4
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { viewer { userId } other }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected_True.md
@@ -1,0 +1,71 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+52DDC1FC3CEEDF059D4A4A9B40B5682AD44360F4
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { viewer { userId } other }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment_True.md
@@ -1,0 +1,68 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  viewer {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A8CB83116739564244E01F56F4419A743BABD3B4
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { viewer { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_False.md
@@ -4,52 +4,13 @@
 
 ```json
 {
-  "errors": [
-    {
-      "message": "The following variables were not declared: skip.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 1
-        }
-      ],
-      "extensions": {
-        "specifiedBy": "https://spec.graphql.org/October2021/#sec-All-Variable-Uses-Defined"
-      }
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
     },
-    {
-      "message": "Cannot return null for non-nullable field.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "viewer"
-      ],
-      "extensions": {
-        "code": "HC0018"
-      }
-    },
-    {
-      "message": "Cannot return null for non-nullable field.",
-      "locations": [
-        {
-          "line": 4,
-          "column": 5
-        }
-      ],
-      "path": [
-        "viewer",
-        "name"
-      ],
-      "extensions": {
-        "code": "HC0018"
-      }
-    }
-  ],
-  "data": null
+    "other": "string"
+  }
 }
 ```
 
@@ -68,7 +29,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-C45FAA47967851A4B12625CDD756A1C323C162CE
+16940BE29715988F4EFF523764D3BB5B7EFD976E
 ```
 
 ## QueryPlan
@@ -86,14 +47,24 @@ C45FAA47967851A4B12625CDD756A1C323C162CE
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_1 { viewer { userId } other }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { viewer @skip(if: $skip) { userId } other }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",
             "subgraph": "Subgraph_1",
-            "document": "query Test_2 { viewer @skip(if: $skip) { name } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_False.md
@@ -1,0 +1,110 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "The following variables were not declared: skip.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 1
+        }
+      ],
+      "extensions": {
+        "specifiedBy": "https://spec.graphql.org/October2021/#sec-All-Variable-Uses-Defined"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "viewer"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    },
+    {
+      "message": "Cannot return null for non-nullable field.",
+      "locations": [
+        {
+          "line": 4,
+          "column": 5
+        }
+      ],
+      "path": [
+        "viewer",
+        "name"
+      ],
+      "extensions": {
+        "code": "HC0018"
+      }
+    }
+  ],
+  "data": null
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer @skip(if: $skip) {
+    userId
+    name
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+C45FAA47967851A4B12625CDD756A1C323C162CE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer @skip(if: $skip) { userId name } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { viewer { userId } other }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_True.md
@@ -25,7 +25,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-C45FAA47967851A4B12625CDD756A1C323C162CE
+16940BE29715988F4EFF523764D3BB5B7EFD976E
 ```
 
 ## QueryPlan
@@ -43,14 +43,24 @@ C45FAA47967851A4B12625CDD756A1C323C162CE
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_1 { viewer { userId } other }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { viewer @skip(if: $skip) { userId } other }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",
             "subgraph": "Subgraph_1",
-            "document": "query Test_2 { viewer @skip(if: $skip) { name } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected_True.md
@@ -1,0 +1,67 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer @skip(if: $skip) {
+    userId
+    name
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+C45FAA47967851A4B12625CDD756A1C323C162CE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer @skip(if: $skip) { userId name } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { viewer { userId } other }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_True.md
@@ -22,7 +22,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-7F12D99D8CEC526D1D2BED58DFDC912E7AEE17BF
+9B94B894786FE90D76FAB8290F12CD0CBE51C564
 ```
 
 ## QueryPlan
@@ -40,14 +40,24 @@ query Test($skip: Boolean!) {
           {
             "type": "Resolve",
             "subgraph": "Subgraph_1",
-            "document": "query Test_1 { viewer { name } }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { viewer @skip(if: $skip) { name } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_2 { viewer @skip(if: $skip) { userId } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { viewer @skip(if: $skip) { userId } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_EntryField_True.md
@@ -1,0 +1,64 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer @skip(if: $skip) {
+    userId
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+7F12D99D8CEC526D1D2BED58DFDC912E7AEE17BF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer @skip(if: $skip) { userId name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer @skip(if: $skip) { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_False.md
@@ -1,0 +1,74 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    userId @skip(if: $skip)
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+359E27BB01CBCC1B008A003A40263BBE81CA5A5B
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { userId @skip(if: $skip) name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($skip: Boolean!) { viewer { userId @skip(if: $skip) } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_False.md
@@ -1,0 +1,73 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    ... Test @skip(if: $skip)
+    name
+  }
+}
+
+fragment Test on Viewer {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+D71B896CB16891D2B0CA1F6F79ECA60E41F2A41F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { ... Test @skip(if: $skip) name } } fragment Test on Viewer { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -1,0 +1,74 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_SubField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "userId": "1",
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    ... Test @skip(if: $skip)
+    userId
+    name
+  }
+}
+
+fragment Test on Viewer {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+653A2F97D20C9C6C47695F68306379FB45775C7F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { ... Test @skip(if: $skip) userId name } } fragment Test on Viewer { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment_True.md
@@ -1,0 +1,72 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    ... Test @skip(if: $skip)
+    name
+  }
+}
+
+fragment Test on Viewer {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+D71B896CB16891D2B0CA1F6F79ECA60E41F2A41F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { ... Test @skip(if: $skip) name } } fragment Test on Viewer { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { viewer { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_SharedEntryField_Skip_On_SubField_True.md
@@ -1,0 +1,73 @@
+# Parallel_Resolve_SharedEntryField_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    userId @skip(if: $skip)
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+359E27BB01CBCC1B008A003A40263BBE81CA5A5B
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { userId @skip(if: $skip) name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($skip: Boolean!) { viewer { userId @skip(if: $skip) } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_False.md
@@ -1,0 +1,73 @@
+# Parallel_Resolve_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other @skip(if: $skip) {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other @skip(if: $skip) { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_False.md
@@ -31,7 +31,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
+EBF12464BEA547C7E5B76B77619C730E63F9BB78
 ```
 
 ## QueryPlan
@@ -55,8 +55,13 @@ C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_2 { other { userId } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { other @skip(if: $skip) { userId } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately_False.md
@@ -1,0 +1,80 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+011B48529F192BCF168898CCD7B79A8D06AC0006
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { userId } ... Test @skip(if: $skip) } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately_True.md
@@ -1,0 +1,80 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment_EntryField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    userId
+  }
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+011B48529F192BCF168898CCD7B79A8D06AC0006
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { userId } ... Test @skip(if: $skip) } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_False.md
@@ -1,0 +1,77 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+9C2E1B5B1976B055D0F3E9380B846B70B9831BC3
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } ... Test @skip(if: $skip) } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected_False.md
@@ -1,0 +1,79 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    },
+    "another": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  ... Test @skip(if: $skip)
+  another
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+28FA0CC34DE3FA1E5BEC2B3AA2B722B768B80609
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } ... Test @skip(if: $skip) another } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { other { userId } another }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected_True.md
@@ -1,0 +1,76 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "another": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  ... Test @skip(if: $skip)
+  another
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+28FA0CC34DE3FA1E5BEC2B3AA2B722B768B80609
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } ... Test @skip(if: $skip) another } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { other { userId } another }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Fragment_True.md
@@ -1,0 +1,74 @@
+# Parallel_Resolve_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  other {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+9C2E1B5B1976B055D0F3E9380B846B70B9831BC3
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } ... Test @skip(if: $skip) } fragment Test on Query { other { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_False.md
@@ -33,7 +33,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-475C1241AAB636FB74A719B919BDD84C2178326A
+A1607582FDA8ACE7201DD6EECD6EF8922C8D9043
 ```
 
 ## QueryPlan
@@ -51,8 +51,13 @@ query Test($skip: Boolean!) {
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_1 { other { userId } another }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { other @skip(if: $skip) { userId } another }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_False.md
@@ -1,0 +1,75 @@
+# Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    },
+    "another": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other @skip(if: $skip) {
+    userId
+  }
+  another
+}
+```
+
+## QueryPlan Hash
+
+```text
+475C1241AAB636FB74A719B919BDD84C2178326A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other @skip(if: $skip) { userId } another }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { other { userId } another }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_True.md
@@ -1,0 +1,72 @@
+# Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "another": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other @skip(if: $skip) {
+    userId
+  }
+  another
+}
+```
+
+## QueryPlan Hash
+
+```text
+475C1241AAB636FB74A719B919BDD84C2178326A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other @skip(if: $skip) { userId } another }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_1 { other { userId } another }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_2 { viewer { name } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_Other_RootField_Selected_True.md
@@ -30,7 +30,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-475C1241AAB636FB74A719B919BDD84C2178326A
+A1607582FDA8ACE7201DD6EECD6EF8922C8D9043
 ```
 
 ## QueryPlan
@@ -48,8 +48,13 @@ query Test($skip: Boolean!) {
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_1 { other { userId } another }",
-            "selectionSetId": 0
+            "document": "query Test_1($skip: Boolean!) { other @skip(if: $skip) { userId } another }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           },
           {
             "type": "Resolve",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_True.md
@@ -1,0 +1,70 @@
+# Parallel_Resolve_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other @skip(if: $skip) {
+    userId
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other @skip(if: $skip) { userId } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_EntryField_True.md
@@ -28,7 +28,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
+EBF12464BEA547C7E5B76B77619C730E63F9BB78
 ```
 
 ## QueryPlan
@@ -52,8 +52,13 @@ C68ECB4ECD7513E1EB4BBC1EF82D212335091BE6
           {
             "type": "Resolve",
             "subgraph": "Subgraph_2",
-            "document": "query Test_2 { other { userId } }",
-            "selectionSetId": 0
+            "document": "query Test_2($skip: Boolean!) { other @skip(if: $skip) { userId } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_False.md
@@ -1,0 +1,78 @@
+# Parallel_Resolve_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    userId @skip(if: $skip)
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+424991873692932F36F2ED2FCF024547AD0AD47A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { userId @skip(if: $skip) } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($skip: Boolean!) { other { userId @skip(if: $skip) } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_False.md
@@ -1,0 +1,77 @@
+# Parallel_Resolve_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Other {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+673C1AC76B07700826D5C27DD146138C765DA6CB
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { ... Test @skip(if: $skip) } } fragment Test on Other { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -1,0 +1,78 @@
+# Parallel_Resolve_Skip_On_SubField_Fragment_SubField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {
+      "userId": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    userId
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Other {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+B9AFD14189FE2CF8604139F95A0501C33D60BB82
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { userId ... Test @skip(if: $skip) } } fragment Test on Other { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_Fragment_True.md
@@ -1,0 +1,75 @@
+# Parallel_Resolve_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {}
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Other {
+  userId
+}
+```
+
+## QueryPlan Hash
+
+```text
+673C1AC76B07700826D5C27DD146138C765DA6CB
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { ... Test @skip(if: $skip) } } fragment Test on Other { userId }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2 { other { userId } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Parallel_Resolve_Skip_On_SubField_True.md
@@ -1,0 +1,76 @@
+# Parallel_Resolve_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "viewer": {
+      "name": "string"
+    },
+    "other": {}
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  viewer {
+    name
+  }
+  other {
+    userId @skip(if: $skip)
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+424991873692932F36F2ED2FCF024547AD0AD47A
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { viewer { name } other { userId @skip(if: $skip) } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query Test_1 { viewer { name } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($skip: Boolean!) { other { userId @skip(if: $skip) } }",
+            "selectionSetId": 0,
+            "forwardedVariables": [
+              {
+                "variable": "skip"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_False.md
@@ -1,0 +1,105 @@
+# ResolveByKey_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    price @skip(if: $skip)
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+49DCEC3B3A87A360729B0D001F5A6913DC573FD6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name price @skip(if: $skip) } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!, $skip: Boolean!) { productsById(ids: $__fusion_exports__1) { price @skip(if: $skip) __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_False.md
@@ -1,0 +1,104 @@
+# ResolveByKey_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Product {
+  price
+}
+```
+
+## QueryPlan Hash
+
+```text
+89B962E6D6970E4B6797A38CC1AE85501E7486CF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name ... Test @skip(if: $skip) } } fragment Test on Product { price }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
@@ -1,0 +1,108 @@
+# ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    ... Test @skip(if: $skip)
+    other
+  }
+}
+
+fragment Test on Product {
+  price
+}
+```
+
+## QueryPlan Hash
+
+```text
+935028235BB705504E70B07C6D0118B5505183CA
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name ... Test @skip(if: $skip) other } } fragment Test on Product { price }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price other __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected_True.md
@@ -1,0 +1,105 @@
+# ResolveByKey_Skip_On_SubField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "other": "string"
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "other": "string"
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "other": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    ... Test @skip(if: $skip)
+    other
+  }
+}
+
+fragment Test on Product {
+  price
+}
+```
+
+## QueryPlan Hash
+
+```text
+935028235BB705504E70B07C6D0118B5505183CA
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name ... Test @skip(if: $skip) other } } fragment Test on Product { price }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price other __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -1,0 +1,105 @@
+# ResolveByKey_Skip_On_SubField_Fragment_SubField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": 123
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    ... Test @skip(if: $skip)
+    price
+  }
+}
+
+fragment Test on Product {
+  price
+}
+```
+
+## QueryPlan Hash
+
+```text
+EAB85F949C3500001321C9AEBD67AE3760355E3D
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name ... Test @skip(if: $skip) price } } fragment Test on Product { price }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Fragment_True.md
@@ -1,0 +1,101 @@
+# ResolveByKey_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string"
+      },
+      {
+        "id": "2",
+        "name": "string"
+      },
+      {
+        "id": "3",
+        "name": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Product {
+  price
+}
+```
+
+## QueryPlan Hash
+
+```text
+89B962E6D6970E4B6797A38CC1AE85501E7486CF
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name ... Test @skip(if: $skip) } } fragment Test on Product { price }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!) { productsById(ids: $__fusion_exports__1) { price __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Other_Field_Selected_False.md
@@ -1,0 +1,109 @@
+# ResolveByKey_Skip_On_SubField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "price": 123,
+        "other": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    price @skip(if: $skip)
+    other
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+4ADF4130AAF9816DC72A9671227E2151B3E05554
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name price @skip(if: $skip) other } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!, $skip: Boolean!) { productsById(ids: $__fusion_exports__1) { price @skip(if: $skip) other __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_Other_Field_Selected_True.md
@@ -1,0 +1,106 @@
+# ResolveByKey_Skip_On_SubField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string",
+        "other": "string"
+      },
+      {
+        "id": "2",
+        "name": "string",
+        "other": "string"
+      },
+      {
+        "id": "3",
+        "name": "string",
+        "other": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    price @skip(if: $skip)
+    other
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+4ADF4130AAF9816DC72A9671227E2151B3E05554
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name price @skip(if: $skip) other } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!, $skip: Boolean!) { productsById(ids: $__fusion_exports__1) { price @skip(if: $skip) other __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.ResolveByKey_Skip_On_SubField_True.md
@@ -1,0 +1,102 @@
+# ResolveByKey_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "products": [
+      {
+        "id": "1",
+        "name": "string"
+      },
+      {
+        "id": "2",
+        "name": "string"
+      },
+      {
+        "id": "3",
+        "name": "string"
+      }
+    ]
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  products {
+    id
+    name
+    price @skip(if: $skip)
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+49DCEC3B3A87A360729B0D001F5A6913DC573FD6
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { products { id name price @skip(if: $skip) } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { products { id name __fusion_exports__1: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "ResolveByKeyBatch",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: [ID!]!, $skip: Boolean!) { productsById(ids: $__fusion_exports__1) { price @skip(if: $skip) __fusion_exports__1: id } }",
+        "selectionSetId": 1,
+        "path": [
+          "productsById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_False.md
@@ -1,0 +1,97 @@
+# Resolve_Sequence_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand @skip(if: $skip) {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+766DA2342654C1585E6163852A6CEA388399CB8F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand @skip(if: $skip) { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { id brand @skip(if: $skip) { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
@@ -1,0 +1,100 @@
+# Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    ... Test @skip(if: $skip)
+    brand {
+      id
+      name
+    }
+  }
+}
+
+fragment Test on Product {
+  brand {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+E29BD8AE1B9E6A7AC6032E10211DAA4AD174FC05
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id ... Test @skip(if: $skip) brand { id name } } } fragment Test on Product { brand { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_False.md
@@ -1,0 +1,96 @@
+# Resolve_Sequence_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Product {
+  brand {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+E44128C141B47EF61E050F0DD1FEE670AADE3125
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id ... Test @skip(if: $skip) } } fragment Test on Product { brand { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_False.md
@@ -1,0 +1,122 @@
+# Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      },
+      "other": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    ... Test @skip(if: $skip)
+    other
+  }
+}
+
+fragment Test on Product {
+  brand {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+D46EDD9E2C2343DBA4034F26AF6A89C30A23A2BE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id ... Test @skip(if: $skip) other } } fragment Test on Product { brand { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } __fusion_exports__2: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          },
+          {
+            "variable": "__fusion_exports__2"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+            "selectionSetId": 2,
+            "path": [
+              "brandById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__1"
+              }
+            ]
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_3($__fusion_exports__2: ID!) { productById(id: $__fusion_exports__2) { other } }",
+            "selectionSetId": 1,
+            "path": [
+              "productById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1,
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id",
+    "__fusion_exports__2": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_True.md
@@ -1,0 +1,118 @@
+# Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "other": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    ... Test @skip(if: $skip)
+    other
+  }
+}
+
+fragment Test on Product {
+  brand {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+D46EDD9E2C2343DBA4034F26AF6A89C30A23A2BE
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id ... Test @skip(if: $skip) other } } fragment Test on Product { brand { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } __fusion_exports__2: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          },
+          {
+            "variable": "__fusion_exports__2"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+            "selectionSetId": 2,
+            "path": [
+              "brandById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__1"
+              }
+            ]
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_3($__fusion_exports__2: ID!) { productById(id: $__fusion_exports__2) { other } }",
+            "selectionSetId": 1,
+            "path": [
+              "productById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1,
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id",
+    "__fusion_exports__2": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_True.md
@@ -1,0 +1,92 @@
+# Resolve_Sequence_Skip_On_EntryField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    ... Test @skip(if: $skip)
+  }
+}
+
+fragment Test on Product {
+  brand {
+    id
+    name
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+E44128C141B47EF61E050F0DD1FEE670AADE3125
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id ... Test @skip(if: $skip) } } fragment Test on Product { brand { id name } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_False.md
@@ -1,0 +1,123 @@
+# Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      },
+      "other": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand @skip(if: $skip) {
+      id
+      name
+    }
+    other
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+187D3C73D0E5FFA7512DC6F8A2FFBC03E623CF85
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand @skip(if: $skip) { id name } other } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { id brand @skip(if: $skip) { id __fusion_exports__1: id } __fusion_exports__2: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          },
+          {
+            "variable": "__fusion_exports__2"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+            "selectionSetId": 2,
+            "path": [
+              "brandById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__1"
+              }
+            ]
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_3($__fusion_exports__2: ID!) { productById(id: $__fusion_exports__2) { other } }",
+            "selectionSetId": 1,
+            "path": [
+              "productById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1,
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id",
+    "__fusion_exports__2": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_True.md
@@ -1,0 +1,119 @@
+# Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "other": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand @skip(if: $skip) {
+      id
+      name
+    }
+    other
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+187D3C73D0E5FFA7512DC6F8A2FFBC03E623CF85
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand @skip(if: $skip) { id name } other } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { id brand @skip(if: $skip) { id __fusion_exports__1: id } __fusion_exports__2: id } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          },
+          {
+            "variable": "__fusion_exports__2"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+            "selectionSetId": 2,
+            "path": [
+              "brandById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__1"
+              }
+            ]
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query Test_3($__fusion_exports__2: ID!) { productById(id: $__fusion_exports__2) { other } }",
+            "selectionSetId": 1,
+            "path": [
+              "productById"
+            ],
+            "requires": [
+              {
+                "variable": "__fusion_exports__2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          1,
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id",
+    "__fusion_exports__2": "Product_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_True.md
@@ -1,0 +1,93 @@
+# Resolve_Sequence_Skip_On_EntryField
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand @skip(if: $skip) {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+766DA2342654C1585E6163852A6CEA388399CB8F
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand @skip(if: $skip) { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { id brand @skip(if: $skip) { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
@@ -33,7 +33,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-D167607A2D21385828EFFCF88ED8194F8B142ECA
+BC8B783BA7D23AED2207786ABCBE977B2138450C
 ```
 
 ## QueryPlan
@@ -48,11 +48,16 @@ D167607A2D21385828EFFCF88ED8194F8B142ECA
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) { id brand { id __fusion_exports__1: id } } }",
         "selectionSetId": 0,
         "provides": [
           {
             "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
@@ -1,0 +1,92 @@
+# Resolve_Sequence_Skip_On_RootField
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+D167607A2D21385828EFFCF88ED8194F8B142ECA
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_False.md
@@ -1,0 +1,96 @@
+# Resolve_Sequence_Skip_On_RootField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A6EBFB1FAE1EEF9C6E715C47035579475761DC8C
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { product { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_False.md
@@ -1,0 +1,98 @@
+# Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    },
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+6E1700DC6EE5369F86BDD345970684098CE4EFA2
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { product { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_True.md
@@ -1,0 +1,91 @@
+# Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+  other
+}
+
+fragment Test on Query {
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+6E1700DC6EE5369F86BDD345970684098CE4EFA2
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) other } fragment Test on Query { product { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_True.md
@@ -1,0 +1,88 @@
+# Resolve_Sequence_Skip_On_RootField_Fragment
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  ... Test @skip(if: $skip)
+}
+
+fragment Test on Query {
+  product {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+A6EBFB1FAE1EEF9C6E715C47035579475761DC8C
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { ... Test @skip(if: $skip) } fragment Test on Query { product { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
@@ -1,0 +1,94 @@
+# Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    },
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    id
+    brand {
+      id
+      name
+    }
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { id brand { id name } } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
@@ -35,7 +35,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
+12CBB47F127A11FEA0B752CFECDF5D239AEDBA24
 ```
 
 ## QueryPlan
@@ -50,11 +50,16 @@ EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) { id brand { id __fusion_exports__1: id } } other }",
         "selectionSetId": 0,
         "provides": [
           {
             "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_True.md
@@ -28,7 +28,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
+12CBB47F127A11FEA0B752CFECDF5D239AEDBA24
 ```
 
 ## QueryPlan
@@ -43,11 +43,16 @@ EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) { id brand { id __fusion_exports__1: id } } other }",
         "selectionSetId": 0,
         "provides": [
           {
             "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_True.md
@@ -1,0 +1,87 @@
+# Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "other": "string"
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    id
+    brand {
+      id
+      name
+    }
+  }
+  other
+}
+```
+
+## QueryPlan Hash
+
+```text
+EBACAB70FC88EC077724B7663EB6ABC1F26D5E28
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { id brand { id name } } other }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } other }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_True.md
@@ -1,0 +1,84 @@
+# Resolve_Sequence_Skip_On_RootField
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    id
+    brand {
+      id
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+D167607A2D21385828EFFCF88ED8194F8B142ECA
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { id brand { id name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_True.md
@@ -25,7 +25,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-D167607A2D21385828EFFCF88ED8194F8B142ECA
+BC8B783BA7D23AED2207786ABCBE977B2138450C
 ```
 
 ## QueryPlan
@@ -40,11 +40,16 @@ D167607A2D21385828EFFCF88ED8194F8B142ECA
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) { id brand { id __fusion_exports__1: id } } }",
         "selectionSetId": 0,
         "provides": [
           {
             "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
           }
         ]
       },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_False.md
@@ -1,0 +1,97 @@
+# Resolve_Sequence_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      name @skip(if: $skip)
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+3606D677DEA5F72F4BCFFF22476A493A194AF5F9
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id name @skip(if: $skip) } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!, $skip: Boolean!) { brandById(id: $__fusion_exports__1) { name @skip(if: $skip) } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_False.md
@@ -1,0 +1,96 @@
+# Resolve_Sequence_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      ... Test @skip(if: $skip)
+    }
+  }
+}
+
+fragment Test on Brand {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+9334F2320F732410E6A92FA83B655CA678BD80E8
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id ... Test @skip(if: $skip) } } } fragment Test on Brand { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
@@ -1,0 +1,98 @@
+# Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string",
+        "other": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      ... Test @skip(if: $skip)
+      other
+    }
+  }
+}
+
+fragment Test on Brand {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+8D098A71B600717F663C5F09256662A3EF6B7501
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id ... Test @skip(if: $skip) other } } } fragment Test on Brand { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name other } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_True.md
@@ -1,0 +1,97 @@
+# Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "other": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      ... Test @skip(if: $skip)
+      other
+    }
+  }
+}
+
+fragment Test on Brand {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+8D098A71B600717F663C5F09256662A3EF6B7501
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id ... Test @skip(if: $skip) other } } } fragment Test on Brand { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name other } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -1,0 +1,97 @@
+# Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      ... Test @skip(if: $skip)
+      name
+    }
+  }
+}
+
+fragment Test on Brand {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+DC36350D9F22A68467B13E2E20BF6A02FCFF791C
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id ... Test @skip(if: $skip) name } } } fragment Test on Brand { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_True.md
@@ -1,0 +1,95 @@
+# Resolve_Sequence_Skip_On_SubField_Fragment
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      ... Test @skip(if: $skip)
+    }
+  }
+}
+
+fragment Test on Brand {
+  name
+}
+```
+
+## QueryPlan Hash
+
+```text
+9334F2320F732410E6A92FA83B655CA678BD80E8
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id ... Test @skip(if: $skip) } } } fragment Test on Brand { name }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!) { brandById(id: $__fusion_exports__1) { name } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_False.md
@@ -1,0 +1,99 @@
+# Resolve_Sequence_Skip_On_SubField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "name": "string",
+        "other": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      name @skip(if: $skip)
+      other
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+06ADDD5F781B1908E4503D6617A487BE592DB04D
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id name @skip(if: $skip) other } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!, $skip: Boolean!) { brandById(id: $__fusion_exports__1) { name @skip(if: $skip) other } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_True.md
@@ -1,0 +1,98 @@
+# Resolve_Sequence_Skip_On_SubField_Other_Field_Selected
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1",
+        "other": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      name @skip(if: $skip)
+      other
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+06ADDD5F781B1908E4503D6617A487BE592DB04D
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id name @skip(if: $skip) other } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!, $skip: Boolean!) { brandById(id: $__fusion_exports__1) { name @skip(if: $skip) other } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_True.md
@@ -1,0 +1,96 @@
+# Resolve_Sequence_Skip_On_SubField
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "id": "1",
+      "brand": {
+        "id": "1"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    id
+    brand {
+      id
+      name @skip(if: $skip)
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+3606D677DEA5F72F4BCFFF22476A493A194AF5F9
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { id brand { id name @skip(if: $skip) } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1 { product { id brand { id __fusion_exports__1: id } } }",
+        "selectionSetId": 0,
+        "provides": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      },
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_2",
+        "document": "query Test_2($__fusion_exports__1: ID!, $skip: Boolean!) { brandById(id: $__fusion_exports__1) { name @skip(if: $skip) } }",
+        "selectionSetId": 2,
+        "path": [
+          "brandById"
+        ],
+        "requires": [
+          {
+            "variable": "__fusion_exports__1"
+          }
+        ],
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          2
+        ]
+      }
+    ]
+  },
+  "state": {
+    "__fusion_exports__1": "Brand_id"
+  }
+}
+```
+


### PR DESCRIPTION
Adds test cases for  various `@skip` scenarios. Some use cases like aliases and `@require` are still missing.
I haven't yet added `@include` tests, since it would be too cumbersome to keep the `@skip` and `@include` tests in sync at the moment. I think once the test coverage is good, we can duplicate the `@skip` tests and repurpose them for `@include`.

Besides adding the tests, this PR also fixes an issue where `@skip` isn't forwarded on root selections. The fix isn't pretty, but it's inline with a similar fix done for `@skip` in the past. The effective changes can be seen here: https://github.com/ChilliCream/graphql-platform/pull/7353/commits/bb42a7d80078872b8659ab514a24002b9066b4d1

While the perceive result is correct in all the cases I've tested, what's happening behind the scenes isn't. In some cases a query plan node is needlessly executed or the skipped selection is still fetched from the subgraph, but stripped out after the fact. I've skipped all failing tests for now.

Maybe it would also be cool to visualize the dependency of when a query plan node is skipped in the query plan. Currently nodes might be skipped conditionally, but this isn't shown in the JSON-based query plan.