### PR TITLE
Fixed typo in Build.Environment.cs

### DIFF
--- a/.build/Build.Environment.cs
+++ b/.build/Build.Environment.cs
@@ -16,7 +16,7 @@ partial class Build
 
     AbsolutePath OutputDirectory => RootDirectory / "output";
     AbsolutePath TestResultDirectory => OutputDirectory / "test-results";
-    AbsolutePath CoverageReportDirectory => OutputDirectory / "coberage-reports";
+    AbsolutePath CoverageReportDirectory => OutputDirectory / "coverage-reports";
     AbsolutePath PackageDirectory => OutputDirectory / "packages";
     AbsolutePath HotChocolateDirectoryBuildProps => SourceDirectory / "HotChocolate" / "Directory.Build.Props";
     AbsolutePath TemplatesNuSpec => RootDirectory / "templates" / "v12" / "HotChocolate.Templates.nuspec";


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed typo in `Build.Environment.cs`.