### PR TITLE
Added migration section for IOperationDocumentStorage

### DIFF
--- a/website/src/docs/hotchocolate/v14/migrating/migrate-from-13-to-14.md
+++ b/website/src/docs/hotchocolate/v14/migrating/migrate-from-13-to-14.md
@@ -176,6 +176,17 @@ Please ensure that your clients are sending date/time strings in the correct for
 | MutationResult&lt;TResult&gt; | FieldResult&lt;TResult&gt; |
 | IMutationResult               | IFieldResult               |
 
+## IReadStoredQueries and IWriteStoredQueries now IOperationDocumentStorage
+
+`IReadStoredQueries` and `IWriteStoredQueries` have been merged into a single interface named `IOperationDocumentStorage`.
+
+Renamed interface methods:
+
+| Old name          | New name     |
+| ----------------- | ------------ |
+| TryReadQueryAsync | TryReadAsync |
+| WriteQueryAsync   | SaveAsync    |
+
 # Deprecations
 
 Things that will continue to function this release, but we encourage you to move away from.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added migration section for `IOperationDocumentStorage`.