### PR TITLE
Add disableDefaultSecurity argument to AddGraphQLFunction

### DIFF
--- a/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions.IsolatedProcess/Extensions/HotChocolateAzFuncIsolatedProcessHostBuilderExtensions.cs
+++ b/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions.IsolatedProcess/Extensions/HotChocolateAzFuncIsolatedProcessHostBuilderExtensions.cs
@@ -25,6 +25,9 @@ public static class HotChocolateAzFuncIsolatedProcessHostBuilderExtensions
     /// <param name="maxAllowedRequestSize">
     /// The max allowed GraphQL request size.
     /// </param>
+    /// <param name="disableDefaultSecurity">
+    /// Defines if the default security policy should be disabled.
+    /// </param>
     /// <param name="apiRoute">
     /// The API route that was used in the GraphQL Azure Function.
     /// </param>
@@ -38,6 +41,7 @@ public static class HotChocolateAzFuncIsolatedProcessHostBuilderExtensions
         this IHostBuilder hostBuilder,
         Action<IRequestExecutorBuilder> configure,
         int maxAllowedRequestSize = GraphQLAzureFunctionsConstants.DefaultMaxRequests,
+        bool disableDefaultSecurity = false,
         string apiRoute = GraphQLAzureFunctionsConstants.DefaultGraphQLRoute)
     {
         if (hostBuilder is null)
@@ -51,7 +55,7 @@ public static class HotChocolateAzFuncIsolatedProcessHostBuilderExtensions
         }
 
         hostBuilder.ConfigureServices(
-            s => configure(s.AddGraphQLFunction(maxAllowedRequestSize, apiRoute)));
+            s => configure(s.AddGraphQLFunction(maxAllowedRequestSize, disableDefaultSecurity, apiRoute)));
 
         return hostBuilder;
     }

--- a/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateAzureFunctionServiceCollectionExtensions.cs
+++ b/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateAzureFunctionServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ public static class HotChocolateAzureFunctionServiceCollectionExtensions
     /// <param name="maxAllowedRequestSize">
     /// The max allowed GraphQL request size.
     /// </param>
+    /// <param name="disableDefaultSecurity">
+    /// Defines if the default security policy should be disabled.
+    /// </param>
     /// <param name="apiRoute">
     /// The API route that was used in the GraphQL Azure Function.
     /// </param>
@@ -39,6 +42,7 @@ public static class HotChocolateAzureFunctionServiceCollectionExtensions
     public static IRequestExecutorBuilder AddGraphQLFunction(
         this IServiceCollection services,
         int maxAllowedRequestSize = GraphQLAzureFunctionsConstants.DefaultMaxRequests,
+        bool disableDefaultSecurity = false,
         string apiRoute = GraphQLAzureFunctionsConstants.DefaultGraphQLRoute,
         string? schemaName = default)
     {
@@ -48,7 +52,7 @@ public static class HotChocolateAzureFunctionServiceCollectionExtensions
         }
 
         var executorBuilder =
-            services.AddGraphQLServer(maxAllowedRequestSize: maxAllowedRequestSize);
+            services.AddGraphQLServer(maxAllowedRequestSize: maxAllowedRequestSize, disableDefaultSecurity: disableDefaultSecurity);
 
         // Register AzFunc Custom Binding Extensions for In-Process Functions.
         // NOTE: This does not work for Isolated Process due to (but is not harmful at all of

--- a/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateFunctionsHostBuilderExtensions.cs
+++ b/src/HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/Extensions/HotChocolateFunctionsHostBuilderExtensions.cs
@@ -20,6 +20,9 @@ public static class HotChocolateFunctionsHostBuilderExtensions
     /// <param name="maxAllowedRequestSize">
     /// The max allowed GraphQL request size.
     /// </param>
+    /// <param name="disableDefaultSecurity">
+    /// Defines if the default security policy should be disabled.
+    /// </param>
     /// <param name="apiRoute">
     /// The API route that was used in the GraphQL Azure Function.
     /// </param>
@@ -32,6 +35,7 @@ public static class HotChocolateFunctionsHostBuilderExtensions
     public static IRequestExecutorBuilder AddGraphQLFunction(
         this IFunctionsHostBuilder hostBuilder,
         int maxAllowedRequestSize = GraphQLAzureFunctionsConstants.DefaultMaxRequests,
+        bool disableDefaultSecurity = false,
         string apiRoute = GraphQLAzureFunctionsConstants.DefaultGraphQLRoute)
     {
         if (hostBuilder is null)
@@ -39,7 +43,7 @@ public static class HotChocolateFunctionsHostBuilderExtensions
             throw new ArgumentNullException(nameof(hostBuilder));
         }
 
-        return hostBuilder.Services.AddGraphQLFunction(maxAllowedRequestSize, apiRoute);
+        return hostBuilder.Services.AddGraphQLFunction(maxAllowedRequestSize, disableDefaultSecurity, apiRoute);
     }
 
     /// <summary>
@@ -57,6 +61,9 @@ public static class HotChocolateFunctionsHostBuilderExtensions
     /// <param name="maxAllowedRequestSize">
     /// The max allowed GraphQL request size.
     /// </param>
+    /// <param name="disableDefaultSecurity">
+    /// Defines if the default security policy should be disabled.
+    /// </param>
     /// <param name="apiRoute">
     /// The API route that was used in the GraphQL Azure Function.
     /// </param>
@@ -70,6 +77,7 @@ public static class HotChocolateFunctionsHostBuilderExtensions
         this IFunctionsHostBuilder hostBuilder,
         Action<IRequestExecutorBuilder> configure,
         int maxAllowedRequestSize = GraphQLAzureFunctionsConstants.DefaultMaxRequests,
+        bool disableDefaultSecurity = false,
         string apiRoute = GraphQLAzureFunctionsConstants.DefaultGraphQLRoute)
     {
         if (hostBuilder is null)
@@ -82,7 +90,7 @@ public static class HotChocolateFunctionsHostBuilderExtensions
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var executorBuilder = hostBuilder.AddGraphQLFunction(maxAllowedRequestSize, apiRoute);
+        var executorBuilder = hostBuilder.AddGraphQLFunction(maxAllowedRequestSize, disableDefaultSecurity, apiRoute);
         configure.Invoke(executorBuilder);
 
         return hostBuilder;


### PR DESCRIPTION
Add `disableDefaultSecurity` argument to `AddGraphQLFunction` like `AddGraphQLServer` also has, so we can disable default security also when using Azure Functions.

Closes #7599
