### PR TITLE
Removed unused tracing code

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/DefaultHttpRequestInterceptor.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/DefaultHttpRequestInterceptor.cs
@@ -24,11 +24,6 @@ public class DefaultHttpRequestInterceptor : IHttpRequestInterceptor
         requestBuilder.TryAddGlobalState(nameof(ClaimsPrincipal), userState.User);
         requestBuilder.TryAddGlobalState(WellKnownContextData.UserState, userState);
 
-        if (context.IsTracingEnabled())
-        {
-            requestBuilder.TryAddGlobalState(WellKnownContextData.EnableTracing, true);
-        }
-
         if (context.IncludeQueryPlan())
         {
             requestBuilder.TryAddGlobalState(WellKnownContextData.IncludeQueryPlan, true);

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/DefaultSocketSessionInterceptor.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/DefaultSocketSessionInterceptor.cs
@@ -34,11 +34,6 @@ public class DefaultSocketSessionInterceptor : ISocketSessionInterceptor
         requestBuilder.TryAddGlobalState(nameof(ClaimsPrincipal), userState.User);
         requestBuilder.TryAddGlobalState(WellKnownContextData.UserState, userState);
 
-        if (context.IsTracingEnabled())
-        {
-            requestBuilder.TryAddGlobalState(EnableTracing, true);
-        }
-
         if (context.IncludeQueryPlan())
         {
             requestBuilder.TryAddGlobalState(IncludeQueryPlan, true);

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HttpContextExtensions.cs
@@ -14,15 +14,6 @@ internal static class HttpContextExtensions
     public static GraphQLSocketOptions? GetGraphQLSocketOptions(this HttpContext context)
         => GetGraphQLServerOptions(context)?.Sockets;
 
-    public static bool IsTracingEnabled(this HttpContext context)
-    {
-        var headers = context.Request.Headers;
-
-        return (headers.TryGetValue(HttpHeaderKeys.Tracing, out var values)
-                || headers.TryGetValue(HttpHeaderKeys.ApolloTracing, out values)) &&
-               values.Any(v => v == HttpHeaderValues.TracingEnabled);
-    }
-
     public static bool IncludeQueryPlan(this HttpContext context)
     {
         var headers = context.Request.Headers;

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/HttpHeaderKeys.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/HttpHeaderKeys.cs
@@ -2,10 +2,6 @@ namespace HotChocolate.AspNetCore;
 
 internal static class HttpHeaderKeys
 {
-    public const string Tracing = "GraphQL-Tracing";
-
-    public const string ApolloTracing = "X-Apollo-Tracing";
-
     public const string QueryPlan = "GraphQL-Query-Plan";
 
     public const string CacheControl = "Cache-Control";

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/HttpHeaderValues.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/HttpHeaderValues.cs
@@ -2,8 +2,6 @@ namespace HotChocolate.AspNetCore;
 
 internal static class HttpHeaderValues
 {
-    public const string TracingEnabled = "1";
-
     public const string IncludeQueryPlan = "1";
 
     public const string NoCache = "no-cache";

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/TestServerExtensions.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/TestServerExtensions.cs
@@ -12,7 +12,6 @@ public static class TestServerExtensions
         this TestServer testServer,
         ClientQueryRequest request,
         string path = "/graphql",
-        bool enableApolloTracing = false,
         bool includeQueryPlan = false)
     {
         var response =
@@ -20,7 +19,6 @@ public static class TestServerExtensions
                 testServer,
                 JsonConvert.SerializeObject(request),
                 path,
-                enableApolloTracing,
                 includeQueryPlan);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -189,15 +187,13 @@ public static class TestServerExtensions
     public static async Task<ClientRawResult> PostRawAsync(
         this TestServer testServer,
         ClientQueryRequest request,
-        string path = "/graphql",
-        bool enableApolloTracing = false)
+        string path = "/graphql")
     {
         var response =
             await SendPostRequestAsync(
                 testServer,
                 JsonConvert.SerializeObject(request),
-                path,
-                enableApolloTracing: enableApolloTracing);
+                path);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -215,15 +211,13 @@ public static class TestServerExtensions
     public static async Task<HttpResponseMessage> PostHttpAsync(
         this TestServer testServer,
         ClientQueryRequest request,
-        string path = "/graphql",
-        bool enableApolloTracing = false)
+        string path = "/graphql")
     {
         var response =
             await SendPostRequestAsync(
                 testServer,
                 JsonConvert.SerializeObject(request),
-                path,
-                enableApolloTracing: enableApolloTracing);
+                path);
 
         return response;
     }
@@ -310,27 +304,23 @@ public static class TestServerExtensions
         this TestServer testServer,
         TObject requestBody,
         string path = "/graphql",
-        bool enableApolloTracing = false,
         bool includeQueryPlan = false) =>
         SendPostRequestAsync(
             testServer,
             JsonConvert.SerializeObject(requestBody),
             path,
-            enableApolloTracing,
             includeQueryPlan);
 
     public static Task<HttpResponseMessage> SendPostRequestAsync(
         this TestServer testServer,
         string requestBody,
         string? path = null,
-        bool enableApolloTracing = false,
         bool includeQueryPlan = false) =>
         SendPostRequestAsync(
             testServer,
             requestBody,
             "application/json",
             path,
-            enableApolloTracing,
             includeQueryPlan);
 
     public static Task<HttpResponseMessage> SendPostRequestAsync(
@@ -338,15 +328,9 @@ public static class TestServerExtensions
         string requestBody,
         string contentType,
         string? path,
-        bool enableApolloTracing = false,
         bool includeQueryPlan = false)
     {
         var content = new StringContent(requestBody, Encoding.UTF8, contentType);
-
-        if (enableApolloTracing)
-        {
-            content.Headers.Add(HttpHeaderKeys.Tracing, HttpHeaderValues.TracingEnabled);
-        }
 
         if (includeQueryPlan)
         {

--- a/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
+++ b/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
@@ -16,11 +16,6 @@ public static class WellKnownContextData
     public const string Subscription = "HotChocolate.Execution.Subscription";
 
     /// <summary>
-    /// The key for storing the enable tracing flag to the context data.
-    /// </summary>
-    public const string EnableTracing = "HotChocolate.Execution.EnableTracing";
-
-    /// <summary>
     /// The key for setting a flag the a document was saved to the persisted query storage.
     /// </summary>
     public const string DocumentSaved = "HotChocolate.Execution.DocumentSaved";


### PR DESCRIPTION
The code for the header parsing and global state setup seems to have been forgotten during a cleanup. The global state is only set and never actually consumed anywhere.