### PR TITLE
Omitted requireOneSlicingArgument if not set in listSize directive

### DIFF
--- a/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeAttribute.cs
+++ b/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeAttribute.cs
@@ -13,6 +13,7 @@ namespace HotChocolate.CostAnalysis.Types;
 public sealed class ListSizeAttribute : ObjectFieldDescriptorAttribute
 {
     private readonly int? _assumedSize;
+    private readonly bool? _requireOneSlicingArgument;
 
     /// <summary>
     /// The maximum length of the list returned by this field.
@@ -38,7 +39,11 @@ public sealed class ListSizeAttribute : ObjectFieldDescriptorAttribute
     /// Whether to require a single slicing argument in the query. If that is not the case (i.e., if
     /// none or multiple slicing arguments are present), the static analysis will throw an error.
     /// </summary>
-    public bool RequireOneSlicingArgument { get; init; } = true;
+    public bool RequireOneSlicingArgument
+    {
+        get => _requireOneSlicingArgument ?? true;
+        init => _requireOneSlicingArgument = value;
+    }
 
     protected override void OnConfigure(
         IDescriptorContext context,
@@ -50,6 +55,6 @@ public sealed class ListSizeAttribute : ObjectFieldDescriptorAttribute
                 _assumedSize,
                 SlicingArguments?.ToImmutableArray(),
                 SizedFields?.ToImmutableArray(),
-                RequireOneSlicingArgument));
+                _requireOneSlicingArgument));
     }
 }

--- a/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeDirective.cs
+++ b/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeDirective.cs
@@ -28,11 +28,7 @@ public sealed class ListSizeDirective
         AssumedSize = assumedSize;
         SlicingArguments = slicingArguments ?? ImmutableArray<string>.Empty;
         SizedFields = sizedFields ?? ImmutableArray<string>.Empty;
-
-        // https://ibm.github.io/graphql-specs/cost-spec.html#sec-requireOneSlicingArgument
-        // Per default, requireOneSlicingArgument is enabled,
-        // and has to be explicitly disabled if not desired for a field.
-        RequireOneSlicingArgument = SlicingArguments is { Length: > 0 } && (requireOneSlicingArgument ?? true);
+        RequireOneSlicingArgument = requireOneSlicingArgument;
     }
 
     /// <summary>
@@ -73,5 +69,5 @@ public sealed class ListSizeDirective
     /// <seealso href="https://ibm.github.io/graphql-specs/cost-spec.html#sec-requireOneSlicingArgument">
     /// Specification URL
     /// </seealso>
-    public bool RequireOneSlicingArgument { get; }
+    public bool? RequireOneSlicingArgument { get; }
 }

--- a/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeDirectiveType.cs
+++ b/src/HotChocolate/CostAnalysis/src/CostAnalysis/Types/ListSizeDirectiveType.cs
@@ -144,7 +144,10 @@ public sealed class ListSizeDirectiveType : DirectiveType<ListSizeDirective>
             arguments.Add(new ArgumentNode(SizedFields, directive.SizedFields.ToListValueNode()));
         }
 
-        arguments.Add(new ArgumentNode(RequireOneSlicingArgument, directive.RequireOneSlicingArgument));
+        if (directive.RequireOneSlicingArgument is not null)
+        {
+            arguments.Add(new ArgumentNode(RequireOneSlicingArgument, directive.RequireOneSlicingArgument.Value));
+        }
 
         return new DirectiveNode(_name, arguments.ToImmutableArray());
     }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Omitted requireOneSlicingArgument if not set in listSize directive.

Closes #7398