### PR TITLE
Fixed EfQueryableCursorPagingHandler (hasNextPage & hasPreviousPage)

### DIFF
--- a/src/HotChocolate/Data/src/EntityFramework/Pagination/EfQueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Data/src/EntityFramework/Pagination/EfQueryableCursorPagingHandler.cs
@@ -107,7 +107,7 @@ internal sealed class EfQueryableCursorPagingHandler<TEntity>(PagingOptions opti
 
                 if (fetchCount > requestedCount)
                 {
-                    continue;
+                    break;
                 }
 
                 builder.Add(new Edge<TEntity>(item.Item, CursorFormatter.Format(item.Item, keys)));
@@ -125,7 +125,7 @@ internal sealed class EfQueryableCursorPagingHandler<TEntity>(PagingOptions opti
 
                 if (fetchCount > requestedCount)
                 {
-                    continue;
+                    break;
                 }
 
                 builder.Add(new Edge<TEntity>(item, CursorFormatter.Format(item, keys)));

--- a/src/HotChocolate/Data/src/EntityFramework/Pagination/EfQueryableCursorPagingHandler.cs
+++ b/src/HotChocolate/Data/src/EntityFramework/Pagination/EfQueryableCursorPagingHandler.cs
@@ -62,7 +62,7 @@ internal sealed class EfQueryableCursorPagingHandler<TEntity>(PagingOptions opti
 
         if (arguments.Last is not null)
         {
-            query = query.Reverse().Take(arguments.Last.Value);
+            query = query.Reverse().Take(arguments.Last.Value + 1);
             requestedCount = arguments.Last.Value;
         }
 
@@ -103,14 +103,15 @@ internal sealed class EfQueryableCursorPagingHandler<TEntity>(PagingOptions opti
                 .ToAsyncEnumerable(context.RequestAborted)
                 .ConfigureAwait(false))
             {
-                builder.Add(new Edge<TEntity>(item.Item, CursorFormatter.Format(item.Item, keys)));
-                totalCount ??= item.TotalCount;
                 fetchCount++;
 
-                if (fetchCount >= requestedCount)
+                if (fetchCount > requestedCount)
                 {
-                    break;
+                    continue;
                 }
+
+                builder.Add(new Edge<TEntity>(item.Item, CursorFormatter.Format(item.Item, keys)));
+                totalCount ??= item.TotalCount;
             }
         }
         else
@@ -120,13 +121,14 @@ internal sealed class EfQueryableCursorPagingHandler<TEntity>(PagingOptions opti
                 .ToAsyncEnumerable(context.RequestAborted)
                 .ConfigureAwait(false))
             {
-                builder.Add(new Edge<TEntity>(item, CursorFormatter.Format(item, keys)));
                 fetchCount++;
 
-                if (fetchCount >= requestedCount)
+                if (fetchCount > requestedCount)
                 {
-                    break;
+                    continue;
                 }
+
+                builder.Add(new Edge<TEntity>(item, CursorFormatter.Format(item, keys)));
             }
         }
 

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using CookieCrumble;
 using HotChocolate.Data.Sorting;
@@ -232,6 +232,76 @@ public class IntegrationTests(PostgreSqlResource resource)
                             name
                         }
                         pageInfo {
+                            endCursor
+                        }
+                    }
+                }
+                """)
+            .SetGlobalState("printSQL", true));
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
+    public async Task Paging_First_10_With_Default_Sorting_HasNextPage()
+    {
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+
+        var executor = await new ServiceCollection()
+            .AddScoped(_ => new CatalogContext(connectionString))
+            .AddGraphQLServer()
+            .AddQueryType<Query>()
+            .AddSorting()
+            .AddDbContextCursorPagingProvider()
+            .BuildRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(q => q
+            .SetDocument(
+                """
+                {
+                    brands(first: 10) {
+                        nodes {
+                            name
+                        }
+                        pageInfo {
+                            hasNextPage
+                            hasPreviousPage
+                            endCursor
+                        }
+                    }
+                }
+                """)
+            .SetGlobalState("printSQL", true));
+
+        result.MatchMarkdownSnapshot();
+    }
+
+    [Fact]
+    public async Task Paging_Last_10_With_Default_Sorting_HasPreviousPage()
+    {
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+
+        var executor = await new ServiceCollection()
+            .AddScoped(_ => new CatalogContext(connectionString))
+            .AddGraphQLServer()
+            .AddQueryType<Query>()
+            .AddSorting()
+            .AddDbContextCursorPagingProvider()
+            .BuildRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(q => q
+            .SetDocument(
+                """
+                {
+                    brands(last: 10) {
+                        nodes {
+                            name
+                        }
+                        pageInfo {
+                            hasNextPage
+                            hasPreviousPage
                             endCursor
                         }
                     }

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/__snapshots__/IntegrationTests.Paging_First_10_With_Default_Sorting_HasNextPage.md
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/__snapshots__/IntegrationTests.Paging_First_10_With_Default_Sorting_HasNextPage.md
@@ -1,0 +1,50 @@
+# Paging_First_10_With_Default_Sorting_HasNextPage
+
+```json
+{
+  "data": {
+    "brands": {
+      "nodes": [
+        {
+          "name": "Brand0"
+        },
+        {
+          "name": "Brand1"
+        },
+        {
+          "name": "Brand2"
+        },
+        {
+          "name": "Brand3"
+        },
+        {
+          "name": "Brand4"
+        },
+        {
+          "name": "Brand5"
+        },
+        {
+          "name": "Brand6"
+        },
+        {
+          "name": "Brand7"
+        },
+        {
+          "name": "Brand8"
+        },
+        {
+          "name": "Brand9"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "endCursor": "MTA="
+      }
+    }
+  },
+  "extensions": {
+    "sql": "-- @__p_0='11'\nSELECT b.\"Id\", b.\"AlwaysNull\", b.\"DisplayName\", b.\"Name\", b.\"BrandDetails_Country_Name\"\nFROM \"Brands\" AS b\nORDER BY b.\"Id\"\nLIMIT @__p_0"
+  }
+}
+```

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/__snapshots__/IntegrationTests.Paging_Last_10_With_Default_Sorting_HasPreviousPage.md
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/__snapshots__/IntegrationTests.Paging_Last_10_With_Default_Sorting_HasPreviousPage.md
@@ -1,0 +1,50 @@
+# Paging_Last_10_With_Default_Sorting_HasPreviousPage
+
+```json
+{
+  "data": {
+    "brands": {
+      "nodes": [
+        {
+          "name": "Brand90"
+        },
+        {
+          "name": "Brand91"
+        },
+        {
+          "name": "Brand92"
+        },
+        {
+          "name": "Brand93"
+        },
+        {
+          "name": "Brand94"
+        },
+        {
+          "name": "Brand95"
+        },
+        {
+          "name": "Brand96"
+        },
+        {
+          "name": "Brand97"
+        },
+        {
+          "name": "Brand98"
+        },
+        {
+          "name": "Brand99"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": true,
+        "endCursor": "MTAw"
+      }
+    }
+  },
+  "extensions": {
+    "sql": "-- @__p_0='11'\nSELECT b.\"Id\", b.\"AlwaysNull\", b.\"DisplayName\", b.\"Name\", b.\"BrandDetails_Country_Name\"\nFROM \"Brands\" AS b\nORDER BY b.\"Id\" DESC\nLIMIT @__p_0"
+  }
+}
+```


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Ensure that the `fetchCount` can be greater than `arguments.First` and `arguments.Last` therefore setting `hasNextPage` and `hasPreviousPage` accordingly

Added tests to check for `hasNextPage` and `hasPreviousPage`

Closes #7500
