### PR TITLE
Upgraded MongoDB Driver to 2.29.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.14" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.29.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="NetTopologySuite" Version="2.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/HotChocolate/MongoDb/src/Data/Driver/FilterDefinitionExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/FilterDefinitionExtensions.cs
@@ -25,12 +25,12 @@ public static class FilterDefinitionExtensions
         {
             if (documentSerializer is IBsonSerializer<TDocument> typedSerializer)
             {
-                return _filter.Render(typedSerializer, serializerRegistry);
+                return _filter.Render(new(typedSerializer, serializerRegistry));
             }
 
-            return _filter.Render(
+            return _filter.Render(new(
                 serializerRegistry.GetSerializer<TDocument>(),
-                serializerRegistry);
+                serializerRegistry));
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/FilterDefinitionExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/FilterDefinitionExtensions.cs
@@ -7,30 +7,29 @@ namespace HotChocolate.Data.MongoDb;
 public static class FilterDefinitionExtensions
 {
     public static MongoDbFilterDefinition Wrap<T>(
-        this FilterDefinition<T> filterDefinition) =>
-        new FilterDefinitionWrapper<T>(filterDefinition);
+        this FilterDefinition<T> filterDefinition)
+        => new FilterDefinitionWrapper<T>(filterDefinition);
 
-    private sealed class FilterDefinitionWrapper<TDocument> : MongoDbFilterDefinition
+    private sealed class FilterDefinitionWrapper<TDocument>(
+        FilterDefinition<TDocument> filter)
+        : MongoDbFilterDefinition
     {
-        private readonly FilterDefinition<TDocument> _filter;
-
-        public FilterDefinitionWrapper(FilterDefinition<TDocument> filter)
-        {
-            _filter = filter;
-        }
-
         public override BsonDocument Render(
             IBsonSerializer documentSerializer,
             IBsonSerializerRegistry serializerRegistry)
         {
             if (documentSerializer is IBsonSerializer<TDocument> typedSerializer)
             {
-                return _filter.Render(new(typedSerializer, serializerRegistry));
+                return filter.Render(
+                    new RenderArgs<TDocument>(
+                        typedSerializer,
+                        serializerRegistry));
             }
 
-            return _filter.Render(new(
-                serializerRegistry.GetSerializer<TDocument>(),
-                serializerRegistry));
+            return filter.Render(
+                new RenderArgs<TDocument>(
+                    serializerRegistry.GetSerializer<TDocument>(),
+                    serializerRegistry));
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
@@ -33,6 +33,11 @@ public abstract class MongoDbFilterDefinition : FilterDefinition<BsonDocument>
         return Render(documentSerializer, serializerRegistry);
     }
 
+    public override BsonDocument Render(RenderArgs<BsonDocument> args)
+    {
+        return Render(args.DocumentSerializer, args.SerializerRegistry);
+    }
+
     public FilterDefinition<T> ToFilterDefinition<T>() => new FilterDefinitionWrapper<T>(this);
 
     private sealed class FilterDefinitionWrapper<T> : FilterDefinition<T>
@@ -57,6 +62,11 @@ public abstract class MongoDbFilterDefinition : FilterDefinition<BsonDocument>
             LinqProvider provider)
         {
             return Render(documentSerializer, serializerRegistry);
+        }
+
+        public override BsonDocument Render(RenderArgs<T> args)
+        {
+            return _filter.Render(args.DocumentSerializer, args.SerializerRegistry);
         }
     }
 

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
@@ -11,41 +11,30 @@ public abstract class MongoDbFilterDefinition : FilterDefinition<BsonDocument>
     /// <summary>
     /// Gets an empty filter. An empty filter matches everything.
     /// </summary>
-    public static new MongoDbFilterDefinition Empty => MongoDbFilterDefinition._empty;
+    public new static MongoDbFilterDefinition Empty => _empty;
 
     public abstract BsonDocument Render(
         IBsonSerializer documentSerializer,
         IBsonSerializerRegistry serializerRegistry);
 
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
-    {
-        return Render(args.DocumentSerializer, args.SerializerRegistry);
-    }
+        => Render(args.DocumentSerializer, args.SerializerRegistry);
 
     public FilterDefinition<T> ToFilterDefinition<T>() => new FilterDefinitionWrapper<T>(this);
 
-    private sealed class FilterDefinitionWrapper<T> : FilterDefinition<T>
+    private sealed class FilterDefinitionWrapper<T>(
+        MongoDbFilterDefinition filter)
+        : FilterDefinition<T>
     {
-        private readonly MongoDbFilterDefinition _filter;
-
-        public FilterDefinitionWrapper(MongoDbFilterDefinition filter)
-        {
-            _filter = filter;
-        }
-
         public override BsonDocument Render(RenderArgs<T> args)
-        {
-            return _filter.Render(args.DocumentSerializer, args.SerializerRegistry);
-        }
+            => filter.Render(args.DocumentSerializer, args.SerializerRegistry);
     }
 
-    internal sealed class MongoDbEmptyFilterDefinition : MongoDbFilterDefinition
+    private sealed class MongoDbEmptyFilterDefinition : MongoDbFilterDefinition
     {
         public override BsonDocument Render(
             IBsonSerializer documentSerializer,
             IBsonSerializerRegistry serializerRegistry)
-        {
-            return new BsonDocument();
-        }
+            => new();
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbFilterDefinition.cs
@@ -1,7 +1,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 namespace HotChocolate.Data.MongoDb;
 
@@ -18,21 +17,6 @@ public abstract class MongoDbFilterDefinition : FilterDefinition<BsonDocument>
         IBsonSerializer documentSerializer,
         IBsonSerializerRegistry serializerRegistry);
 
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
-
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry,
-        LinqProvider provider)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
-
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
     {
         return Render(args.DocumentSerializer, args.SerializerRegistry);
@@ -47,21 +31,6 @@ public abstract class MongoDbFilterDefinition : FilterDefinition<BsonDocument>
         public FilterDefinitionWrapper(MongoDbFilterDefinition filter)
         {
             _filter = filter;
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<T> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry)
-        {
-            return _filter.Render(documentSerializer, serializerRegistry);
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<T> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry,
-            LinqProvider provider)
-        {
-            return Render(documentSerializer, serializerRegistry);
         }
 
         public override BsonDocument Render(RenderArgs<T> args)

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
@@ -26,6 +26,11 @@ public abstract class MongoDbProjectionDefinition : ProjectionDefinition<BsonDoc
         return Render(documentSerializer, serializerRegistry);
     }
 
+    public override BsonDocument Render(RenderArgs<BsonDocument> args)
+    {
+        return Render(args.DocumentSerializer, args.SerializerRegistry);
+    }
+
     public ProjectionDefinition<T> ToProjectionDefinition<T>() =>
         new ProjectionDefinitionWrapper<T>(this);
 
@@ -51,6 +56,11 @@ public abstract class MongoDbProjectionDefinition : ProjectionDefinition<BsonDoc
             LinqProvider provider)
         {
             return Render(documentSerializer, serializerRegistry);
+        }
+
+        public override BsonDocument Render(RenderArgs<T> args)
+        {
+            return _filter.Render(args.DocumentSerializer, args.SerializerRegistry);
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
@@ -11,25 +11,16 @@ public abstract class MongoDbProjectionDefinition : ProjectionDefinition<BsonDoc
         IBsonSerializerRegistry serializerRegistry);
 
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
-    {
-        return Render(args.DocumentSerializer, args.SerializerRegistry);
-    }
+        => Render(args.DocumentSerializer, args.SerializerRegistry);
 
     public ProjectionDefinition<T> ToProjectionDefinition<T>() =>
         new ProjectionDefinitionWrapper<T>(this);
 
-    private sealed class ProjectionDefinitionWrapper<T> : ProjectionDefinition<T>
+    private sealed class ProjectionDefinitionWrapper<T>(
+        MongoDbProjectionDefinition filter)
+        : ProjectionDefinition<T>
     {
-        private readonly MongoDbProjectionDefinition _filter;
-
-        public ProjectionDefinitionWrapper(MongoDbProjectionDefinition filter)
-        {
-            _filter = filter;
-        }
-
         public override BsonDocument Render(RenderArgs<T> args)
-        {
-            return _filter.Render(args.DocumentSerializer, args.SerializerRegistry);
-        }
+            => filter.Render(args.DocumentSerializer, args.SerializerRegistry);
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbProjectionDefinition.cs
@@ -1,7 +1,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 namespace HotChocolate.Data.MongoDb;
 
@@ -10,21 +9,6 @@ public abstract class MongoDbProjectionDefinition : ProjectionDefinition<BsonDoc
     public abstract BsonDocument Render(
         IBsonSerializer documentSerializer,
         IBsonSerializerRegistry serializerRegistry);
-
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
-
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry,
-        LinqProvider provider)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
 
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
     {
@@ -41,21 +25,6 @@ public abstract class MongoDbProjectionDefinition : ProjectionDefinition<BsonDoc
         public ProjectionDefinitionWrapper(MongoDbProjectionDefinition filter)
         {
             _filter = filter;
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<T> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry)
-        {
-            return _filter.Render(documentSerializer, serializerRegistry);
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<T> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry,
-            LinqProvider provider)
-        {
-            return Render(documentSerializer, serializerRegistry);
         }
 
         public override BsonDocument Render(RenderArgs<T> args)

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
@@ -1,7 +1,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 namespace HotChocolate.Data.MongoDb;
 
@@ -10,21 +9,6 @@ public abstract class MongoDbSortDefinition : SortDefinition<BsonDocument>
     public abstract BsonDocument Render(
         IBsonSerializer documentSerializer,
         IBsonSerializerRegistry serializerRegistry);
-
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
-
-    public override BsonDocument Render(
-        IBsonSerializer<BsonDocument> documentSerializer,
-        IBsonSerializerRegistry serializerRegistry,
-        LinqProvider provider)
-    {
-        return Render(documentSerializer, serializerRegistry);
-    }
 
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
     {
@@ -40,21 +24,6 @@ public abstract class MongoDbSortDefinition : SortDefinition<BsonDocument>
         public SortDefinitionWrapper(MongoDbSortDefinition sort)
         {
             _sort = sort;
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<TDocument> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry)
-        {
-            return _sort.Render(documentSerializer, serializerRegistry);
-        }
-
-        public override BsonDocument Render(
-            IBsonSerializer<TDocument> documentSerializer,
-            IBsonSerializerRegistry serializerRegistry,
-            LinqProvider provider)
-        {
-            return Render(documentSerializer, serializerRegistry);
         }
 
         public override BsonDocument Render(RenderArgs<TDocument> args)

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
@@ -26,6 +26,11 @@ public abstract class MongoDbSortDefinition : SortDefinition<BsonDocument>
         return Render(documentSerializer, serializerRegistry);
     }
 
+    public override BsonDocument Render(RenderArgs<BsonDocument> args)
+    {
+        return Render(args.DocumentSerializer, args.SerializerRegistry);
+    }
+
     public SortDefinition<T> ToSortDefinition<T>() => new SortDefinitionWrapper<T>(this);
 
     private sealed class SortDefinitionWrapper<TDocument> : SortDefinition<TDocument>
@@ -50,6 +55,11 @@ public abstract class MongoDbSortDefinition : SortDefinition<BsonDocument>
             LinqProvider provider)
         {
             return Render(documentSerializer, serializerRegistry);
+        }
+
+        public override BsonDocument Render(RenderArgs<TDocument> args)
+        {
+            return _sort.Render(args.DocumentSerializer, args.SerializerRegistry);
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/MongoDbSortDefinition.cs
@@ -11,24 +11,15 @@ public abstract class MongoDbSortDefinition : SortDefinition<BsonDocument>
         IBsonSerializerRegistry serializerRegistry);
 
     public override BsonDocument Render(RenderArgs<BsonDocument> args)
-    {
-        return Render(args.DocumentSerializer, args.SerializerRegistry);
-    }
+        => Render(args.DocumentSerializer, args.SerializerRegistry);
 
     public SortDefinition<T> ToSortDefinition<T>() => new SortDefinitionWrapper<T>(this);
 
-    private sealed class SortDefinitionWrapper<TDocument> : SortDefinition<TDocument>
+    private sealed class SortDefinitionWrapper<TDocument>(
+        MongoDbSortDefinition sort)
+        : SortDefinition<TDocument>
     {
-        private readonly MongoDbSortDefinition _sort;
-
-        public SortDefinitionWrapper(MongoDbSortDefinition sort)
-        {
-            _sort = sort;
-        }
-
         public override BsonDocument Render(RenderArgs<TDocument> args)
-        {
-            return _sort.Render(args.DocumentSerializer, args.SerializerRegistry);
-        }
+            => sort.Render(args.DocumentSerializer, args.SerializerRegistry);
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/SortDefinitionExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/SortDefinitionExtensions.cs
@@ -6,30 +6,30 @@ namespace HotChocolate.Data.MongoDb;
 
 public static class SortDefinitionExtensions
 {
-    public static MongoDbSortDefinition Wrap<T>(this SortDefinition<T> sortDefinition) =>
-        new SortDefinitionWrapper<T>(sortDefinition);
+    public static MongoDbSortDefinition Wrap<T>(
+        this SortDefinition<T> sortDefinition)
+        => new SortDefinitionWrapper<T>(sortDefinition);
 
-    private sealed class SortDefinitionWrapper<TDocument> : MongoDbSortDefinition
+    private sealed class SortDefinitionWrapper<TDocument>(
+        SortDefinition<TDocument> sort)
+        : MongoDbSortDefinition
     {
-        private readonly SortDefinition<TDocument> _sort;
-
-        public SortDefinitionWrapper(SortDefinition<TDocument> sort)
-        {
-            _sort = sort;
-        }
-
         public override BsonDocument Render(
             IBsonSerializer documentSerializer,
             IBsonSerializerRegistry serializerRegistry)
         {
             if (documentSerializer is IBsonSerializer<TDocument> typedSerializer)
             {
-                return _sort.Render(new(typedSerializer, serializerRegistry));
+                return sort.Render(
+                    new RenderArgs<TDocument>(
+                        typedSerializer,
+                        serializerRegistry));
             }
 
-            return _sort.Render(new(
-                serializerRegistry.GetSerializer<TDocument>(),
-                serializerRegistry));
+            return sort.Render(
+                new RenderArgs<TDocument>(
+                    serializerRegistry.GetSerializer<TDocument>(),
+                    serializerRegistry));
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Driver/SortDefinitionExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Driver/SortDefinitionExtensions.cs
@@ -24,12 +24,12 @@ public static class SortDefinitionExtensions
         {
             if (documentSerializer is IBsonSerializer<TDocument> typedSerializer)
             {
-                return _sort.Render(typedSerializer, serializerRegistry);
+                return _sort.Render(new(typedSerializer, serializerRegistry));
             }
 
-            return _sort.Render(
+            return _sort.Render(new(
                 serializerRegistry.GetSerializer<TDocument>(),
-                serializerRegistry);
+                serializerRegistry));
         }
     }
 }

--- a/src/HotChocolate/MongoDb/src/Data/Extensions/BsonDocumentExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Extensions/BsonDocumentExtensions.cs
@@ -14,9 +14,15 @@ public static class BsonDocumentExtensions
 
     public static BsonDocument DefaultRender(
         this FilterDefinition<BsonDocument> bsonQuery)
-        => bsonQuery.Render(new(_documentSerializer, _serializerRegistry));
+        => bsonQuery.Render(
+            new RenderArgs<BsonDocument>(
+                _documentSerializer,
+                _serializerRegistry));
 
     public static BsonDocument DefaultRender(
         this SortDefinition<BsonDocument> bsonQuery)
-        => bsonQuery.Render(new(_documentSerializer, _serializerRegistry));
+        => bsonQuery.Render(
+            new RenderArgs<BsonDocument>(
+                _documentSerializer,
+                _serializerRegistry));
 }

--- a/src/HotChocolate/MongoDb/src/Data/Extensions/BsonDocumentExtensions.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Extensions/BsonDocumentExtensions.cs
@@ -14,9 +14,9 @@ public static class BsonDocumentExtensions
 
     public static BsonDocument DefaultRender(
         this FilterDefinition<BsonDocument> bsonQuery)
-        => bsonQuery.Render(_documentSerializer, _serializerRegistry);
+        => bsonQuery.Render(new(_documentSerializer, _serializerRegistry));
 
     public static BsonDocument DefaultRender(
         this SortDefinition<BsonDocument> bsonQuery)
-        => bsonQuery.Render(_documentSerializer, _serializerRegistry);
+        => bsonQuery.Render(new(_documentSerializer, _serializerRegistry));
 }


### PR DESCRIPTION
2.29.0 has a binary incompatibility https://github.com/mongodb/mongo-csharp-driver/pull/1278