### PR TITLE
Used non-escaped text from XML doc summary for descriptions

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/XmlDocumentationProvider.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/XmlDocumentationProvider.cs
@@ -156,10 +156,13 @@ public class XmlDocumentationProvider : IDocumentationProvider
 
         foreach (var node in element.Nodes())
         {
-            var currentElement = node as XElement;
-            if (currentElement is null)
+            if (node is not XElement currentElement)
             {
-                description.Append(node);
+                if (node is XText text)
+                {
+                    description.Append(text.Value);
+                }
+
                 continue;
             }
 

--- a/src/HotChocolate/Core/test/Types.Tests.Documentation/ClassWithSummary.cs
+++ b/src/HotChocolate/Core/test/Types.Tests.Documentation/ClassWithSummary.cs
@@ -1,8 +1,6 @@
 namespace HotChocolate.Types.Descriptors;
 
 /// <summary>
-/// I am a test class.
+/// I am a test class. This should not be escaped: >
 /// </summary>
-public class ClassWithSummary
-{
-}
+public class ClassWithSummary;

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
@@ -316,7 +316,7 @@ public class XmlDocumentationProviderTests
             typeof(ClassWithSummary));
 
         // assert
-        Assert.Equal("I am a test class.", description);
+        Assert.Equal("I am a test class. This should not be escaped: >", description);
     }
 
     [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Used non-escaped text from XML doc summary for descriptions.

Closes #7521