### PR TITLE
Make "CreateParameter" public

### DIFF
--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/FilterExpressionBuilder.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/FilterExpressionBuilder.cs
@@ -205,7 +205,7 @@ public static class FilterExpressionBuilder
             nameof(parameter.p));
     }
 
-    private static Expression CreateParameter(object? value, Type type)
+    public static Expression CreateParameter(object? value, Type type)
     {
         if (value is null)
         {


### PR DESCRIPTION
Making "CreateParameter" assists in scenarios where developers are writing their own custom FilterConventions, enabling code like this ( https://github.com/PascalSenn/Filtering.Demo/blob/master/QueryableStringInvariantEqualsHandler.cs ) to easily parameterize strings, rather than embedding the raw string into the query
