### PR TITLE
Allow flag enums to have a custom prefix by making the naming function virtual

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/FlagEnumTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/FlagEnumTypeInterceptor.cs
@@ -194,7 +194,7 @@ public class FlagsEnumInterceptor : TypeInterceptor
         return extendedType.Type.IsDefined(typeof(FlagsAttribute), false);
     }
 
-    private static string GetFlagFieldName(Type type, object value)
+    protected virtual string GetFlagFieldName(Type type, object value)
     {
         var valueName = Enum.GetName(type, value);
         if (string.IsNullOrEmpty(valueName))


### PR DESCRIPTION
Currently in order to do this, the entire file needs to be copied to modify this one static function. Simple making it virtual allows a child class to override it instead.