### PR TITLE
Aligned ExtendObjectTypeAttribute binding behavior

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Attributes/ExtendObjectTypeAttribute.cs
@@ -204,6 +204,9 @@ public sealed class ExtendObjectTypeAttribute<T>
             descriptor.ExtendsType(ExtendsType);
         }
 
+        var definition = descriptor.Extend().Definition;
+        definition.Fields.BindingBehavior = BindingBehavior.Implicit;
+
         if (IncludeStaticMembers)
         {
             descriptor.Extend().Definition.FieldBindingFlags = Instance | Static;

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/ExtendObjectTypeAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/ExtendObjectTypeAttributeTests.cs
@@ -1,0 +1,58 @@
+using Snapshooter.Xunit;
+
+namespace HotChocolate.Types;
+
+public class ExtendObjectTypeAttributeTests
+{
+    [Fact]
+    public void NonGeneric_ImplicitlyExtends()
+    {
+        SchemaBuilder.New()
+            .AddQueryType<FooType>()
+            .AddType<NonGenericExtendFoo>()
+            .ModifyOptions(options => options.DefaultBindingBehavior = BindingBehavior.Explicit)
+            .Create()
+            .Print()
+            .MatchSnapshot();
+    }
+
+    [Fact]
+    public void Generic_ImplicitlyExtends()
+    {
+        SchemaBuilder.New()
+            .AddQueryType<FooType>()
+            .AddType<GenericExtendFoo>()
+            .ModifyOptions(options => options.DefaultBindingBehavior = BindingBehavior.Explicit)
+            .Create()
+            .Print()
+            .MatchSnapshot();
+    }
+
+    public class Foo
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string IgnoreMe { get; set; }
+    }
+
+    public class FooType : ObjectType<Foo>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Foo> descriptor)
+        {
+            descriptor.Field(x => x.Id);
+            descriptor.Field(x => x.Name);
+        }
+    }
+
+    [ExtendObjectType(typeof(Foo))]
+    public class NonGenericExtendFoo
+    {
+        public string GetBar() => "bar";
+    }
+
+    [ExtendObjectType<Foo>]
+    public class GenericExtendFoo
+    {
+        public string GetBar() => "bar";
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/__snapshots__/ExtendObjectTypeAttributeTests.Generic_ImplicitlyExtends.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/__snapshots__/ExtendObjectTypeAttributeTests.Generic_ImplicitlyExtends.snap
@@ -1,0 +1,9 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  id: Int!
+  name: String
+  bar: String
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/__snapshots__/ExtendObjectTypeAttributeTests.NonGeneric_ImplicitlyExtends.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Attributes/__snapshots__/ExtendObjectTypeAttributeTests.NonGeneric_ImplicitlyExtends.snap
@@ -1,0 +1,9 @@
+﻿schema {
+  query: Foo
+}
+
+type Foo {
+  id: Int!
+  name: String
+  bar: String
+}


### PR DESCRIPTION
The generic version of ExtendObjectTypeAttribute has diverged by not implicitly bind fields like the non generic attribute does. Modify the generic attribute to have the same implicit binding behavior.
