### PR TITLE
Expose annotations of wrapped Aspire ProjectResource

### DIFF
--- a/src/HotChocolate/Fusion/src/Aspire/Aspire/FusionGatewayResource.cs
+++ b/src/HotChocolate/Fusion/src/Aspire/Aspire/FusionGatewayResource.cs
@@ -8,6 +8,8 @@ public sealed class FusionGatewayResource(ProjectResource projectResource)
     , IResourceWithEnvironment
     , IResourceWithServiceDiscovery
 {
+    public override ResourceAnnotationCollection Annotations => projectResource.Annotations;
+
     public ProjectResource ProjectResource { get; } = projectResource;
 
     public EndpointReference GetEndpoint(string endpointName)


### PR DESCRIPTION
Allows other Aspire extension methods to access the `ProjectResource` wrapped inside the `FusionGatewayResource`.

- This fixes issues with other Aspire resources attempting to use data from the `IResourceBuilder<FusionGatewayResource>` created by `.AddFusionGateway<TProject>()`.
- It might also be desirable to use the `resourceBuilder.Resource.Annotations` directly in the `FusionExtensions` methods such as `SetFusionGatewayMetadata`. I haven't included this change.
- Note that the existing property implementation for `FusionGatewayResource.ProjectResource` raises:
  ```
  warning CS9124: Parameter 'ProjectResource projectResource' is captured into the state of the enclosing type and its value is also used to initialize a field, property, or event.
  ````
  which could also potentially be fixed by changing the declaration to `public ProjectResource ProjectResource => projectResource;`.

Closes #7544
