### PR TITLE
Disable introspection by default on non dev environments

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/EndpointRouteBuilderExtensions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/EndpointRouteBuilderExtensions.cs
@@ -123,7 +123,7 @@ public static class EndpointRouteBuilderExtensions
             .UseMiddleware<HttpPostMiddleware>(schemaName)
             .UseMiddleware<HttpMultipartMiddleware>(schemaName)
             .UseMiddleware<HttpGetMiddleware>(schemaName)
-            .UseMiddleware<HttpGetSchemaMiddleware>(schemaName, Integrated)
+            .UseMiddleware<HttpGetSchemaMiddleware>(schemaName, path, Integrated)
             .UseBananaCakePop(path)
             .Use(
                 _ => context =>
@@ -359,7 +359,7 @@ public static class EndpointRouteBuilderExtensions
 
         requestPipeline
             .UseCancellation()
-            .UseMiddleware<HttpGetSchemaMiddleware>(schemaNameOrDefault, Explicit)
+            .UseMiddleware<HttpGetSchemaMiddleware>(schemaNameOrDefault, PathString.Empty, Explicit)
             .Use(
                 _ => context =>
                 {

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.Http.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.Http.cs
@@ -102,14 +102,15 @@ public static partial class HotChocolateAspNetCoreServiceCollectionExtensions
     {
         services.RemoveAll<IHttpResponseFormatter>();
         services.AddSingleton<IHttpResponseFormatter>(
-            DefaultHttpResponseFormatter.Create(
+            sp => DefaultHttpResponseFormatter.Create(
                 new HttpResponseFormatterOptions
                 {
                     Json = new JsonResultFormatterOptions
                     {
                         Indented = indented,
                     },
-                }));
+                },
+                sp.GetRequiredService<ITimeProvider>()));
         return services;
     }
 
@@ -131,7 +132,10 @@ public static partial class HotChocolateAspNetCoreServiceCollectionExtensions
         HttpResponseFormatterOptions options)
     {
         services.RemoveAll<IHttpResponseFormatter>();
-        services.AddSingleton<IHttpResponseFormatter>(DefaultHttpResponseFormatter.Create(options));
+        services.AddSingleton<IHttpResponseFormatter>(
+            sp => DefaultHttpResponseFormatter.Create(
+                options,
+                sp.GetRequiredService<ITimeProvider>()));
         return services;
     }
 

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using HotChocolate.Execution.Configuration;
 using HotChocolate.Internal;
 using HotChocolate.Language;
 using HotChocolate.Utilities;
+using Microsoft.Extensions.Hosting;
 using static HotChocolate.AspNetCore.ServerDefaults;
 
 // ReSharper disable once CheckNamespace
@@ -114,6 +115,12 @@ public static partial class HotChocolateAspNetCoreServiceCollectionExtensions
         if (!disableCostAnalyzer)
         {
             builder.AddCostAnalyzer();
+            builder.AddIntrospectionAllowedRule(
+                (sp, _) =>
+                {
+                    var environment = sp.GetService<IHostEnvironment>();
+                    return (environment?.IsDevelopment() ?? true) == false;
+                });
         }
 
         return builder;

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Extensions/HotChocolateAspNetCoreServiceCollectionExtensions.cs
@@ -43,11 +43,9 @@ public static partial class HotChocolateAspNetCoreServiceCollectionExtensions
 
         services.AddGraphQLCore();
         services.TryAddSingleton<IHttpResponseFormatter>(
-            DefaultHttpResponseFormatter.Create(
-                new HttpResponseFormatterOptions
-                {
-                    HttpTransportVersion = HttpTransportVersion.Latest,
-                }));
+            sp => DefaultHttpResponseFormatter.Create(
+                new HttpResponseFormatterOptions { HttpTransportVersion = HttpTransportVersion.Latest },
+                sp.GetRequiredService<ITimeProvider>()));
         services.TryAddSingleton<IHttpRequestParser>(
             sp => new DefaultHttpRequestParser(
                 sp.GetRequiredService<IDocumentCache>(),

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/HttpGetSchemaMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/HttpGetSchemaMiddleware.cs
@@ -143,7 +143,13 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
     {
         context.Response.ContentType = ContentType.GraphQL;
         context.Response.Headers.SetContentDisposition(GetSchemaFileName(schema));
+        context.Response.Headers.ETag = "";
         await PrintAsync(schema, context.Response.Body, indent, context.RequestAborted);
+    }
+
+    private static async Task TryCacheAsync(IRequestExecutor executor)
+    {
+        var cacheFile = System.IO.Path.GetTempPath()
     }
 
     private string GetTypesFileName(List<INamedType> types)
@@ -152,7 +158,26 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
             : "types.graphql";
 
     private string GetSchemaFileName(ISchema schema)
-        => schema.Name is null || schema.Name.EqualsOrdinal(Schema.DefaultName)
+        => schema.Name.EqualsOrdinal(Schema.DefaultName)
             ? "schema.graphql"
             : schema.Name + ".schema.graphql";
+}
+
+public interface ISchemaPrinter
+{
+    Task GetOrAddAsync(
+        long version,
+        string fileName,
+        ISchema schema,
+        HttpResponse response);
+}
+
+public sealed class InMemoryCacheSchemaPrinter : ISchemaPrinter
+{
+
+
+    public Task GetOrAddAsync(long version, string fileName, ISchema schema, HttpResponse response)
+    {
+
+    }
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/HttpGetSchemaMiddleware.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/HttpGetSchemaMiddleware.cs
@@ -1,7 +1,8 @@
 using HotChocolate.AspNetCore.Instrumentation;
 using HotChocolate.AspNetCore.Serialization;
-using HotChocolate.Utilities;
+using HotChocolate.Execution.Options;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using static System.Net.HttpStatusCode;
 using static HotChocolate.AspNetCore.ErrorHelper;
 using static HotChocolate.SchemaPrinter;
@@ -19,8 +20,10 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
             null,
             default),
     ];
+
     private readonly MiddlewareRoutingType _routing;
     private readonly IServerDiagnosticEvents _diagnosticEvents;
+    private readonly PathString _path;
 
     public HttpGetSchemaMiddleware(
         HttpRequestDelegate next,
@@ -28,22 +31,23 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
         IHttpResponseFormatter responseFormatter,
         IServerDiagnosticEvents diagnosticEvents,
         string schemaName,
+        PathString path,
         MiddlewareRoutingType routing)
         : base(next, executorResolver, responseFormatter, schemaName)
     {
-        _diagnosticEvents = diagnosticEvents ??
-            throw new ArgumentNullException(nameof(diagnosticEvents));
+        _diagnosticEvents = diagnosticEvents ?? throw new ArgumentNullException(nameof(diagnosticEvents));
+        _path = path;
         _routing = routing;
     }
 
     public async Task InvokeAsync(HttpContext context)
     {
         var handle = _routing == MiddlewareRoutingType.Integrated
-            ? HttpMethods.IsGet(context.Request.Method) &&
-              context.Request.Query.ContainsKey("SDL") &&
-                GetOptions(context).EnableSchemaRequests
-            : HttpMethods.IsGet(context.Request.Method) &&
-                GetOptions(context).EnableSchemaRequests;
+            ? HttpMethods.IsGet(context.Request.Method)
+                && (context.Request.Query.ContainsKey("SDL") || IsSchemaPath(context.Request))
+                && GetOptions(context).EnableSchemaRequests
+            : HttpMethods.IsGet(context.Request.Method)
+                && GetOptions(context).EnableSchemaRequests;
 
         if (handle)
         {
@@ -65,17 +69,29 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
         }
     }
 
+    private bool IsSchemaPath(HttpRequest request)
+    {
+        if(request.Path.StartsWithSegments(_path, StringComparison.OrdinalIgnoreCase, out var remaining))
+        {
+            return remaining.Equals("/schema", StringComparison.OrdinalIgnoreCase)
+                || remaining.Equals("/schema/", StringComparison.OrdinalIgnoreCase)
+                || remaining.Equals("/schema.graphql", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
     private async Task HandleRequestAsync(HttpContext context)
     {
-        var schema = await GetSchemaAsync(context.RequestAborted);
-        context.Items[WellKnownContextData.Schema] = schema;
+        var executor = await GetExecutorAsync(context.RequestAborted);
+        context.Items[WellKnownContextData.Schema] = executor.Schema;
+        var options = executor.Schema.Services.GetRequiredService<IRequestExecutorOptionsAccessor>();
 
-        var indent =
-            !(context.Request.Query.ContainsKey("indentation") &&
-                string.Equals(
-                    context.Request.Query["indentation"].FirstOrDefault(),
-                    "none",
-                    StringComparison.OrdinalIgnoreCase));
+        if (!options.EnableSchemaFileSupport)
+        {
+            context.Response.StatusCode = 404;
+            return;
+        }
 
         if (context.Request.Query.TryGetValue("types", out var typesValue))
         {
@@ -91,11 +107,11 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
                 return;
             }
 
-            await WriteTypesAsync(context, schema, s, indent);
+            await WriteTypesAsync(context, executor.Schema, s, true);
         }
         else
         {
-            await WriteSchemaAsync(context, schema, indent);
+            await WriteSchemaAsync(context, executor);
         }
     }
 
@@ -109,9 +125,9 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
 
         foreach (var typeName in typeNames.Split(','))
         {
-            if (!SchemaCoordinate.TryParse(typeName, out var coordinate) ||
-                coordinate.Value.MemberName is not null ||
-                coordinate.Value.ArgumentName is not null)
+            if (!SchemaCoordinate.TryParse(typeName, out var coordinate)
+                || coordinate.Value.MemberName is not null
+                || coordinate.Value.ArgumentName is not null)
             {
                 await WriteResultAsync(
                     context,
@@ -139,45 +155,17 @@ public sealed class HttpGetSchemaMiddleware : MiddlewareBase
         await PrintAsync(types, context.Response.Body, indent, context.RequestAborted);
     }
 
-    private async Task WriteSchemaAsync(HttpContext context, ISchema schema, bool indent)
-    {
-        context.Response.ContentType = ContentType.GraphQL;
-        context.Response.Headers.SetContentDisposition(GetSchemaFileName(schema));
-        context.Response.Headers.ETag = "";
-        await PrintAsync(schema, context.Response.Body, indent, context.RequestAborted);
-    }
-
-    private static async Task TryCacheAsync(IRequestExecutor executor)
-    {
-        var cacheFile = System.IO.Path.GetTempPath()
-    }
+    private ValueTask WriteSchemaAsync(
+        HttpContext context,
+        IRequestExecutor executor)
+        => ResponseFormatter.FormatAsync(
+            context.Response,
+            executor.Schema,
+            executor.Version,
+            context.RequestAborted);
 
     private string GetTypesFileName(List<INamedType> types)
         => types.Count == 1
             ? $"{types[0].Name}.graphql"
             : "types.graphql";
-
-    private string GetSchemaFileName(ISchema schema)
-        => schema.Name.EqualsOrdinal(Schema.DefaultName)
-            ? "schema.graphql"
-            : schema.Name + ".schema.graphql";
-}
-
-public interface ISchemaPrinter
-{
-    Task GetOrAddAsync(
-        long version,
-        string fileName,
-        ISchema schema,
-        HttpResponse response);
-}
-
-public sealed class InMemoryCacheSchemaPrinter : ISchemaPrinter
-{
-
-
-    public Task GetOrAddAsync(long version, string fileName, ISchema schema, HttpResponse response)
-    {
-
-    }
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/DefaultHttpResponseFormatter.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/DefaultHttpResponseFormatter.cs
@@ -1,8 +1,12 @@
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using HotChocolate.Execution.Serialization;
+using HotChocolate.Utilities;
 using Microsoft.AspNetCore.Http;
 #if !NET6_0_OR_GREATER
 using Microsoft.Net.Http.Headers;
@@ -21,6 +25,7 @@ namespace HotChocolate.AspNetCore.Serialization;
 /// </summary>
 public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 {
+    private readonly ConcurrentDictionary<string, CachedSchemaOutput> _schemaCache = new(StringComparer.Ordinal);
     private readonly FormatInfo _defaultFormat;
     private readonly FormatInfo _graphqlResponseFormat;
     private readonly FormatInfo _multiPartFormat;
@@ -46,11 +51,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
         : this(
             new HttpResponseFormatterOptions
             {
-                Json = new JsonResultFormatterOptions
-                {
-                    Indented = indented,
-                    Encoder = encoder,
-                },
+                Json = new JsonResultFormatterOptions { Indented = indented, Encoder = encoder, },
             })
     {
     }
@@ -154,7 +155,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
         {
             // we should not hit this point except if a middleware did not validate the
             // GraphQL request flags which would indicate that there is no way to execute
-            // the GraphQL request with the specified accept header content types.
+            // the GraphQL request with the specified accept-header content types.
             throw ThrowHelper.Formatter_InvalidAcceptMediaType();
         }
 
@@ -167,9 +168,9 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
                 response.ContentType = format.ContentType;
                 response.StatusCode = statusCode;
 
-                if (result.ContextData is not null &&
-                    result.ContextData.TryGetValue(CacheControlHeaderValue, out var value) &&
-                    value is string cacheControlHeaderValue)
+                if (result.ContextData is not null
+                    && result.ContextData.TryGetValue(CacheControlHeaderValue, out var value)
+                    && value is string cacheControlHeaderValue)
                 {
                     response.Headers.CacheControl = cacheControlHeaderValue;
                 }
@@ -215,6 +216,41 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
         }
     }
 
+    public async ValueTask FormatAsync(
+        HttpResponse response,
+        ulong version,
+        ISchema schema,
+        CancellationToken cancellationToken)
+    {
+        var output = _schemaCache.GetOrAdd(schema.Name, Update);
+
+        if (output.Version < version)
+        {
+            lock (_schemaCache)
+            {
+                if (!_schemaCache.TryGetValue(schema.Name, out output)
+                    || output.Version < version)
+                {
+                    _schemaCache[schema.Name] = output = Update(schema.Name);
+                }
+            }
+        }
+
+        var memory = output.AsMemory();
+        response.ContentType = ContentType.GraphQL;
+        response.Headers.SetContentDisposition(output.FileName);
+        response.Headers.ETag = output.ETag;
+        response.Headers.LastModified = output.LastModifiedTime.ToString("R");
+        response.Headers.CacheControl = "public, max-age=3600, must-revalidate";
+        response.Headers.Vary = "Accept-Encoding";
+        response.Headers.ContentLength = memory.Length;
+        await response.Body.WriteAsync(memory, cancellationToken);
+        return;
+
+        CachedSchemaOutput Update(string _) => new(schema, version);
+    }
+
+
     /// <summary>
     /// Determines which status code shall be returned for this result.
     /// </summary>
@@ -244,7 +280,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
         // if we are sending a single result with the multipart/mixed header or
         // with a text/event-stream response content-type we as well will just
-        // respond with a OK status code.
+        // respond with an OK status code.
         if (format.Kind is ResponseContentType.MultiPartMixed or ResponseContentType.EventStream)
         {
             return HttpStatusCode.OK;
@@ -263,7 +299,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
             }
 
             // if the GraphQL result has context data we will check if some middleware provided
-            // a status code or indicated an error that should be interpreted as an status code.
+            // a status code or indicated an error that should be interpreted as a status code.
             if (result.ContextData is not null)
             {
                 var contextData = result.ContextData;
@@ -320,7 +356,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
     /// <summary>
     /// Override to write response headers to the response message before
-    /// the the formatter starts writing the response body.
+    /// the formatter starts writing the response body.
     /// </summary>
     /// <param name="result">
     /// The <see cref="IOperationResult"/>.
@@ -334,7 +370,9 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
     protected virtual void OnWriteResponseHeaders(
         IOperationResult result,
         FormatInfo format,
-        IHeaderDictionary headers) { }
+        IHeaderDictionary headers)
+    {
+    }
 
     /// <summary>
     /// Determines which status code shall be returned for this response stream.
@@ -358,7 +396,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
     {
         // if we are sending a response stream with the multipart/mixed header or
         // with a text/event-stream response content-type we as well will just
-        // respond with a OK status code.
+        // respond with an OK status code.
         if (format.Kind is ResponseContentType.MultiPartMixed or ResponseContentType.EventStream)
         {
             return HttpStatusCode.OK;
@@ -372,7 +410,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
     /// <summary>
     /// Override to write response headers to the response message before
-    /// the the formatter starts writing the response body.
+    /// the formatter starts writing the response body.
     /// </summary>
     /// <param name="responseStream">
     /// The <see cref="IResponseStream"/>.
@@ -386,7 +424,9 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
     protected virtual void OnWriteResponseHeaders(
         IResponseStream responseStream,
         FormatInfo format,
-        IHeaderDictionary headers) { }
+        IHeaderDictionary headers)
+    {
+    }
 
     /// <summary>
     /// Determines which status code shall be returned for a result batch.
@@ -411,7 +451,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
     /// <summary>
     /// Override to write response headers to the response message before
-    /// the the formatter starts writing the response body.
+    /// the formatter starts writing the response body.
     /// </summary>
     /// <param name="resultBatch">
     /// The <see cref="OperationResultBatch"/>.
@@ -425,7 +465,9 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
     protected virtual void OnWriteResponseHeaders(
         OperationResultBatch resultBatch,
         FormatInfo format,
-        IHeaderDictionary headers) { }
+        IHeaderDictionary headers)
+    {
+    }
 
     private FormatInfo? TryGetFormatter(
         IExecutionResult result,
@@ -473,26 +515,23 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
         {
             var mediaType = start;
 
-            if (resultKind is ResultKind.Single &&
-                mediaType.Kind is ApplicationGraphQL)
+            if (resultKind is ResultKind.Single && mediaType.Kind is ApplicationGraphQL)
             {
                 return _graphqlResponseFormat;
             }
 
-            if (resultKind is ResultKind.Single &&
-                mediaType.Kind is ApplicationJson)
+            if (resultKind is ResultKind.Single && mediaType.Kind is ApplicationJson)
             {
                 return _legacyFormat;
             }
 
-            if (resultKind is ResultKind.Single &&
-                mediaType.Kind is AllApplication or All)
+            if (resultKind is ResultKind.Single && mediaType.Kind is AllApplication or All)
             {
                 return _defaultFormat;
             }
 
-            if (resultKind is ResultKind.Stream or ResultKind.Single &&
-                mediaType.Kind is MultiPartMixed or AllMultiPart or All)
+            if (resultKind is ResultKind.Stream or ResultKind.Single
+                && mediaType.Kind is MultiPartMixed or AllMultiPart or All)
             {
                 return _multiPartFormat;
             }
@@ -505,21 +544,19 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
             return null;
         }
 
-        // If we have more than one specified Accept header value we will try to find the best for
+        // If we have more than one specified accept-header value we will try to find the best for
         // our GraphQL result.
         ref var end = ref Unsafe.Add(ref start, length);
         FormatInfo? possibleFormat = null;
 
         while (Unsafe.IsAddressLessThan(ref start, ref end))
         {
-            if (resultKind is ResultKind.Single &&
-                start.Kind is AllApplication or All)
+            if (resultKind is ResultKind.Single && start.Kind is AllApplication or All)
             {
                 return _defaultFormat;
             }
 
-            if (resultKind is ResultKind.Single &&
-                start.Kind is ApplicationJson)
+            if (resultKind is ResultKind.Single && start.Kind is ApplicationJson)
             {
                 // application/json is a legacy response content-type.
                 // We will create a formatInfo but keep on validating for
@@ -527,14 +564,13 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
                 possibleFormat = _legacyFormat;
             }
 
-            if (resultKind is ResultKind.Single &&
-                start.Kind is ApplicationGraphQL)
+            if (resultKind is ResultKind.Single && start.Kind is ApplicationGraphQL)
             {
                 return _graphqlResponseFormat;
             }
 
-            if (resultKind is ResultKind.Stream or ResultKind.Single &&
-                start.Kind is MultiPartMixed or AllMultiPart or All)
+            if (resultKind is ResultKind.Stream or ResultKind.Single
+                && start.Kind is MultiPartMixed or AllMultiPart or All)
             {
                 // if the result is a stream we consider this a perfect match and
                 // will use this format.
@@ -543,7 +579,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
                     possibleFormat = _multiPartFormat;
                 }
 
-                // if the format is a event-stream or not set we will create a
+                // if the format is an event-stream or not set we will create a
                 // multipart/mixed formatInfo for the current result but also keep
                 // on validating for a better suited format.
                 if (possibleFormat?.Kind is not ResponseContentType.Json)
@@ -607,7 +643,7 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
         /// <summary>
         /// Gets an enum value representing well-known response content types.
-        /// This prop is an optimization that helps avoiding comparing strings.
+        /// This prop is an optimization that helps to avoid comparing strings.
         /// </summary>
         public ResponseContentType Kind { get; }
 
@@ -626,4 +662,41 @@ public class DefaultHttpResponseFormatter : IHttpResponseFormatter
 
     private sealed class SealedDefaultHttpResponseFormatter(HttpResponseFormatterOptions options)
         : DefaultHttpResponseFormatter(options);
+
+    private sealed class CachedSchemaOutput
+    {
+        private readonly byte[] _schema;
+
+        public CachedSchemaOutput(ISchema schema, ulong version)
+        {
+            _schema = Encoding.UTF8.GetBytes(schema.ToString());
+            FileName = GetSchemaFileName(schema);
+            ETag = CreateETag(_schema, version);
+            LastModifiedTime = DateTimeOffset.UtcNow;
+            Version = version;
+        }
+
+        public string FileName { get; }
+
+        public string ETag { get; }
+
+        public ulong Version { get; }
+
+        public DateTimeOffset LastModifiedTime { get; }
+
+        public ReadOnlyMemory<byte> AsMemory() => _schema;
+
+        private static string CreateETag(byte[] schema, ulong version)
+        {
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(schema);
+            var hash = Convert.ToBase64String(hashBytes);
+            return $"\"{version}-{hash}\"";
+        }
+
+        private static string GetSchemaFileName(ISchema schema)
+            => schema.Name.EqualsOrdinal(Schema.DefaultName)
+                ? "schema.graphql"
+                : schema.Name + ".schema.graphql";
+    }
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/IHttpResponseFormatter.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/IHttpResponseFormatter.cs
@@ -46,4 +46,10 @@ public interface IHttpResponseFormatter
         AcceptMediaType[] acceptMediaTypes,
         HttpStatusCode? proposedStatusCode,
         CancellationToken cancellationToken);
+
+    ValueTask FormatAsync(
+        HttpResponse response,
+        ulong version,
+        ISchema schema,
+        CancellationToken cancellationToken);
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/IHttpResponseFormatter.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore/Serialization/IHttpResponseFormatter.cs
@@ -49,7 +49,7 @@ public interface IHttpResponseFormatter
 
     ValueTask FormatAsync(
         HttpResponse response,
-        ulong version,
         ISchema schema,
+        ulong version,
         CancellationToken cancellationToken);
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/ServerTestBase.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/ServerTestBase.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
 using Xunit.Abstractions;
 
 namespace HotChocolate.AspNetCore.Tests.Utilities;
@@ -20,12 +22,17 @@ public abstract class ServerTestBase(TestServerFactory serverFactory) : IClassFi
         Action<IServiceCollection>? configureServices = default,
         Action<GraphQLEndpointConventionBuilder>? configureConventions = default,
         ITestOutputHelper? output = null,
-        bool requireOperationName = false)
+        bool requireOperationName = false,
+        string? environment = null)
     {
+        var mockHostEnvironment = new Mock<IHostEnvironment>();
+        mockHostEnvironment.Setup(env => env.EnvironmentName).Returns(environment ?? Environments.Development);
+
         return ServerFactory.Create(
             services =>
             {
                 services
+                    .AddSingleton(mockHostEnvironment.Object)
                     .AddRouting()
                     .AddHttpResponseFormatter()
                     .AddGraphQLServer()

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/ServerTestBase.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/ServerTestBase.cs
@@ -17,6 +17,8 @@ public abstract class ServerTestBase(TestServerFactory serverFactory) : IClassFi
 {
     protected TestServerFactory ServerFactory { get; } = serverFactory;
 
+    protected Uri Url { get; } = new("http://localhost:5000/graphql");
+
     protected virtual TestServer CreateStarWarsServer(
         string pattern = "/graphql",
         Action<IServiceCollection>? configureServices = default,

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpGetSchemaMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpGetSchemaMiddlewareTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using CookieCrumble;
 using HotChocolate.AspNetCore.Tests.Utilities;
+using HotChocolate.Execution;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace HotChocolate.AspNetCore;
 
@@ -32,6 +35,57 @@ public class HttpGetSchemaMiddlewareTests : ServerTestBase
 #else
         result.MatchSnapshot("NET6");
 #endif
+    }
+
+    [Theory]
+    [InlineData("/graphql?sdl")]
+    [InlineData("/graphql/schema/")]
+    [InlineData("/graphql/schema.graphql")]
+    [InlineData("/graphql/schema")]
+    public async Task Download_GraphQL_Schema(string path)
+    {
+        // arrange
+        var server = CreateStarWarsServer(
+            configureServices: sp =>
+                sp.RemoveAll<ITimeProvider>()
+                    .AddSingleton<ITimeProvider, StaticTimeProvider>());
+        var url = TestServerExtensions.CreateUrl(path);
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // act
+        var response = await server.CreateClient().SendAsync(request);
+
+        // assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+#if NET7_0_OR_GREATER
+        response.MatchMarkdownSnapshot();
+#else
+        response.MatchMarkdownSnapshot("NET6");
+#endif
+    }
+
+    [Theory]
+    [InlineData("/graphql/?sdl")]
+    [InlineData("/graphql/schema/")]
+    [InlineData("/graphql/schema.graphql")]
+    [InlineData("/graphql/schema")]
+    public async Task Download_GraphQL_Schema_Not_Allowed(string path)
+    {
+        // arrange
+        var server = CreateStarWarsServer(
+            configureServices: s =>
+                s.AddGraphQL()
+                    .ModifyRequestOptions(o => o.EnableSchemaFileSupport = false));
+
+        var url = TestServerExtensions.CreateUrl(path);
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // act
+        var response = await server.CreateClient().SendAsync(request);
+
+        // assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
@@ -178,11 +232,7 @@ public class HttpGetSchemaMiddlewareTests : ServerTestBase
         // arrange
         var server = CreateStarWarsServer(
             configureConventions: e => e.WithOptions(
-                new GraphQLServerOptions
-                {
-                    EnableSchemaRequests = false,
-                    Tool = { Enable = false, },
-                }));
+                new GraphQLServerOptions { EnableSchemaRequests = false, Tool = { Enable = false, }, }));
         var url = TestServerExtensions.CreateUrl("/graphql?sdl");
         var request = new HttpRequestMessage(HttpMethod.Get, url);
 
@@ -193,5 +243,10 @@ public class HttpGetSchemaMiddlewareTests : ServerTestBase
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         var result = await response.Content.ReadAsStringAsync();
         result.MatchSnapshot();
+    }
+
+    private sealed class StaticTimeProvider : ITimeProvider
+    {
+        public DateTimeOffset UtcNow { get; } = new(2021, 1, 1, 0, 0, 0, TimeSpan.Zero);
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
@@ -972,7 +972,13 @@ public class HttpPostMiddlewareTests(TestServerFactory serverFactory) : ServerTe
         var server = CreateStarWarsServer(
             configureServices: s => s.AddHttpResponseFormatter(
                 _ => new DefaultHttpResponseFormatter(
-                    new() { Json = new() { NullIgnoreCondition = Fields, }, })));
+                    new HttpResponseFormatterOptions
+                    {
+                        Json = new JsonResultFormatterOptions
+                        {
+                            NullIgnoreCondition = Fields,
+                        }
+                    })));
         var client = server.CreateClient();
 
         // act

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
@@ -51,7 +51,7 @@ public class IntrospectionTests(TestServerFactory serverFactory) : ServerTestBas
         // assert
         response.HttpResponseMessage.MatchMarkdownSnapshot();
     }
-    
+
 #endif
     private GraphQLHttpClient GetClient(string environment)
     {

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
@@ -1,0 +1,59 @@
+using CookieCrumble;
+using HotChocolate.AspNetCore.Tests.Utilities;
+using HotChocolate.Transport.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace HotChocolate.AspNetCore;
+
+public class IntrospectionTests(TestServerFactory serverFactory) : ServerTestBase(serverFactory)
+{
+    [Fact]
+    public async Task Introspection_Request_When_Development_Success()
+    {
+        // arrange
+        var client = GetClient(Environments.Development);
+
+        // act
+        var response = await client.PostAsync(
+            """
+            {
+                __type(name: "Query") {
+                    name
+                }
+            }
+            """,
+            Url);
+
+        // assert
+        response.HttpResponseMessage.MatchMarkdownSnapshot();
+    }
+
+    [Theory]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    public async Task Introspection_Request_When_NOT_Development_Fail(string environment)
+    {
+        // arrange
+        var client = GetClient(environment);
+
+        // act
+        var response = await client.PostAsync(
+            """
+            {
+                __type(name: "Query") {
+                    name
+                }
+            }
+            """,
+            Url);
+
+        // assert
+        response.HttpResponseMessage.MatchMarkdownSnapshot();
+    }
+
+    private GraphQLHttpClient GetClient(string environment)
+    {
+        var server = CreateStarWarsServer(environment: environment);
+        return new DefaultGraphQLHttpClient(server.CreateClient());
+    }
+}

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
@@ -1,6 +1,7 @@
 using CookieCrumble;
 using HotChocolate.AspNetCore.Tests.Utilities;
 using HotChocolate.Transport.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace HotChocolate.AspNetCore;
@@ -52,10 +53,41 @@ public class IntrospectionTests(TestServerFactory serverFactory) : ServerTestBas
         response.HttpResponseMessage.MatchMarkdownSnapshot();
     }
 
-#endif
-    private GraphQLHttpClient GetClient(string environment)
+    [Theory]
+    [InlineData("Staging")]
+    [InlineData("Production")]
+    public async Task Introspection_Request_With_Rule_Removed_Fail(string environment)
     {
-        var server = CreateStarWarsServer(environment: environment);
+        // arrange
+        var client = GetClient(environment, removeRule: true);
+
+        // act
+        var response = await client.PostAsync(
+            """
+            {
+                __type(name: "Query") {
+                    name
+                }
+            }
+            """,
+            Url);
+
+        // assert
+        response.HttpResponseMessage.MatchMarkdownSnapshot();
+    }
+
+#endif
+    private GraphQLHttpClient GetClient(string environment, bool removeRule = false)
+    {
+        var server = CreateStarWarsServer(
+            environment: environment,
+            configureServices: s =>
+            {
+                if (removeRule)
+                {
+                    s.AddGraphQL().RemoveIntrospectionAllowedRule();
+                }
+            });
         return new DefaultGraphQLHttpClient(server.CreateClient());
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/IntrospectionTests.cs
@@ -28,6 +28,7 @@ public class IntrospectionTests(TestServerFactory serverFactory) : ServerTestBas
         response.HttpResponseMessage.MatchMarkdownSnapshot();
     }
 
+#if NET7_0_OR_GREATER
     [Theory]
     [InlineData("Staging")]
     [InlineData("Production")]
@@ -50,7 +51,8 @@ public class IntrospectionTests(TestServerFactory serverFactory) : ServerTestBas
         // assert
         response.HttpResponseMessage.MatchMarkdownSnapshot();
     }
-
+    
+#endif
     private GraphQLHttpClient GetClient(string environment)
     {
         var server = CreateStarWarsServer(environment: environment);

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema.md
@@ -1,0 +1,151 @@
+# Download_GraphQL_Schema
+
+```text
+Headers:
+ETag: "1-B2t9cwf/BRF8NYIpFDtJE4DLg8FfD5d5HdAF9KObaUc="
+Cache-Control: public, must-revalidate, max-age=3600
+Content-Type: application/graphql; charset=utf-8
+Content-Disposition: attachment; filename="schema.graphql"
+Last-Modified: Fri, 01 Jan 2021 00:00:00 GMT
+Content-Length: 7193
+-------------------------->
+Status Code: OK
+-------------------------->
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+interface Character {
+  id: ID!
+  name: String!
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection
+  appearsIn: [Episode]
+  traits: JSON
+  height(unit: Unit): Float
+}
+
+type Droid implements Character {
+  id: ID!
+  name: String!
+  appearsIn: [Episode]
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection @listSize(assumedSize: 50, slicingArguments: [ "first", "last" ], sizedFields: [ "edges", "nodes" ])
+  height(unit: Unit): Float
+  primaryFunction: String
+  traits: JSON
+}
+
+"A connection to a list of items."
+type FriendsConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [FriendsEdge!]
+  "A flattened list of the nodes."
+  nodes: [Character]
+}
+
+"An edge in a connection."
+type FriendsEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Character
+}
+
+type Human implements Character {
+  id: ID!
+  name: String!
+  appearsIn: [Episode]
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection @listSize(assumedSize: 50, slicingArguments: [ "first", "last" ], sizedFields: [ "edges", "nodes" ])
+  otherHuman: Human
+  height(unit: Unit): Float
+  homePlanet: String
+  traits: JSON
+}
+
+type Mutation {
+  createReview(episode: Episode! review: ReviewInput!): Review! @cost(weight: "10")
+  complete(episode: Episode!): Boolean! @cost(weight: "10")
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+
+type Query {
+  hero(episode: Episode! = NEW_HOPE): Character
+  heroByTraits(traits: JSON!): Character
+  heroes(episodes: [Episode!]!): [Character!]
+  character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
+  search(text: String!): [SearchResult]
+  human(id: String!): Human
+  droid(id: String!): Droid
+  time: Long!
+  evict: Boolean!
+  wait(m: Int!): Boolean! @cost(weight: "10")
+  someDeprecatedField(deprecatedArg: String! = "foo" @deprecated(reason: "use something else")): String! @deprecated(reason: "use something else")
+}
+
+type Review {
+  commentary: String @cost(weight: "10")
+  stars: Int!
+}
+
+type Starship {
+  id: ID!
+  name: String!
+  length(unit: Unit): Float!
+}
+
+type Subscription {
+  onReview(episode: Episode!): Review!
+  onNext: String! @cost(weight: "10")
+  onException: String! @cost(weight: "10")
+  delay(delay: Int! count: Int!): String! @cost(weight: "10")
+}
+
+union SearchResult = Starship | Human | Droid
+
+input ReviewInput {
+  stars: Int!
+  commentary: String
+}
+
+enum Episode {
+  NEW_HOPE
+  EMPIRE
+  JEDI
+}
+
+enum Unit {
+  FOOT
+  METERS
+}
+
+"The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."
+directive @cost("The `weight` argument defines what value to add to the overall cost for every appearance, or possible appearance, of a type, field, argument, etc." weight: String!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM | INPUT_FIELD_DEFINITION
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The purpose of the `@listSize` directive is to either inform the static analysis about the size of returned lists (if that information is statically available), or to point the analysis to where to find that information."
+directive @listSize("The `assumedSize` argument can be used to statically define the maximum length of a list returned by a field." assumedSize: Int "The `slicingArguments` argument can be used to define which of the field's arguments with numeric type are slicing arguments, so that their value determines the size of the list returned by that field. It may specify a list of multiple slicing arguments." slicingArguments: [String!] "The `sizedFields` argument can be used to define that the value of the `assumedSize` argument or of a slicing argument does not affect the size of a list returned by a field itself, but that of a list returned by one of its sub-fields." sizedFields: [String!] "The `requireOneSlicingArgument` argument can be used to inform the static analysis that it should expect that exactly one of the defined slicing arguments is present in a query. If that is not the case (i.e., if none or multiple slicing arguments are present), the static analysis may throw an error." requireOneSlicingArgument: Boolean! = true) on FIELD_DEFINITION
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD
+
+scalar JSON
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+```

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema_NET6.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema_NET6.md
@@ -1,0 +1,145 @@
+# Download_GraphQL_Schema
+
+```text
+Headers:
+ETag: "1-kBEjhe2t+jfqbeZRxnezu0WDQFYAc0qzjLF1RlHs428="
+Cache-Control: public, must-revalidate, max-age=3600
+Content-Type: application/graphql; charset=utf-8
+Content-Disposition: attachment; filename="schema.graphql"
+Last-Modified: Fri, 01 Jan 2021 00:00:00 GMT
+Content-Length: 5070
+-------------------------->
+Status Code: OK
+-------------------------->
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+interface Character {
+  id: ID!
+  name: String!
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection
+  appearsIn: [Episode]
+  traits: JSON
+  height(unit: Unit): Float
+}
+
+type Droid implements Character {
+  id: ID!
+  name: String!
+  appearsIn: [Episode]
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection
+  height(unit: Unit): Float
+  primaryFunction: String
+  traits: JSON
+}
+
+"A connection to a list of items."
+type FriendsConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [FriendsEdge!]
+  "A flattened list of the nodes."
+  nodes: [Character]
+}
+
+"An edge in a connection."
+type FriendsEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Character
+}
+
+type Human implements Character {
+  id: ID!
+  name: String!
+  appearsIn: [Episode]
+  friends("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): FriendsConnection
+  otherHuman: Human
+  height(unit: Unit): Float
+  homePlanet: String
+  traits: JSON
+}
+
+type Mutation {
+  createReview(episode: Episode! review: ReviewInput!): Review!
+  complete(episode: Episode!): Boolean!
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+
+type Query {
+  hero(episode: Episode! = NEW_HOPE): Character
+  heroByTraits(traits: JSON!): Character
+  heroes(episodes: [Episode!]!): [Character!]
+  character(characterIds: [String!]!): [Character!]!
+  search(text: String!): [SearchResult]
+  human(id: String!): Human
+  droid(id: String!): Droid
+  time: Long!
+  evict: Boolean!
+  wait(m: Int!): Boolean!
+  someDeprecatedField(deprecatedArg: String! = "foo" @deprecated(reason: "use something else")): String! @deprecated(reason: "use something else")
+}
+
+type Review {
+  commentary: String
+  stars: Int!
+}
+
+type Starship {
+  id: ID!
+  name: String!
+  length(unit: Unit): Float!
+}
+
+type Subscription {
+  onReview(episode: Episode!): Review!
+  onNext: String!
+  onException: String!
+  delay(delay: Int! count: Int!): String!
+}
+
+union SearchResult = Starship | Human | Droid
+
+input ReviewInput {
+  stars: Int!
+  commentary: String
+}
+
+enum Episode {
+  NEW_HOPE
+  EMPIRE
+  JEDI
+}
+
+enum Unit {
+  FOOT
+  METERS
+}
+
+"The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
+directive @defer("If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String "Deferred when true." if: Boolean) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
+directive @stream("If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String "The initial elements that shall be send down to the consumer." initialCount: Int! = 0 "Streamed when true." if: Boolean) on FIELD
+
+scalar JSON
+
+"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
+scalar Long
+```

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_When_Development_Success.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_When_Development_Success.md
@@ -1,0 +1,10 @@
+# Introspection_Request_When_Development_Success
+
+```text
+Headers:
+Content-Type: application/graphql-response+json; charset=utf-8
+-------------------------->
+Status Code: OK
+-------------------------->
+{"data":{"__type":{"name":"Query"}}}
+```

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_When_NOT_Development_Fail.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_When_NOT_Development_Fail.md
@@ -1,0 +1,10 @@
+# Introspection_Request_When_NOT_Development_Fail
+
+```text
+Headers:
+Content-Type: application/graphql-response+json; charset=utf-8
+-------------------------->
+Status Code: BadRequest
+-------------------------->
+{"errors":[{"message":"Introspection is not allowed for the current request.","locations":[{"line":2,"column":5}],"extensions":{"field":"__type","code":"HC0046"}}]}
+```

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_With_Rule_Removed_Fail.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/IntrospectionTests.Introspection_Request_With_Rule_Removed_Fail.md
@@ -1,0 +1,10 @@
+# Introspection_Request_With_Rule_Removed_Fail
+
+```text
+Headers:
+Content-Type: application/graphql-response+json; charset=utf-8
+-------------------------->
+Status Code: OK
+-------------------------->
+{"data":{"__type":{"name":"Query"}}}
+```

--- a/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateAzureFunctionServiceCollectionExtensions.cs
+++ b/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateAzureFunctionServiceCollectionExtensions.cs
@@ -100,7 +100,10 @@ public static class HotChocolateAzureFunctionServiceCollectionExtensions
                     .UseMiddleware<HttpMultipartMiddleware>(schemaNameOrDefault)
                     .UseMiddleware<HttpGetMiddleware>(schemaNameOrDefault)
                     .UseBananaCakePop(path)
-                    .UseMiddleware<HttpGetSchemaMiddleware>(schemaNameOrDefault)
+                    .UseMiddleware<HttpGetSchemaMiddleware>(
+                        schemaNameOrDefault,
+                        path,
+                        MiddlewareRoutingType.Integrated)
                     .Compile(sp);
 
             return new DefaultGraphQLRequestExecutor(pipeline, options);

--- a/src/HotChocolate/Core/src/Abstractions/Execution/DefaultTimeProvider.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/DefaultTimeProvider.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Execution;
+
+/// <summary>
+/// Represents a default time provider.
+/// </summary>
+public sealed class DefaultTimeProvider : ITimeProvider
+{
+    /// <summary>
+    /// Gets the current time in UTC.
+    /// </summary>
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/src/HotChocolate/Core/src/Abstractions/Execution/ITimeProvider.cs
+++ b/src/HotChocolate/Core/src/Abstractions/Execution/ITimeProvider.cs
@@ -1,0 +1,15 @@
+namespace HotChocolate.Execution;
+
+/// <summary>
+/// Represents a time provider abstraction.
+/// </summary>
+public interface ITimeProvider
+{
+    /// <summary>
+    /// Gets the current time in UTC.
+    /// </summary>
+    /// <returns>
+    /// Returns the current time in UTC.
+    /// </returns>
+    DateTimeOffset UtcNow { get; }
+}

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.Validation.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.Validation.cs
@@ -216,8 +216,16 @@ public static partial class RequestExecutorBuilderExtensions
     /// </summary>
     public static IRequestExecutorBuilder AddIntrospectionAllowedRule(
         this IRequestExecutorBuilder builder,
-        Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null) =>
-        ConfigureValidation(builder, b => b.AddIntrospectionAllowedRule(isEnabled));
+        Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null)
+        => ConfigureValidation(builder, b => b.AddIntrospectionAllowedRule(isEnabled));
+
+    /// <summary>
+    /// Removes a validation rule that only allows requests to use `__schema` or `__type`
+    /// if the request carries an introspection allowed flag.
+    /// </summary>
+    public static IRequestExecutorBuilder RemoveIntrospectionAllowedRule(
+        this IRequestExecutorBuilder builder)
+        => ConfigureValidation(builder, b => b.RemoveIntrospectionAllowedRule());
 
     /// <summary>
     /// Toggle whether introspection is allow or not.

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.Validation.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorBuilderExtensions.Validation.cs
@@ -215,8 +215,9 @@ public static partial class RequestExecutorBuilderExtensions
     /// if the request carries an introspection allowed flag.
     /// </summary>
     public static IRequestExecutorBuilder AddIntrospectionAllowedRule(
-        this IRequestExecutorBuilder builder) =>
-        ConfigureValidation(builder, b => b.AddIntrospectionAllowedRule());
+        this IRequestExecutorBuilder builder,
+        Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null) =>
+        ConfigureValidation(builder, b => b.AddIntrospectionAllowedRule(isEnabled));
 
     /// <summary>
     /// Toggle whether introspection is allow or not.

--- a/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Core/src/Execution/DependencyInjection/RequestExecutorServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class RequestExecutorServiceCollectionExtensions
 
         services.AddOptions();
 
+        services.TryAddSingleton<ITimeProvider, DefaultTimeProvider>();
         services.TryAddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
         services.TryAddSingleton<DefaultRequestContextAccessor>();
         services.TryAddSingleton<IRequestContextAccessor>(sp => sp.GetRequiredService<DefaultRequestContextAccessor>());

--- a/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/IRequestExecutorOptionsAccessor.cs
@@ -9,4 +9,10 @@ namespace HotChocolate.Execution.Options;
 public interface IRequestExecutorOptionsAccessor
     : IErrorHandlerOptionsAccessor
     , IRequestTimeoutOptionsAccessor
-    , IPersistedQueryOptionsAccessor;
+    , IPersistedQueryOptionsAccessor
+{
+    /// <summary>
+    /// Specifies that the transport is allowed to provide the schema SDL document as a file.
+    /// </summary>
+    bool EnableSchemaFileSupport { get; }
+}

--- a/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
+++ b/src/HotChocolate/Core/src/Execution/Options/RequestExecutorOptions.cs
@@ -72,4 +72,9 @@ public class RequestExecutorOptions : IRequestExecutorOptionsAccessor
                     nameof(OnlyPersistedQueriesAreAllowedError));
         }
     }
+
+    /// <summary>
+    /// Specifies that the transport is allowed to provide the schema SDL document as a file.
+    /// </summary>
+    public bool EnableSchemaFileSupport { get; set; } = true;
 }

--- a/src/HotChocolate/Core/src/Types/AggregateSchemaDocumentFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/AggregateSchemaDocumentFormatter.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using HotChocolate.Language;
+
+namespace HotChocolate;
+
+internal sealed class AggregateSchemaDocumentFormatter(
+    IEnumerable<ISchemaDocumentFormatter> formatters)
+    : ISchemaDocumentFormatter
+{
+    private readonly ISchemaDocumentFormatter[] _formatters = formatters.ToArray();
+
+    public DocumentNode Format(DocumentNode schema)
+    {
+        if(_formatters.Length == 0)
+        {
+            return schema;
+        }
+
+        if(_formatters.Length == 1)
+        {
+            return _formatters[0].Format(schema);
+        }
+
+        var current = schema;
+
+        for (var i = 0; i < _formatters.Length; i++)
+        {
+            current = _formatters[i].Format(current);
+        }
+
+        return current;
+    }
+}

--- a/src/HotChocolate/Core/src/Types/AggregateSchemaDocumentFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/AggregateSchemaDocumentFormatter.cs
@@ -4,10 +4,10 @@ using HotChocolate.Language;
 namespace HotChocolate;
 
 internal sealed class AggregateSchemaDocumentFormatter(
-    IEnumerable<ISchemaDocumentFormatter> formatters)
+    IEnumerable<ISchemaDocumentFormatter>? formatters)
     : ISchemaDocumentFormatter
 {
-    private readonly ISchemaDocumentFormatter[] _formatters = formatters.ToArray();
+    private readonly ISchemaDocumentFormatter[] _formatters = formatters?.ToArray() ?? [];
 
     public DocumentNode Format(DocumentNode schema)
     {

--- a/src/HotChocolate/Core/src/Types/ISchemaDocumentFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/ISchemaDocumentFormatter.cs
@@ -5,7 +5,7 @@ namespace HotChocolate;
 
 /// <summary>
 /// A schema document formatter can be used to format/rewrite the
-/// schema document that is produced by the a <see cref="Schema"/>
+/// schema document that is produced by a <see cref="Schema"/>
 /// instance.
 /// </summary>
 public interface ISchemaDocumentFormatter

--- a/src/HotChocolate/Core/src/Types/ISchemaDocumentFormatter.cs
+++ b/src/HotChocolate/Core/src/Types/ISchemaDocumentFormatter.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using HotChocolate.Language;
+
+namespace HotChocolate;
+
+/// <summary>
+/// A schema document formatter can be used to format/rewrite the
+/// schema document that is produced by the a <see cref="Schema"/>
+/// instance.
+/// </summary>
+public interface ISchemaDocumentFormatter
+{
+    /// <summary>
+    /// Formats the schema document.
+    /// </summary>
+    /// <param name="schema">
+    /// The schema document that shall be formatted.
+    /// </param>
+    /// <returns>
+    /// Returns the formatted schema document.
+    /// </returns>
+    DocumentNode Format(DocumentNode schema);
+}

--- a/src/HotChocolate/Core/src/Types/Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.cs
@@ -245,7 +245,7 @@ public partial class Schema
     public DocumentNode ToDocument(bool includeSpecScalars = false)
     {
         _formatter ??= new AggregateSchemaDocumentFormatter(
-            Services.GetServices<ISchemaDocumentFormatter>());
+            Services.GetService<IEnumerable<ISchemaDocumentFormatter>>());
         var document = SchemaPrinter.PrintSchema(this, includeSpecScalars);
         return _formatter.Format(document);
     }

--- a/src/HotChocolate/Core/src/Types/Schema.cs
+++ b/src/HotChocolate/Core/src/Types/Schema.cs
@@ -4,6 +4,7 @@ using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using HotChocolate.Features;
 using HotChocolate.Language;
+using HotChocolate.Language.Utilities;
 using HotChocolate.Properties;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors.Definitions;
@@ -29,6 +30,7 @@ public partial class Schema
 #else
     private Dictionary<string, DirectiveType> _directiveTypes = default!;
 #endif
+    private AggregateSchemaDocumentFormatter? _formatter;
 
     /// <summary>
     /// Gets the schema directives.
@@ -133,7 +135,7 @@ public partial class Schema
     /// <param name="runtimeType">The resolved .net type.</param>
     /// <returns>
     /// <c>true</c>, if a .net type was found that was bound
-    /// the the specified schema type, <c>false</c> otherwise.
+    /// the specified schema type, <c>false</c> otherwise.
     /// </returns>
     public bool TryGetRuntimeType(string typeName, [NotNullWhen(true)] out Type? runtimeType)
     {
@@ -241,12 +243,17 @@ public partial class Schema
     /// Generates a schema document.
     /// </summary>
     public DocumentNode ToDocument(bool includeSpecScalars = false)
-        => SchemaPrinter.PrintSchema(this, includeSpecScalars);
+    {
+        _formatter ??= new AggregateSchemaDocumentFormatter(
+            Services.GetServices<ISchemaDocumentFormatter>());
+        var document = SchemaPrinter.PrintSchema(this, includeSpecScalars);
+        return _formatter.Format(document);
+    }
 
     /// <summary>
     /// Returns the schema SDL representation.
     /// </summary>
-    public string Print() => SchemaPrinter.Print(this);
+    public string Print() => ToDocument().Print();
 
     /// <summary>
     /// Returns the schema SDL representation.

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidatiobBuilderExtensions.Rules.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidatiobBuilderExtensions.Rules.cs
@@ -339,6 +339,7 @@ public static partial class HotChocolateValidationBuilderExtensions
     /// if the request carries an introspection allowed flag.
     /// </summary>
     public static IValidationBuilder AddIntrospectionAllowedRule(
-        this IValidationBuilder builder) =>
-        builder.TryAddValidationVisitor((_, _) => new IntrospectionVisitor(), false);
+        this IValidationBuilder builder,
+        Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null)
+        => builder.TryAddValidationVisitor((_, _) => new IntrospectionVisitor(), false, isEnabled);
 }

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidatiobBuilderExtensions.Rules.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidatiobBuilderExtensions.Rules.cs
@@ -342,4 +342,13 @@ public static partial class HotChocolateValidationBuilderExtensions
         this IValidationBuilder builder,
         Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null)
         => builder.TryAddValidationVisitor((_, _) => new IntrospectionVisitor(), false, isEnabled);
+
+    /// <summary>
+    /// Removes a validation rule that only allows requests to use `__schema` or `__type`
+    /// if the request carries an introspection allowed flag.
+    /// </summary>
+    public static IValidationBuilder RemoveIntrospectionAllowedRule(
+        this IValidationBuilder builder,
+        Func<IServiceProvider, ValidationOptions, bool>? isEnabled = null)
+        => builder.TryRemoveValidationVisitor<IntrospectionVisitor>();
 }

--- a/src/HotChocolate/Core/src/Validation/Extensions/ValidationBuilderExtensions.cs
+++ b/src/HotChocolate/Core/src/Validation/Extensions/ValidationBuilderExtensions.cs
@@ -169,6 +169,24 @@ public static partial class HotChocolateValidationBuilderExtensions
     }
 
     /// <summary>
+    /// Removes the specified validation visitor from the configuration.
+    /// </summary>
+    public static IValidationBuilder TryRemoveValidationVisitor<T>(
+        this IValidationBuilder builder)
+        where T : DocumentValidatorVisitor
+    {
+        return builder.ConfigureValidation((_, m) =>
+            m.Modifiers.Add(o =>
+            {
+                var entries = o.Rules.Where(t => t.GetType() == typeof(DocumentValidatorRule<T>)).ToList();
+                foreach (var entry in entries)
+                {
+                    o.Rules.Remove(entry);
+                }
+            }));
+    }
+
+    /// <summary>
     /// Registers the specified validation rule,
     /// if the same type of validation rule was not yet registered.
     /// </summary>

--- a/src/HotChocolate/Core/test/Types.Tests/SchemaDocumentFormatterTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/SchemaDocumentFormatterTests.cs
@@ -1,0 +1,123 @@
+using CookieCrumble;
+using HotChocolate.Execution;
+using HotChocolate.Language;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate;
+
+public static class SchemaDocumentFormatterTests
+{
+    [Fact]
+    public static async Task Add_No_Schema_Formatter()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .BuildSchemaAsync();
+
+        schema.MatchInlineSnapshot(
+            """
+            schema {
+              query: Query
+            }
+
+            type Query {
+              hello: String
+            }
+            """);
+    }
+
+
+    [Fact]
+    public static async Task Add_Single_Schema_Formatter()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ConfigureSchemaServices(sp => sp.AddSingleton<ISchemaDocumentFormatter, Formatter1>())
+                .BuildSchemaAsync();
+
+        schema.MatchInlineSnapshot(
+            """
+            schema {
+              query: Query
+            }
+
+            type Query {
+              hello: String
+            }
+
+            scalar Scalar1
+            """);
+    }
+
+    [Fact]
+    public static async Task Add_Two_Schema_Formatters()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQLServer()
+                .AddQueryType<Query>()
+                .ConfigureSchemaServices(
+                    sp =>
+                        sp.AddSingleton<ISchemaDocumentFormatter, Formatter1>()
+                            .AddSingleton<ISchemaDocumentFormatter, Formatter2>())
+                .BuildSchemaAsync();
+
+        schema.MatchInlineSnapshot(
+            """
+            schema {
+              query: Query
+            }
+
+            type Query {
+              hello: String
+            }
+
+            scalar Scalar1
+
+            scalar Scalar2
+            """);
+    }
+
+    public class Query
+    {
+        public string Hello() => "Hello";
+    }
+
+    public class Formatter1 : ISchemaDocumentFormatter
+    {
+        public DocumentNode Format(DocumentNode schema)
+        {
+            var definitions = schema.Definitions.ToList();
+
+            definitions.Add(
+                new ScalarTypeDefinitionNode(
+                    null,
+                    new NameNode("Scalar1"),
+                    null,
+                    Array.Empty<DirectiveNode>()));
+
+            return new DocumentNode(null, definitions);
+        }
+    }
+
+    public class Formatter2 : ISchemaDocumentFormatter
+    {
+        public DocumentNode Format(DocumentNode schema)
+        {
+            var definitions = schema.Definitions.ToList();
+
+            definitions.Add(
+                new ScalarTypeDefinitionNode(
+                    null,
+                    new NameNode("Scalar2"),
+                    null,
+                    Array.Empty<DirectiveNode>()));
+
+            return new DocumentNode(null, definitions);
+        }
+    }
+}

--- a/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/TestServerHelper.cs
+++ b/src/StrawberryShake/Client/test/Transport.WebSocket.Tests/TestHelper/TestServerHelper.cs
@@ -35,6 +35,7 @@ public static class TestServerHelper
 
                             builder
                                 .AddStarWarsTypes()
+                                .RemoveIntrospectionAllowedRule()
                                 .AddStarWarsRepositories()
                                 .AddInMemorySubscriptions()
                                 .ModifyOptions(


### PR DESCRIPTION
- Schema middleware caches now the SDL per version
- Schema middleware adds caching headers
- Introduces new route for schema `/graphql/schema.graphql`
- Allows to disable schema middleware with request options
- Disables introspection when NON dev environment is detected
- Introduces `ISchemaDocumentFormatter` so components can reformat the public schema file.