### PR TITLE
Included tag directive in Apollo Federation import list

### DIFF
--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Schema_Snapshot.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Schema_Snapshot.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@external", "@provides", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@tag", "@key", "@external", "@provides", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Subgraph_SDL.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/AnnotationBased/__snapshots__/CertificationTests.Subgraph_SDL.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@external", "@provides", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@tag", "@key", "@external", "@provides", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Schema_Snapshot.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@tag", "@key", "@provides", "@external", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/CertificationSchema/CodeFirst/__snapshots__/CertificationTests.Subgraph_SDL.snap
@@ -1,4 +1,4 @@
-﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "@external", "FieldSet" ]) {
+﻿schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@tag", "@key", "@provides", "@external", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ComposeDirectiveTests.TestServiceTypeEmptyQueryTypePureCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ComposeDirectiveTests.TestServiceTypeEmptyQueryTypePureCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @composeDirective(name: "custom") @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet", "@composeDirective" ]) @link(url: "https:\/\/specs.custom.dev\/custom\/v1.0", import: [ "@custom" ]) {
+schema @composeDirective(name: "custom") @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet", "@composeDirective" ]) @link(url: "https:\/\/specs.custom.dev\/custom\/v1.0", import: [ "@custom" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ExternalDirectiveTests.AnnotateExternalToTypeFieldAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ExternalDirectiveTests.AnnotateExternalToTypeFieldAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@external", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@external", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ExternalDirectiveTests.AnnotateExternalToTypeFieldCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ExternalDirectiveTests.AnnotateExternalToTypeFieldCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@external", "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@external", "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToClassAttributeAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToClassAttributeAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypePropertyDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToClassAttributesAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToClassAttributesAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypePropertyDirectives
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToInterfaceAttributesAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToInterfaceAttributesAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypeClassDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToInterfaceTypeCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToInterfaceTypeCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToObjectTypeAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToObjectTypeAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypeClassDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToObjectTypeCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/KeyDirectiveTests.AnnotateKeyToObjectTypeCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToClassAttributeAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToClassAttributeAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypePropertyDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToClassAttributesAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToClassAttributesAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypePropertyDirectives
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToInterfaceAttributesAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToInterfaceAttributesAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypeClassDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToInterfaceTypeCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToInterfaceTypeCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToObjectTypeAnnotationBased.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToObjectTypeAnnotationBased.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: QueryOfTestTypeClassDirective
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToObjectTypeCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/NonResolvableKeyDirectiveTests.AnnotateKeyToObjectTypeCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Annotation.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Annotation.snap
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.0", import: [ "@key", "@override", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.0", import: [ "@key", "@override", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Progressive_Annotation.snap
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/OverrideDirectiveTests.OverrideDirective_Progressive_Annotation.snap
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.7", import: [ "@key", "@override", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.7", import: [ "@key", "@override", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirective_GetsAddedCorrectly_Annotations.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirective_GetsAddedCorrectly_Annotations.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet", "@policy" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet", "@policy" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirectives_GetAddedCorrectly_Annotations.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirectives_GetAddedCorrectly_Annotations.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet", "@policy" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet", "@policy" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirectives_GetAddedCorrectly_CodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/PolicyDirectiveTests.PolicyDirectives_GetAddedCorrectly_CodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@policy", "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@policy", "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ProvidesDirectiveTests.AnnotateProvidesToClassAttributePureCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ProvidesDirectiveTests.AnnotateProvidesToClassAttributePureCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@provides", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ProvidesDirectiveTests.AnnotateProvidesToFieldCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/ProvidesDirectiveTests.AnnotateProvidesToFieldCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@provides", "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@provides", "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresDirectiveTests.AnnotateProvidesToClassAttributePureCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresDirectiveTests.AnnotateProvidesToClassAttributePureCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@requires", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@requires", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresDirectiveTests.AnnotateProvidesToFieldCodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresDirectiveTests.AnnotateProvidesToFieldCodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@requires", "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@requires", "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirective_GetsAddedCorrectly_Annotations.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirective_GetsAddedCorrectly_Annotations.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet", "@requiresScopes" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet", "@requiresScopes" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirectives_GetAddedCorrectly_Annotations.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirectives_GetAddedCorrectly_Annotations.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet", "@requiresScopes" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet", "@requiresScopes" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirectives_GetAddedCorrectly_CodeFirst.graphql
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/Directives/__snapshots__/RequiresScopesDirectiveTests.RequiresScopesDirectives_GetAddedCorrectly_CodeFirst.graphql
@@ -1,4 +1,4 @@
-schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@requiresScopes", "@key", "FieldSet" ]) {
+schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@requiresScopes", "@key", "@tag", "FieldSet" ]) {
   query: Query
 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ServiceTypeTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/ServiceTypeTests.cs
@@ -33,7 +33,7 @@ public class ServiceTypeTests
             .Parse((string)value!)
             .MatchInlineSnapshot(
                 """
-                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "FieldSet" ]) {
+                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.6", import: [ "@key", "@tag", "FieldSet" ]) {
                   query: Query
                 }
 
@@ -89,7 +89,7 @@ public class ServiceTypeTests
             .Parse((string)value!)
             .MatchInlineSnapshot(
                 """
-                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.2", import: [ "@key", "FieldSet" ]) {
+                schema @link(url: "https:\/\/specs.apollo.dev\/federation\/v2.2", import: [ "@key", "@tag", "FieldSet" ]) {
                   query: Query
                 }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Included tag directive in Apollo Federation import list.

Closes #7413

---

@michaelstaib This is roughly what we discussed, but it's probably not correct, since I assume that it should only be included when the tag directive is used in the schema? If so, is there an easy way to check that?