### PR TITLE
Make node and nodes field distinguishable

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
+++ b/src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
@@ -212,7 +212,7 @@ public static class WellKnownContextData
     /// <summary>
     /// The key to get check if a field is the nodes field.
     /// </summary>
-    public const string IsNodesField = "HotChocolate.Relay.Node.IsNodeField";
+    public const string IsNodesField = "HotChocolate.Relay.Node.IsNodesField";
 
     /// <summary>
     /// The key to override the max allowed execution depth.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Make the value of the `WellKnownContextData` constants `IsNodeField` and `IsNodesField` distinct.

The current values are identical, making them practically indistinguishable. Given that current code implementation does not need to distinguish them anywhere, having identical values functions equivalently, but is probably confusing.
