### PR TITLE
Add PagingOptions.IncludeNodesField option

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
@@ -358,7 +358,8 @@ public static class PagingObjectFieldDescriptorExtensions
         return CreateConnectionType(
             connectionName,
             nodeType,
-            options.IncludeTotalCount ?? false);
+            options.IncludeTotalCount ?? false,
+            options.IncludeNodesField ?? IncludeNodesField);
     }
 
     private static CursorPagingProvider ResolvePagingProvider(
@@ -420,13 +421,14 @@ public static class PagingObjectFieldDescriptorExtensions
     private static TypeReference CreateConnectionType(
         string? connectionName,
         TypeReference nodeType,
-        bool withTotalCount)
+        bool includeTotalCount,
+        bool includeNodesField)
     {
         return connectionName is null
             ? TypeReference.Create(
                 "HotChocolate_Types_Connection",
                 nodeType,
-                _ => new ConnectionType(nodeType, withTotalCount),
+                _ => new ConnectionType(nodeType, includeTotalCount, includeNodesField),
                 TypeContext.Output)
             : TypeReference.Create(
                 connectionName + "Connection",
@@ -434,7 +436,8 @@ public static class PagingObjectFieldDescriptorExtensions
                 factory: _ => new ConnectionType(
                     connectionName,
                     nodeType,
-                    withTotalCount));
+                    includeTotalCount,
+                    includeNodesField));
     }
 
     private static string EnsureConnectionNameCasing(string connectionName)

--- a/src/HotChocolate/Core/src/Types/Types/Pagination/PagingDefaults.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Pagination/PagingDefaults.cs
@@ -15,4 +15,6 @@ public static class PagingDefaults
     public const bool InferCollectionSegmentNameFromField = true;
 
     public const bool RequirePagingBoundaries = false;
+
+    public const bool IncludeNodesField = true;
 }

--- a/src/HotChocolate/Core/src/Types/Types/Pagination/PagingOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Pagination/PagingOptions.cs
@@ -18,8 +18,9 @@ public class PagingOptions
     public int? MaxPageSize { get; set; }
 
     /// <summary>
-    /// Defines if the total count of the paged data set
-    /// shall be included into the paging result type.
+    /// Defines whether a <c>totalCount</c> field shall be
+    /// exposed on the Connection type, returning the total
+    /// count of items in the paginated data set.
     /// </summary>
     public bool? IncludeTotalCount { get; set; }
 
@@ -52,6 +53,13 @@ public class PagingOptions
     public string? ProviderName { get; set; }
 
     /// <summary>
+    /// Defines whether a <c>nodes</c> field shall be
+    /// exposed on the Connection type, returning the
+    /// flattened nodes of the <c>edges</c> field.
+    /// </summary>
+    public bool? IncludeNodesField { get; set; }
+
+    /// <summary>
     /// Merges the <paramref name="other"/> options into this options instance wherever
     /// a property is not set.
     /// </summary>
@@ -68,6 +76,7 @@ public class PagingOptions
         InferConnectionNameFromField ??= other.InferConnectionNameFromField;
         InferCollectionSegmentNameFromField ??= other.InferCollectionSegmentNameFromField;
         ProviderName ??= other.ProviderName;
+        IncludeNodesField ??= other.IncludeNodesField;
     }
 
     /// <summary>
@@ -83,6 +92,7 @@ public class PagingOptions
             RequirePagingBoundaries = RequirePagingBoundaries,
             InferConnectionNameFromField = InferConnectionNameFromField,
             InferCollectionSegmentNameFromField = InferCollectionSegmentNameFromField,
-            ProviderName = ProviderName
+            ProviderName = ProviderName,
+            IncludeNodesField = IncludeNodesField
         };
 }

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
@@ -24,6 +24,21 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task IncludeNodesField_False()
+    {
+        var executor =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryType>()
+                .ModifyPagingOptions(o => o.IncludeNodesField = false)
+                .Services
+                .BuildServiceProvider()
+                .GetRequestExecutorAsync();
+
+        executor.Schema.Print().MatchSnapshot();
+    }
+
+    [Fact]
     public async Task SetPagingOptionsIsStillApplied()
     {
         var executor =

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.IncludeNodesField_False.snap
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.IncludeNodesField_False.snap
@@ -1,0 +1,75 @@
+﻿schema {
+  query: Query
+}
+
+"A connection to a list of items."
+type ExplicitTypeConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [ExplicitTypeEdge!]
+}
+
+"An edge in a connection."
+type ExplicitTypeEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: String!
+}
+
+type Foo {
+  bar: String!
+}
+
+"A connection to a list of items."
+type LettersConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [LettersEdge!]
+}
+
+"An edge in a connection."
+type LettersEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: String!
+}
+
+"A connection to a list of items."
+type NestedObjectListConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [NestedObjectListEdge!]
+  "Identifies the total count of items in the connection."
+  totalCount: Int!
+}
+
+"An edge in a connection."
+type NestedObjectListEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: [Foo!]!
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+
+type Query {
+  letters("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): LettersConnection
+  explicitType("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): ExplicitTypeConnection
+  nestedObjectList("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): NestedObjectListConnection
+}


### PR DESCRIPTION
This PR adds a new `IncludeNodesField` option on the `PagingOptions` that allows to turn off the generation of the `nodes` field on the `Connection` type.

The nodes fields is mostly for convenience, but it becomes a bit bothersome when using the Relay client and unexperienced Frontend developers. Some of the things that can go wrong and why it might be a good idea to disable the `nodes` field:
- Developers selecting both the `edges` and `nodes` field from different fragments, leading to double the amount of data being returned
- If `nodes` is being used, Relay can't delete stuff from the list automatically, because it doesn't "know" about the `nodes` field