### PR TITLE
Added migration section for MutationResult -> FieldResult

### DIFF
--- a/website/src/docs/hotchocolate/v14/migrating/migrate-from-13-to-14.md
+++ b/website/src/docs/hotchocolate/v14/migrating/migrate-from-13-to-14.md
@@ -169,6 +169,13 @@ Please ensure that your clients are sending date/time strings in the correct for
 | -------------- | ------------------- | ---------------------- |
 | cacheDirectory | "persisted_queries" | "persisted_operations" |
 
+## MutationResult renamed to FieldResult
+
+| Old name                      | New name                   |
+| ----------------------------- | -------------------------- |
+| MutationResult&lt;TResult&gt; | FieldResult&lt;TResult&gt; |
+| IMutationResult               | IFieldResult               |
+
 # Deprecations
 
 Things that will continue to function this release, but we encourage you to move away from.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added migration section for `MutationResult` -> `FieldResult`.