### PR TITLE
Ensured correct culture is set on tests to match culture dependent snapshots

### DIFF
--- a/src/CookieCrumble/src/CookieCrumble/Attributes/UseCultureAttribute.cs
+++ b/src/CookieCrumble/src/CookieCrumble/Attributes/UseCultureAttribute.cs
@@ -1,0 +1,92 @@
+/*
+ * This code was copied from xunit samples https://github.com/xunit/samples.xunit/blob/main/v2/UseCulture/UseCultureAttribute.cs
+ */
+
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace CookieCrumble.Attributes;
+
+/// <summary>
+/// Apply this attribute to your test method to replace the
+/// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+/// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class UseCultureAttribute : BeforeAfterTestAttribute
+{
+    private readonly Lazy<CultureInfo> _culture;
+    private readonly Lazy<CultureInfo> _uiCulture;
+
+    private CultureInfo _originalCulture;
+    private CultureInfo _originalUiCulture;
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <remarks>
+    /// <para>
+    /// This constructor overload uses <paramref name="culture" /> for both
+    /// <see cref="Culture" /> and <see cref="UICulture" />.
+    /// </para>
+    /// </remarks>
+    public UseCultureAttribute(string culture)
+        : this(culture, culture) { }
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" /> and <paramref name="uiCulture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <param name="uiCulture">The name of the UI culture.</param>
+    public UseCultureAttribute(string culture, string uiCulture)
+    {
+        _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, false));
+        _uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, false));
+    }
+
+    /// <summary>
+    /// Gets the culture.
+    /// </summary>
+    public CultureInfo Culture { get { return _culture.Value; } }
+
+    /// <summary>
+    /// Gets the UI culture.
+    /// </summary>
+    public CultureInfo UICulture { get { return _uiCulture.Value; } }
+
+    /// <summary>
+    /// Stores the current <see cref="Thread.CurrentPrincipal" />
+    /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+    /// and replaces them with the new cultures defined in the constructor.
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        _originalCulture = Thread.CurrentThread.CurrentCulture;
+        _originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+
+        Thread.CurrentThread.CurrentCulture = Culture;
+        Thread.CurrentThread.CurrentUICulture = UICulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+
+    /// <summary>
+    /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void After(MethodInfo methodUnderTest)
+    {
+        Thread.CurrentThread.CurrentCulture = _originalCulture;
+        Thread.CurrentThread.CurrentUICulture = _originalUiCulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/LatitudeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/LatitudeTypeTests.cs
@@ -1,3 +1,4 @@
+using CookieCrumble.Attributes;
 using HotChocolate.Execution;
 using HotChocolate.Language;
 using Microsoft.Extensions.DependencyInjection;
@@ -184,6 +185,7 @@ public class LatitudeTypeTests : ScalarTypeTestBase
     }
 
     [Theory]
+    [UseCulture("en-US")]
     [InlineData("38° 36' 0.000\" S", -38.6, 1)]
     [InlineData("66° 54' 0.000\" S", -66.9, 1)]
     [InlineData("39° 51' 21.600\" N", 39.86, 2)]
@@ -259,6 +261,7 @@ public class LatitudeTypeTests : ScalarTypeTestBase
     }
 
     [Theory]
+    [UseCulture("en-US")]
     [InlineData(-38.6, "38° 36' 0\" S")]
     [InlineData(-66.9, "66° 54' 0\" S")]
     [InlineData(52.33, "52° 19' 48\" N")]

--- a/src/HotChocolate/Core/test/Types.Scalars.Tests/LongitudeTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Scalars.Tests/LongitudeTypeTests.cs
@@ -1,3 +1,4 @@
+using CookieCrumble.Attributes;
 using HotChocolate.Execution;
 using HotChocolate.Language;
 using Microsoft.Extensions.DependencyInjection;
@@ -185,6 +186,7 @@ public class LongitudeTypeTests : ScalarTypeTestBase
     }
 
     [Theory]
+    [UseCulture("en-US")]
     [InlineData("176° 19' 26.576\" E", 176.3, 1)]
     [InlineData("62° 12' 48.831\" W", -62.2, 1)]
     [InlineData("4° 46' 6.456\" W", -4.77, 2)]
@@ -260,6 +262,7 @@ public class LongitudeTypeTests : ScalarTypeTestBase
     }
 
     [Theory]
+    [UseCulture("en-US")]
     [InlineData(179d, "179° 0' 0\" E")]
     [InlineData(-179d, "179° 0' 0\" W")]
     [InlineData(174.3, "174° 18' 0\" E")]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/JsonTypeTests.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Text.Json;
 using CookieCrumble;
+using CookieCrumble.Attributes;
 using HotChocolate.Execution;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -124,6 +125,7 @@ public class JsonTypeTests
     }
 
     [Theory]
+    [UseCulture("en-US")]
     [InlineData(0)]
     [InlineData(-15)]
     [InlineData(-10.5)]


### PR DESCRIPTION
Some tests compare the results of graphql queries agains a snapshot. If the snapshot contains numbers or dates/time the assertion will not match if the machine running the test is not using the same culture setting. The current tests fails due to my local culture (no-NB) formats numbers using comma instead of dot as decimal precision.

To solve this the current PR adds the UseCultureAttribute from the xunit sample code and annotated the failing tests to use en-US culture.
