### PR TITLE
The OperationExecutor does not emit error results

### DIFF
--- a/src/StrawberryShake/Client/src/Core/OperationExecutor.Observable.cs
+++ b/src/StrawberryShake/Client/src/Core/OperationExecutor.Observable.cs
@@ -91,12 +91,19 @@ public partial class OperationExecutor<TData, TResult>
                         result = resultBuilder.Build(response);
                     }
 
+                    if (result.IsErrorResult())
+                    {
+                        observer.OnNext(result);
+                        break;
+                    }
+
                     // Emit the result, if it isn't a duplicate
                     if (!Equals(result.Data, lastEmittedResult?.Data))
                     {
                         observer.OnNext(result);
                         lastEmittedResult = result;
                     }
+
                     _operationStore.Set(_request, result);
                 }
 

--- a/src/StrawberryShake/Client/src/Core/StorelessOperationExecutor.Observable.cs
+++ b/src/StrawberryShake/Client/src/Core/StorelessOperationExecutor.Observable.cs
@@ -49,7 +49,12 @@ public partial class StorelessOperationExecutor<TData, TResult>
                         return;
                     }
 
-                    observer.OnNext(resultBuilder.Build(response));
+                    var result = resultBuilder.Build(response);
+                    observer.OnNext(result);
+                    if (result.IsErrorResult())
+                    {
+                        break;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
When the `OperationExecutor` does not emit any error results, because the `Result` is always null.

I was not sure how best to fix this, and I'm not as deeply involved in the spec, so this is my best guess atm.
Basically if any error results are found, `OperationExecutor` will `OnNext` and complete the observable.  This could be wrong behavior instead of just `OnNext` the result and move on.

I made the change to both `OperationExecutor` and `StorelessOperationExecutor` so their behavior would be consistent. (And to help identify if I'm thinking about errors all the wrong way).
