### PR TITLE
Fix bug in 'AddNodeIdParser'

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/DependencyInjection/FusionRequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/Fusion/src/Core/DependencyInjection/FusionRequestExecutorBuilderExtensions.cs
@@ -136,7 +136,7 @@ public static class FusionRequestExecutorBuilderExtensions
                 (_, sc) =>
                 {
                     sc.RemoveAll<NodeIdParser>();
-                    sc.AddSingleton<NodeIdParser, DefaultNodeIdParser>();
+                    sc.AddSingleton<NodeIdParser, T>();
                 }));
 
         return builder;


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

When calling 'AddNodeIdParser' from FusionRequestExecutorBuilder it used a `DefaultNodeIdParser` instead of the type passed in through the generic argument passed in. 