### PR TITLE
Added opt-in features

### DIFF
--- a/src/HotChocolate/Core/src/Abstractions/WellKnownDirectives.cs
+++ b/src/HotChocolate/Core/src/Abstractions/WellKnownDirectives.cs
@@ -69,4 +69,29 @@ public static class WellKnownDirectives
     /// The name of the @tag argument name.
     /// </summary>
     public const string Name = "name";
+
+    /// <summary>
+    /// The name of the @requiresOptIn directive.
+    /// </summary>
+    public const string RequiresOptIn = "requiresOptIn";
+
+    /// <summary>
+    /// The name of the @requiresOptIn feature argument.
+    /// </summary>
+    public const string RequiresOptInFeatureArgument = "feature";
+
+    /// <summary>
+    /// The name of the @optInFeatureStability directive.
+    /// </summary>
+    public const string OptInFeatureStability = "optInFeatureStability";
+
+    /// <summary>
+    /// The name of the @optInFeatureStability feature argument.
+    /// </summary>
+    public const string OptInFeatureStabilityFeatureArgument = "feature";
+
+    /// <summary>
+    /// The name of the @optInFeatureStability stability argument.
+    /// </summary>
+    public const string OptInFeatureStabilityStabilityArgument = "stability";
 }

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/RequiresOptInValidationRule.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/RequiresOptInValidationRule.cs
@@ -1,0 +1,67 @@
+using HotChocolate.Types;
+using HotChocolate.Types.Descriptors;
+using static HotChocolate.Utilities.ErrorHelper;
+
+namespace HotChocolate.Configuration.Validation;
+
+internal sealed class RequiresOptInValidationRule : ISchemaValidationRule
+{
+    public void Validate(
+        IDescriptorContext context,
+        ISchema schema,
+        ICollection<ISchemaError> errors)
+    {
+        if (!context.Options.EnableOptInFeatures)
+        {
+            return;
+        }
+
+        foreach (var type in schema.Types)
+        {
+            switch (type)
+            {
+                case IInputObjectType inputObjectType:
+                    foreach (var field in inputObjectType.Fields)
+                    {
+                        if (field.Type.IsNonNullType() && field.DefaultValue is null)
+                        {
+                            var requiresOptInDirectives = field.Directives
+                                .Where(d => d.Type is RequiresOptInDirectiveType);
+
+                            foreach (var _ in requiresOptInDirectives)
+                            {
+                                errors.Add(RequiresOptInOnRequiredInputField(
+                                    inputObjectType,
+                                    field));
+                            }
+                        }
+                    }
+
+                    break;
+
+                case IObjectType objectType:
+                    foreach (var field in objectType.Fields)
+                    {
+                        foreach (var argument in field.Arguments)
+                        {
+                            if (argument.Type.IsNonNullType() && argument.DefaultValue is null)
+                            {
+                                var requiresOptInDirectives = argument.Directives
+                                    .Where(d => d.Type is RequiresOptInDirectiveType);
+
+                                foreach (var _ in requiresOptInDirectives)
+                                {
+                                    errors.Add(RequiresOptInOnRequiredArgument(
+                                        objectType,
+                                        field,
+                                        argument));
+                                }
+                            }
+                        }
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/Validation/SchemaValidator.cs
@@ -12,7 +12,8 @@ internal static class SchemaValidator
         new DirectiveValidationRule(),
         new InterfaceHasAtLeastOneImplementationRule(),
         new IsSelectedPatternValidation(),
-        new EnsureFieldResultsDeclareErrorsRule()
+        new EnsureFieldResultsDeclareErrorsRule(),
+        new RequiresOptInValidationRule()
     ];
 
     public static IReadOnlyList<ISchemaError> Validate(

--- a/src/HotChocolate/Core/src/Types/IReadOnlySchemaOptions.cs
+++ b/src/HotChocolate/Core/src/Types/IReadOnlySchemaOptions.cs
@@ -186,6 +186,11 @@ public interface IReadOnlySchemaOptions
     bool EnableTag { get; }
 
     /// <summary>
+    /// Specifies that the opt-in features functionality will be enabled.
+    /// </summary>
+    bool EnableOptInFeatures { get; }
+
+    /// <summary>
     /// Specifies the default dependency injection scope for query fields.
     /// </summary>
     public DependencyInjectionScope DefaultQueryDependencyInjectionScope { get; }

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.Designer.cs
@@ -1025,6 +1025,24 @@ namespace HotChocolate.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The @requiresOptIn directive must not appear on required (non-null without a default) arguments..
+        /// </summary>
+        internal static string ErrorHelper_RequiresOptInOnRequiredArgument {
+            get {
+                return ResourceManager.GetString("ErrorHelper_RequiresOptInOnRequiredArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The @requiresOptIn directive must not appear on required (non-null without a default) input object field definitions..
+        /// </summary>
+        internal static string ErrorHelper_RequiresOptInOnRequiredInputField {
+            get {
+                return ResourceManager.GetString("ErrorHelper_RequiresOptInOnRequiredInputField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field names starting with `__` are reserved for the GraphQL specification..
         /// </summary>
         internal static string ErrorHelper_TwoUnderscoresNotAllowedField {
@@ -1515,6 +1533,42 @@ namespace HotChocolate.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An OptInFeatureStability object describes the stability level of an opt-in feature..
+        /// </summary>
+        internal static string OptInFeatureStability_Description {
+            get {
+                return ResourceManager.GetString("OptInFeatureStability_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the feature for which to set the stability..
+        /// </summary>
+        internal static string OptInFeatureStabilityDirectiveType_FeatureDescription {
+            get {
+                return ResourceManager.GetString("OptInFeatureStabilityDirectiveType_FeatureDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The stability level of the feature..
+        /// </summary>
+        internal static string OptInFeatureStabilityDirectiveType_StabilityDescription {
+            get {
+                return ResourceManager.GetString("OptInFeatureStabilityDirectiveType_StabilityDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets the stability level of an opt-in feature..
+        /// </summary>
+        internal static string OptInFeatureStabilityDirectiveType_TypeDescription {
+            get {
+                return ResourceManager.GetString("OptInFeatureStabilityDirectiveType_TypeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The member expression must specify a property or method that is public and that belongs to the type {0}.
         /// </summary>
         internal static string Reflection_MemberMust_BeMethodOrProperty {
@@ -1592,6 +1646,33 @@ namespace HotChocolate.Properties {
         internal static string Relay_NodesField_Ids_Description {
             get {
                 return ResourceManager.GetString("Relay_NodesField_Ids_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RequiresOptIn is not supported on the specified descriptor..
+        /// </summary>
+        internal static string RequiresOptInDirective_Descriptor_NotSupported {
+            get {
+                return ResourceManager.GetString("RequiresOptInDirective_Descriptor_NotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the feature that requires opt in..
+        /// </summary>
+        internal static string RequiresOptInDirectiveType_FeatureDescription {
+            get {
+                return ResourceManager.GetString("RequiresOptInDirectiveType_FeatureDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used..
+        /// </summary>
+        internal static string RequiresOptInDirectiveType_TypeDescription {
+            get {
+                return ResourceManager.GetString("RequiresOptInDirectiveType_TypeDescription", resourceCulture);
             }
         }
         

--- a/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
+++ b/src/HotChocolate/Core/src/Types/Properties/TypeResources.resx
@@ -1003,4 +1003,31 @@ Type: `{0}`</value>
   <data name="ObjectToDictionaryConverter_CycleInObjectGraph" xml:space="preserve">
     <value>Cycle in object graph detected.</value>
   </data>
+  <data name="RequiresOptInDirectiveType_TypeDescription" xml:space="preserve">
+    <value>Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used.</value>
+  </data>
+  <data name="RequiresOptInDirectiveType_FeatureDescription" xml:space="preserve">
+    <value>The name of the feature that requires opt in.</value>
+  </data>
+  <data name="RequiresOptInDirective_Descriptor_NotSupported" xml:space="preserve">
+    <value>RequiresOptIn is not supported on the specified descriptor.</value>
+  </data>
+  <data name="OptInFeatureStabilityDirectiveType_TypeDescription" xml:space="preserve">
+    <value>Sets the stability level of an opt-in feature.</value>
+  </data>
+  <data name="OptInFeatureStabilityDirectiveType_FeatureDescription" xml:space="preserve">
+    <value>The name of the feature for which to set the stability.</value>
+  </data>
+  <data name="OptInFeatureStabilityDirectiveType_StabilityDescription" xml:space="preserve">
+    <value>The stability level of the feature.</value>
+  </data>
+  <data name="OptInFeatureStability_Description" xml:space="preserve">
+    <value>An OptInFeatureStability object describes the stability level of an opt-in feature.</value>
+  </data>
+  <data name="ErrorHelper_RequiresOptInOnRequiredInputField" xml:space="preserve">
+    <value>The @requiresOptIn directive must not appear on required (non-null without a default) input object field definitions.</value>
+  </data>
+  <data name="ErrorHelper_RequiresOptInOnRequiredArgument" xml:space="preserve">
+    <value>The @requiresOptIn directive must not appear on required (non-null without a default) arguments.</value>
+  </data>
 </root>

--- a/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaBuilder.cs
@@ -37,6 +37,7 @@ public partial class SchemaBuilder : ISchemaBuilder
         typeof(InterfaceCompletionTypeInterceptor),
         typeof(MiddlewareValidationTypeInterceptor),
         typeof(EnableTrueNullabilityTypeInterceptor),
+        typeof(OptInFeaturesTypeInterceptor)
     ];
 
     private SchemaOptions _options = new();

--- a/src/HotChocolate/Core/src/Types/SchemaOptions.cs
+++ b/src/HotChocolate/Core/src/Types/SchemaOptions.cs
@@ -216,6 +216,11 @@ public class SchemaOptions : IReadOnlySchemaOptions
     public bool EnableTag { get; set; } = true;
 
     /// <summary>
+    /// Specifies that the opt-in features functionality will be enabled.
+    /// </summary>
+    public bool EnableOptInFeatures { get; set; }
+
+    /// <summary>
     /// Defines the default dependency injection scope for query fields.
     /// </summary>
     public DependencyInjectionScope DefaultQueryDependencyInjectionScope { get; set; } =

--- a/src/HotChocolate/Core/src/Types/Types/Directives/Directives.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/Directives.cs
@@ -43,6 +43,15 @@ public static class Directives
             directiveTypes.Add(typeInspector.GetTypeRef(typeof(Tag)));
         }
 
+        if (descriptorContext.Options.EnableOptInFeatures)
+        {
+            directiveTypes.Add(
+                typeInspector.GetTypeRef(typeof(OptInFeatureStabilityDirectiveType)));
+
+            directiveTypes.Add(
+                typeInspector.GetTypeRef(typeof(RequiresOptInDirectiveType)));
+        }
+
         directiveTypes.Add(typeInspector.GetTypeRef(typeof(SkipDirectiveType)));
         directiveTypes.Add(typeInspector.GetTypeRef(typeof(IncludeDirectiveType)));
         directiveTypes.Add(typeInspector.GetTypeRef(typeof(DeprecatedDirectiveType)));

--- a/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirective.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirective.cs
@@ -1,0 +1,37 @@
+namespace HotChocolate.Types;
+
+public sealed class OptInFeatureStabilityDirective
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="OptInFeatureStabilityDirective"/>.
+    /// </summary>
+    /// <param name="feature">
+    /// The name of the feature for which to set the stability.
+    /// </param>
+    /// <param name="stability">
+    /// The stability level of the feature.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="feature"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="stability"/> is <c>null</c>.
+    /// </exception>
+    public OptInFeatureStabilityDirective(string feature, string stability)
+    {
+        Feature = feature ?? throw new ArgumentNullException(nameof(feature));
+        Stability = stability ?? throw new ArgumentNullException(nameof(stability));
+    }
+
+    /// <summary>
+    /// The name of the feature for which to set the stability.
+    /// </summary>
+    [GraphQLDescription("The name of the feature for which to set the stability.")]
+    public string Feature { get; }
+
+    /// <summary>
+    /// The stability level of the feature.
+    /// </summary>
+    [GraphQLDescription("The stability level of the feature.")]
+    public string Stability { get; }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirectiveExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirectiveExtensions.cs
@@ -1,0 +1,12 @@
+namespace HotChocolate.Types;
+
+public static class OptInFeatureStabilityDirectiveExtensions
+{
+    public static ISchemaTypeDescriptor OptInFeatureStability(
+        this ISchemaTypeDescriptor descriptor,
+        string feature,
+        string stability)
+    {
+        return descriptor.Directive(new OptInFeatureStabilityDirective(feature, stability));
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirectiveType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/OptInFeatureStabilityDirectiveType.cs
@@ -1,0 +1,32 @@
+using HotChocolate.Properties;
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Sets the stability level of an opt-in feature.
+/// </summary>
+public sealed class OptInFeatureStabilityDirectiveType
+    : DirectiveType<OptInFeatureStabilityDirective>
+{
+    protected override void Configure(
+        IDirectiveTypeDescriptor<OptInFeatureStabilityDirective> descriptor)
+    {
+        descriptor
+            .Name(WellKnownDirectives.OptInFeatureStability)
+            .Description(TypeResources.OptInFeatureStabilityDirectiveType_TypeDescription)
+            .Location(DirectiveLocation.Schema)
+            .Repeatable();
+
+        descriptor
+            .Argument(t => t.Feature)
+            .Name(WellKnownDirectives.OptInFeatureStabilityFeatureArgument)
+            .Description(TypeResources.OptInFeatureStabilityDirectiveType_FeatureDescription)
+            .Type<NonNullType<StringType>>();
+
+        descriptor
+            .Argument(t => t.Stability)
+            .Name(WellKnownDirectives.OptInFeatureStabilityStabilityArgument)
+            .Description(TypeResources.OptInFeatureStabilityDirectiveType_StabilityDescription)
+            .Type<NonNullType<StringType>>();
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInAttribute.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInAttribute.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using HotChocolate.Properties;
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Indicates that the given field, argument, input field, or enum value requires giving explicit
+/// consent before being used.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Field // Required for enum values
+    | AttributeTargets.Method
+    | AttributeTargets.Parameter
+    | AttributeTargets.Property,
+    AllowMultiple = true)]
+public sealed class RequiresOptInAttribute : DescriptorAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiresOptInAttribute"/>
+    /// with a specific feature name and stability.
+    /// </summary>
+    /// <param name="feature">The name of the feature that requires opt in.</param>
+    public RequiresOptInAttribute(string feature)
+    {
+        Feature = feature ?? throw new ArgumentNullException(nameof(feature));
+    }
+
+    /// <summary>
+    /// The name of the feature that requires opt in.
+    /// </summary>
+    public string Feature { get; }
+
+    protected internal override void TryConfigure(
+        IDescriptorContext context,
+        IDescriptor descriptor,
+        ICustomAttributeProvider element)
+    {
+        switch (descriptor)
+        {
+            case IObjectFieldDescriptor desc:
+                desc.RequiresOptIn(Feature);
+                break;
+
+            case IInputFieldDescriptor desc:
+                desc.RequiresOptIn(Feature);
+                break;
+
+            case IArgumentDescriptor desc:
+                desc.RequiresOptIn(Feature);
+                break;
+
+            case IEnumValueDescriptor desc:
+                desc.RequiresOptIn(Feature);
+                break;
+
+            default:
+                throw new SchemaException(
+                    SchemaErrorBuilder.New()
+                        .SetMessage(TypeResources.RequiresOptInDirective_Descriptor_NotSupported)
+                        .SetExtension("member", element)
+                        .SetExtension("descriptor", descriptor)
+                        .Build());
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirective.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirective.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Indicates that the given field, argument, input field, or enum value requires giving explicit
+/// consent before being used.
+///
+/// <code>
+/// type Session {
+///     id: ID!
+///     title: String!
+///     # [...]
+///     startInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+///     endInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+/// }
+/// </code>
+/// </summary>
+[DirectiveType(
+    WellKnownDirectives.RequiresOptIn,
+    DirectiveLocation.ArgumentDefinition |
+    DirectiveLocation.EnumValue |
+    DirectiveLocation.FieldDefinition |
+    DirectiveLocation.InputFieldDefinition,
+    IsRepeatable = true)]
+[GraphQLDescription(
+    """
+    Indicates that the given field, argument, input field, or enum value requires giving explicit
+    consent before being used.
+
+    type Session {
+        id: ID!
+        title: String!
+        # [...]
+        startInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+        endInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+    }
+    """)]
+public sealed class RequiresOptInDirective
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="RequiresOptInDirective"/>.
+    /// </summary>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="feature"/> is <c>null</c>.
+    /// </exception>
+    public RequiresOptInDirective(string feature)
+    {
+        Feature = feature ?? throw new ArgumentNullException(nameof(feature));
+    }
+
+    /// <summary>
+    /// The name of the feature that requires opt in.
+    /// </summary>
+    [GraphQLDescription("The name of the feature that requires opt in.")]
+    public string Feature { get; }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveExtensions.cs
@@ -1,0 +1,147 @@
+using HotChocolate.Properties;
+
+namespace HotChocolate.Types;
+
+public static class RequiresOptInDirectiveExtensions
+{
+    /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to an <see cref="ObjectField"/>.
+    /// <code>
+    /// type Book {
+    ///   id: ID!
+    ///   title: String!
+    ///   author: String @requiresOptIn(feature: "your-feature")
+    /// }
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IObjectFieldDescriptor RequiresOptIn(
+        this IObjectFieldDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to an <see cref="InputField"/>.
+    /// <code>
+    /// input BookInput {
+    ///   title: String!
+    ///   author: String!
+    ///   publishedDate: String @requiresOptIn(feature: "your-feature")
+    /// }
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IInputFieldDescriptor RequiresOptIn(
+        this IInputFieldDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to an <see cref="Argument"/>.
+    /// <code>
+    /// type Query {
+    ///   books(search: String @requiresOptIn(feature: "your-feature")): [Book]
+    /// }
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IArgumentDescriptor RequiresOptIn(
+        this IArgumentDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Adds an <c>@requiresOptIn</c> directive to an <see cref="EnumValue"/>.
+    /// <code>
+    /// enum Episode {
+    ///   NEWHOPE @requiresOptIn(feature: "your-feature")
+    ///   EMPIRE
+    ///   JEDI
+    /// }
+    /// </code>
+    /// </summary>
+    /// <param name="descriptor">
+    /// The <paramref name="descriptor"/> on which this directive shall be annotated.
+    /// </param>
+    /// <param name="feature">
+    /// The name of the feature that requires opt in.
+    /// </param>
+    /// <returns>
+    /// Returns the <paramref name="descriptor"/> on which this directive
+    /// was applied for configuration chaining.
+    /// </returns>
+    public static IEnumValueDescriptor RequiresOptIn(
+        this IEnumValueDescriptor descriptor,
+        string feature)
+    {
+        ApplyRequiresOptIn(descriptor, feature);
+        return descriptor;
+    }
+
+    private static void ApplyRequiresOptIn(this IDescriptor descriptor, string feature)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        switch (descriptor)
+        {
+            case IObjectFieldDescriptor desc:
+                desc.Directive(new RequiresOptInDirective(feature));
+                break;
+
+            case IInputFieldDescriptor desc:
+                desc.Directive(new RequiresOptInDirective(feature));
+                break;
+
+            case IArgumentDescriptor desc:
+                desc.Directive(new RequiresOptInDirective(feature));
+                break;
+
+            case IEnumValueDescriptor desc:
+                desc.Directive(new RequiresOptInDirective(feature));
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    TypeResources.RequiresOptInDirective_Descriptor_NotSupported);
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Directives/RequiresOptInDirectiveType.cs
@@ -1,0 +1,38 @@
+using HotChocolate.Properties;
+
+namespace HotChocolate.Types;
+
+/// <summary>
+/// Indicates that the given field, argument, input field, or enum value requires giving explicit
+/// consent before being used.
+///
+/// <code>
+/// type Session {
+///     id: ID!
+///     title: String!
+///     # [...]
+///     startInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+///     endInstant: Instant @requiresOptIn(feature: "experimentalInstantApi")
+/// }
+/// </code>
+/// </summary>
+public sealed class RequiresOptInDirectiveType : DirectiveType<RequiresOptInDirective>
+{
+    protected override void Configure(
+        IDirectiveTypeDescriptor<RequiresOptInDirective> descriptor)
+    {
+        descriptor
+            .Name(WellKnownDirectives.RequiresOptIn)
+            .Description(TypeResources.RequiresOptInDirectiveType_TypeDescription)
+            .Location(DirectiveLocation.ArgumentDefinition)
+            .Location(DirectiveLocation.EnumValue)
+            .Location(DirectiveLocation.FieldDefinition)
+            .Location(DirectiveLocation.InputFieldDefinition);
+
+        descriptor
+            .Argument(t => t.Feature)
+            .Name(WellKnownDirectives.RequiresOptInFeatureArgument)
+            .Description(TypeResources.RequiresOptInDirectiveType_FeatureDescription)
+            .Type<NonNullType<StringType>>();
+    }
+}

--- a/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Interceptors/OptInFeaturesTypeInterceptor.cs
@@ -1,0 +1,62 @@
+using HotChocolate.Configuration;
+using HotChocolate.Types.Descriptors;
+using HotChocolate.Types.Descriptors.Definitions;
+
+namespace HotChocolate.Types.Interceptors;
+
+internal sealed class OptInFeaturesTypeInterceptor : TypeInterceptor
+{
+    internal override bool IsEnabled(IDescriptorContext context)
+        => context.Options.EnableOptInFeatures;
+
+    private readonly OptInFeatures _optInFeatures = [];
+
+    public override void OnBeforeCompleteName(
+        ITypeCompletionContext completionContext,
+        DefinitionBase definition)
+    {
+        if (definition is SchemaTypeDefinition schema)
+        {
+            schema.Features.Set(_optInFeatures);
+        }
+    }
+
+    public override void OnBeforeCompleteType(
+        ITypeCompletionContext completionContext,
+        DefinitionBase definition)
+    {
+        switch (definition)
+        {
+            case EnumTypeDefinition enumType:
+                _optInFeatures.UnionWith(enumType.Values.SelectMany(v => v.GetOptInFeatures()));
+
+                break;
+
+            case InputObjectTypeDefinition inputType:
+                _optInFeatures.UnionWith(inputType.Fields.SelectMany(f => f.GetOptInFeatures()));
+
+                break;
+
+            case ObjectTypeDefinition objectType:
+                _optInFeatures.UnionWith(objectType.Fields.SelectMany(f => f.GetOptInFeatures()));
+
+                _optInFeatures.UnionWith(objectType.Fields.SelectMany(
+                    f => f.Arguments.SelectMany(a => a.GetOptInFeatures())));
+
+                break;
+        }
+    }
+}
+
+file static class Extensions
+{
+    public static IEnumerable<string> GetOptInFeatures(this IHasDirectiveDefinition definition)
+    {
+        return definition.Directives
+            .Select(d => d.Value)
+            .OfType<RequiresOptInDirective>()
+            .Select(r => r.Feature);
+    }
+}
+
+internal sealed class OptInFeatures : SortedSet<string>;

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/IntrospectionTypes.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/IntrospectionTypes.cs
@@ -42,6 +42,11 @@ public static class IntrospectionTypes
             types.Add(context.TypeInspector.GetTypeRef(typeof(__DirectiveArgument)));
         }
 
+        if (context.Options.EnableOptInFeatures)
+        {
+            types.Add(context.TypeInspector.GetTypeRef(typeof(__OptInFeatureStability)));
+        }
+
         return types;
     }
 

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__EnumValue.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__EnumValue.cs
@@ -17,6 +17,7 @@ internal sealed class __EnumValue : ObjectType<IEnumValue>
     {
         var stringType = Create(ScalarNames.String);
         var nonNullStringType = Parse($"{ScalarNames.String}!");
+        var nonNullStringListType = Parse($"[{ScalarNames.String}!]");
         var nonNullBooleanType = Parse($"{ScalarNames.Boolean}!");
         var appDirectiveListType = Parse($"[{nameof(__AppliedDirective)}!]!");
 
@@ -44,6 +45,14 @@ internal sealed class __EnumValue : ObjectType<IEnumValue>
                 pureResolver: Resolvers.AppliedDirectives));
         }
 
+        if (context.DescriptorContext.Options.EnableOptInFeatures)
+        {
+            def.Fields.Add(new(
+                Names.RequiresOptIn,
+                type: nonNullStringListType,
+                pureResolver: Resolvers.RequiresOptIn));
+        }
+
         return def;
     }
 
@@ -65,6 +74,11 @@ internal sealed class __EnumValue : ObjectType<IEnumValue>
             => context.Parent<IEnumValue>().Directives
                 .Where(t => t.Type.IsPublic)
                 .Select(d => d.AsSyntaxNode());
+
+        public static object RequiresOptIn(IResolverContext context)
+            => context.Parent<IEnumValue>().Directives
+                .Where(t => t.Type is RequiresOptInDirectiveType)
+                .Select(d => d.AsValue<RequiresOptInDirective>().Feature);
     }
 
     public static class Names
@@ -76,6 +90,7 @@ internal sealed class __EnumValue : ObjectType<IEnumValue>
         public const string IsDeprecated = "isDeprecated";
         public const string DeprecationReason = "deprecationReason";
         public const string AppliedDirectives = "appliedDirectives";
+        public const string RequiresOptIn = "requiresOptIn";
     }
 }
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__InputValue.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__InputValue.cs
@@ -19,6 +19,7 @@ internal sealed class __InputValue : ObjectType
     {
         var stringType = Create(ScalarNames.String);
         var nonNullStringType = Parse($"{ScalarNames.String}!");
+        var nonNullStringListType = Parse($"[{ScalarNames.String}!]");
         var nonNullTypeType = Parse($"{nameof(__Type)}!");
         var nonNullBooleanType = Parse($"{ScalarNames.Boolean}!");
         var appDirectiveListType = Parse($"[{nameof(__AppliedDirective)}!]!");
@@ -54,6 +55,14 @@ internal sealed class __InputValue : ObjectType
                 pureResolver: Resolvers.AppliedDirectives));
         }
 
+        if (context.DescriptorContext.Options.EnableOptInFeatures)
+        {
+            def.Fields.Add(new(
+                Names.RequiresOptIn,
+                type: nonNullStringListType,
+                pureResolver: Resolvers.RequiresOptIn));
+        }
+
         return def;
     }
 
@@ -85,6 +94,12 @@ internal sealed class __InputValue : ObjectType
                 .Directives
                 .Where(t => t.Type.IsPublic)
                 .Select(d => d.AsSyntaxNode());
+
+        public static object RequiresOptIn(IResolverContext context)
+            => context.Parent<IInputField>()
+                .Directives
+                .Where(t => t.Type is RequiresOptInDirectiveType)
+                .Select(d => d.AsValue<RequiresOptInDirective>().Feature);
     }
 
     public static class Names
@@ -98,6 +113,7 @@ internal sealed class __InputValue : ObjectType
         public const string AppliedDirectives = "appliedDirectives";
         public const string IsDeprecated = "isDeprecated";
         public const string DeprecationReason = "deprecationReason";
+        public const string RequiresOptIn = "requiresOptIn";
     }
 }
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/HotChocolate/Core/src/Types/Types/Introspection/__OptInFeatureStability.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Introspection/__OptInFeatureStability.cs
@@ -1,0 +1,58 @@
+#pragma warning disable IDE1006 // Naming Styles
+using HotChocolate.Configuration;
+using HotChocolate.Language;
+using HotChocolate.Properties;
+using HotChocolate.Resolvers;
+using HotChocolate.Types.Descriptors.Definitions;
+using static HotChocolate.Types.Descriptors.TypeReference;
+
+#nullable enable
+
+namespace HotChocolate.Types.Introspection;
+
+/// <summary>
+/// An OptInFeatureStability object describes the stability level of an opt-in feature.
+/// </summary>
+[Introspection]
+// ReSharper disable once InconsistentNaming
+internal sealed class __OptInFeatureStability : ObjectType<DirectiveNode>
+{
+    protected override ObjectTypeDefinition CreateDefinition(ITypeDiscoveryContext context)
+    {
+        var nonNullStringType = Parse($"{ScalarNames.String}!");
+
+        return new ObjectTypeDefinition(
+            Names.__OptInFeatureStability,
+            TypeResources.OptInFeatureStability_Description,
+            typeof(DirectiveNode))
+        {
+            Fields =
+            {
+                new(Names.Feature, type: nonNullStringType, pureResolver: Resolvers.Feature),
+                new(Names.Stability, type: nonNullStringType, pureResolver: Resolvers.Stability)
+            }
+        };
+    }
+
+    private static class Resolvers
+    {
+        public static string Feature(IResolverContext context) =>
+            ((StringValueNode)context.Parent<DirectiveNode>()
+                .Arguments
+                .Single(a => a.Name.Value == Names.Feature).Value).Value;
+
+        public static string Stability(IResolverContext context) =>
+            ((StringValueNode)context.Parent<DirectiveNode>()
+                .Arguments
+                .Single(a => a.Name.Value == Names.Stability).Value).Value;
+    }
+
+    public static class Names
+    {
+        // ReSharper disable once InconsistentNaming
+        public const string __OptInFeatureStability = "__OptInFeatureStability";
+        public const string Feature = "feature";
+        public const string Stability = "stability";
+    }
+}
+#pragma warning restore IDE1006 // Naming Styles

--- a/src/HotChocolate/Core/src/Types/Utilities/ErrorHelper.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/ErrorHelper.cs
@@ -538,4 +538,24 @@ internal static class ErrorHelper
             .SetTypeSystemObject(type)
             .Build();
     }
+
+    public static ISchemaError RequiresOptInOnRequiredInputField(
+        IInputObjectType type,
+        IInputField field)
+        => SchemaErrorBuilder.New()
+            .SetMessage(ErrorHelper_RequiresOptInOnRequiredInputField)
+            .SetType(type)
+            .SetField(field)
+            .Build();
+
+    public static ISchemaError RequiresOptInOnRequiredArgument(
+        IComplexOutputType type,
+        IOutputField field,
+        IInputField argument)
+        => SchemaErrorBuilder.New()
+            .SetMessage(ErrorHelper_RequiresOptInOnRequiredArgument)
+            .SetType(type)
+            .SetField(field)
+            .SetArgument(argument)
+            .Build();
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/OptInFeaturesIntrospectionTests.cs
@@ -1,0 +1,562 @@
+using CookieCrumble;
+using HotChocolate.Types;
+
+namespace HotChocolate.Execution;
+
+public sealed class OptInFeaturesIntrospectionTests
+{
+    [Fact]
+    public async Task Execute_IntrospectionOnSchema_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __schema {
+                    optInFeatures
+                    optInFeatureStability {
+                        feature
+                        stability
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__schema": {
+                  "optInFeatures": [
+                    "enumValueFeature1",
+                    "enumValueFeature2",
+                    "inputFieldFeature1",
+                    "inputFieldFeature2",
+                    "objectFieldArgFeature1",
+                    "objectFieldArgFeature2",
+                    "objectFieldFeature1",
+                    "objectFieldFeature2"
+                  ],
+                  "optInFeatureStability": [
+                    {
+                      "feature": "enumValueFeature1",
+                      "stability": "draft"
+                    },
+                    {
+                      "feature": "enumValueFeature2",
+                      "stability": "experimental"
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnObjectFields_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields(includeOptIn: ["objectFieldFeature1"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": [
+                    {
+                      "requiresOptIn": [
+                        "objectFieldFeature1",
+                        "objectFieldFeature2"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnObjectFieldsFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields(includeOptIn: ["objectFieldFeatureDoesNotExist"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": []
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnObjectFieldsNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": []
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnArgs_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields(includeOptIn: ["objectFieldFeature1"]) {
+                        args(includeOptIn: ["objectFieldArgFeature1"]) {
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": [
+                    {
+                      "args": [
+                        {
+                          "requiresOptIn": [
+                            "objectFieldArgFeature1",
+                            "objectFieldArgFeature2"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnArgsFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields(includeOptIn: ["objectFieldFeature1"]) {
+                        args(includeOptIn: ["objectFieldArgFeatureDoesNotExist"]) {
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": [
+                    {
+                      "args": []
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnArgsNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "Query") {
+                    fields(includeOptIn: ["objectFieldFeature1"]) {
+                        args {
+                            requiresOptIn
+                        }
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "fields": [
+                    {
+                      "args": []
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnInputFields_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleInput") {
+                    inputFields(includeOptIn: ["inputFieldFeature1"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "inputFields": [
+                    {
+                      "requiresOptIn": [
+                        "inputFieldFeature1",
+                        "inputFieldFeature2"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnInputFieldsFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleInput") {
+                    inputFields(includeOptIn: ["inputFieldFeatureDoesNotExist"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "inputFields": []
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnInputFieldsNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleInput") {
+                    inputFields {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "inputFields": []
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnEnumValues_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleEnum") {
+                    enumValues(includeOptIn: ["enumValueFeature1"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "enumValues": [
+                    {
+                      "requiresOptIn": [
+                        "enumValueFeature1",
+                        "enumValueFeature2"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnEnumValuesFeatureDoesNotExist_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleEnum") {
+                    enumValues(includeOptIn: ["enumValueFeatureDoesNotExist"]) {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "enumValues": []
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task Execute_IntrospectionOnEnumValuesNoIncludedFeatures_MatchesSnapshot()
+    {
+        // arrange
+        const string query =
+            """
+            {
+                __type(name: "ExampleEnum") {
+                    enumValues {
+                        requiresOptIn
+                    }
+                }
+            }
+            """;
+
+        var executor = CreateSchema().MakeExecutable();
+
+        // act
+        var result = await executor.ExecuteAsync(query);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "__type": {
+                  "enumValues": []
+                }
+              }
+            }
+            """);
+    }
+
+    private static ISchema CreateSchema()
+    {
+        return SchemaBuilder.New()
+            .SetSchema(
+                s => s
+                    .OptInFeatureStability("enumValueFeature1", "draft")
+                    .OptInFeatureStability("enumValueFeature2", "experimental"))
+            .AddQueryType<QueryType>()
+            .AddType<ExampleInputType>()
+            .AddType<ExampleEnumType>()
+            .ModifyOptions(o => o.EnableOptInFeatures = true)
+            .Create();
+    }
+
+    private sealed class QueryType : ObjectType
+    {
+        protected override void Configure(IObjectTypeDescriptor descriptor)
+        {
+            descriptor.Name(OperationTypeNames.Query);
+
+            descriptor
+                .Field("field")
+                .Type<IntType>()
+                .Argument(
+                    "argument",
+                    a => a
+                        .Type<IntType>()
+                        .RequiresOptIn("objectFieldArgFeature1")
+                        .RequiresOptIn("objectFieldArgFeature2"))
+                .Resolve(() => 1)
+                .RequiresOptIn("objectFieldFeature1")
+                .RequiresOptIn("objectFieldFeature2");
+        }
+    }
+
+    private sealed class ExampleInputType : InputObjectType
+    {
+        protected override void Configure(IInputObjectTypeDescriptor descriptor)
+        {
+            descriptor
+                .Field("field")
+                .Type<IntType>()
+                .RequiresOptIn("inputFieldFeature1")
+                .RequiresOptIn("inputFieldFeature2");
+        }
+    }
+
+    private sealed class ExampleEnumType : EnumType
+    {
+        protected override void Configure(IEnumTypeDescriptor descriptor)
+        {
+            descriptor
+                .Name("ExampleEnum")
+                .Value("VALUE")
+                    .RequiresOptIn("enumValueFeature1")
+                    .RequiresOptIn("enumValueFeature2");
+        }
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/RequiresOptInValidation.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/RequiresOptInValidation.cs
@@ -1,0 +1,83 @@
+namespace HotChocolate.Configuration.Validation;
+
+public class RequiresOptInValidation : TypeValidationTestBase
+{
+    [Fact]
+    public void Must_Not_Appear_On_Required_Input_Object_Field()
+    {
+        ExpectError(
+            """
+            input Input {
+                field: Int!
+                    @requiresOptIn(feature: "feature1")
+                    @requiresOptIn(feature: "feature2")
+            }
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Required_With_Default_Input_Object_Field()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            input Input {
+                field: Int! = 1 @requiresOptIn(feature: "feature")
+            }
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Nullable_Input_Object_Field()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            input Input {
+                field: Int @requiresOptIn(feature: "feature")
+            }
+            """);
+    }
+
+    [Fact]
+    public void Must_Not_Appear_On_Required_Argument()
+    {
+        ExpectError(
+            """
+            type Object {
+                field(
+                    argument: Int!
+                        @requiresOptIn(feature: "feature1")
+                        @requiresOptIn(feature: "feature2")): Int
+            }
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Required_With_Default_Argument()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            type Object {
+                field(argument: Int! = 1 @requiresOptIn(feature: "feature")): Int
+            }
+            """);
+    }
+
+    [Fact]
+    public void May_Appear_On_Nullable_Argument()
+    {
+        ExpectValid(
+            """
+            type Query { field: Int }
+
+            type Object {
+                field(argument: Int @requiresOptIn(feature: "feature")): Int
+            }
+            """);
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/TypeValidationTestBase.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/TypeValidationTestBase.cs
@@ -10,7 +10,11 @@ public abstract class TypeValidationTestBase
         SchemaBuilder.New()
             .AddDocumentFromString(schema)
             .Use(_ => _ => default)
-            .ModifyOptions(o => o.EnableOneOf = true)
+            .ModifyOptions(o =>
+            {
+                o.EnableOneOf = true;
+                o.EnableOptInFeatures = true;
+            })
             .Create();
     }
 
@@ -21,7 +25,11 @@ public abstract class TypeValidationTestBase
             SchemaBuilder.New()
                 .AddDocumentFromString(schema)
                 .Use(_ => _ => default)
-                .ModifyOptions(o => o.EnableOneOf = true)
+                .ModifyOptions(o =>
+                {
+                    o.EnableOneOf = true;
+                    o.EnableOptInFeatures = true;
+                })
                 .Create();
             Assert.Fail("Expected error!");
         }

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Argument.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Argument.snap
@@ -1,0 +1,18 @@
+{
+  "message": "The @requiresOptIn directive must not appear on required (non-null without a default) arguments.",
+  "type": "Object",
+  "extensions": {
+    "argument": "argument",
+    "field": "field"
+  }
+}
+
+{
+  "message": "The @requiresOptIn directive must not appear on required (non-null without a default) arguments.",
+  "type": "Object",
+  "extensions": {
+    "argument": "argument",
+    "field": "field"
+  }
+}
+

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Input_Object_Field.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/Validation/__snapshots__/RequiresOptInValidation.Must_Not_Appear_On_Required_Input_Object_Field.snap
@@ -1,0 +1,16 @@
+{
+  "message": "The @requiresOptIn directive must not appear on required (non-null without a default) input object field definitions.",
+  "type": "Input",
+  "extensions": {
+    "field": "field"
+  }
+}
+
+{
+  "message": "The @requiresOptIn directive must not appear on required (non-null without a default) input object field definitions.",
+  "type": "Input",
+  "extensions": {
+    "field": "field"
+  }
+}
+

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/OptInFeatureStabilityDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/OptInFeatureStabilityDirectiveTests.cs
@@ -1,0 +1,54 @@
+using CookieCrumble;
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Types.Directives;
+
+public sealed class OptInFeatureStabilityDirectiveTests
+{
+    [Fact]
+    public async Task BuildSchemaAsync_CodeFirst_MatchesSnapshot()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .SetSchema(s => s
+                    .OptInFeatureStability("feature1", "stability1")
+                    .OptInFeatureStability("feature2", "stability2"))
+                .AddQueryType(d => d.Field("field").Type<IntType>())
+                .UseField(_ => _ => default)
+                .BuildSchemaAsync();
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task BuildSchemaAsync_SchemaFirst_MatchesSnapshot()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddDocumentFromString(
+                    """
+                    schema
+                        @optInFeatureStability(feature: "feature1", stability: "stability1")
+                        @optInFeatureStability(feature: "feature2", stability: "stability2") {
+                        query: Query
+                    }
+
+                    type Query {
+                        field: Int
+                    }
+                    """)
+                .UseField(_ => _ => default)
+                .BuildSchemaAsync();
+
+        // assert
+        schema.MatchSnapshot();
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/RequiresOptInDirectiveTests.cs
@@ -1,0 +1,124 @@
+using CookieCrumble;
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Types.Directives;
+
+public sealed class RequiresOptInDirectiveTests
+{
+    [Fact]
+    public async Task BuildSchemaAsync_CodeFirst_MatchesSnapshot()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddQueryType(d => d
+                    .Field("field")
+                    .Type<IntType>()
+                    .Argument(
+                        "argument",
+                        a => a
+                            .Type<IntType>()
+                            .RequiresOptIn("objectFieldArgFeature1")
+                            .RequiresOptIn("objectFieldArgFeature2"))
+                    .Resolve(() => 1)
+                    .RequiresOptIn("objectFieldFeature1")
+                    .RequiresOptIn("objectFieldFeature2"))
+                .AddInputObjectType(d => d
+                    .Name("Input")
+                    .Field("field")
+                    .Type<IntType>()
+                    .RequiresOptIn("inputFieldFeature1")
+                    .RequiresOptIn("inputFieldFeature2"))
+                .AddEnumType(d => d
+                    .Name("Enum")
+                    .Value("VALUE")
+                    .RequiresOptIn("enumValueFeature1")
+                    .RequiresOptIn("enumValueFeature2"))
+                .BuildSchemaAsync();
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task BuildSchemaAsync_ImplementationFirst_MatchesSnapshot()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddQueryType<Query>()
+                .AddInputObjectType<Input>()
+                .AddType<Enum>()
+                .BuildSchemaAsync();
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task BuildSchemaAsync_SchemaFirst_MatchesSnapshot()
+    {
+        // arrange & act
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .ModifyOptions(o => o.EnableOptInFeatures = true)
+                .AddDocumentFromString(
+                    """
+                    type Query {
+                        field(
+                            argument: Int
+                                @requiresOptIn(feature: "objectFieldArgFeature1")
+                                @requiresOptIn(feature: "objectFieldArgFeature2")): Int
+                                    @requiresOptIn(feature: "objectFieldFeature1")
+                                    @requiresOptIn(feature: "objectFieldFeature2")
+                    }
+
+                    input Input {
+                        field: Int
+                            @requiresOptIn(feature: "inputFieldFeature1")
+                            @requiresOptIn(feature: "inputFieldFeature2")
+                    }
+
+                    enum Enum {
+                        VALUE
+                            @requiresOptIn(feature: "enumValueFeature1")
+                            @requiresOptIn(feature: "enumValueFeature2")
+                    }
+                    """)
+                .UseField(_ => _ => default)
+                .BuildSchemaAsync();
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
+    public sealed class Query
+    {
+        [RequiresOptIn("objectFieldFeature1")]
+        [RequiresOptIn("objectFieldFeature2")]
+        public int? GetField(
+            [RequiresOptIn("objectFieldArgFeature1")]
+            [RequiresOptIn("objectFieldArgFeature2")] int? argument)
+            => argument;
+    }
+
+    public sealed class Input
+    {
+        [RequiresOptIn("inputFieldFeature1")]
+        [RequiresOptIn("inputFieldFeature2")]
+        public int? Field { get; set; }
+    }
+
+    public enum Enum
+    {
+        [RequiresOptIn("enumValueFeature1")]
+        [RequiresOptIn("enumValueFeature2")]
+        Value
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/OptInFeatureStabilityDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/OptInFeatureStabilityDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
@@ -1,0 +1,10 @@
+schema @optInFeatureStability(feature: "feature1", stability: "stability1") @optInFeatureStability(feature: "feature2", stability: "stability2") {
+  query: Query
+}
+
+type Query {
+  field: Int
+}
+
+"Sets the stability level of an opt-in feature."
+directive @optInFeatureStability("The name of the feature for which to set the stability." feature: String! "The stability level of the feature." stability: String!) repeatable on SCHEMA

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/OptInFeatureStabilityDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/OptInFeatureStabilityDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
@@ -1,0 +1,10 @@
+schema @optInFeatureStability(feature: "feature1", stability: "stability1") @optInFeatureStability(feature: "feature2", stability: "stability2") {
+  query: Query
+}
+
+type Query {
+  field: Int
+}
+
+"Sets the stability level of an opt-in feature."
+directive @optInFeatureStability("The name of the feature for which to set the stability." feature: String! "The stability level of the feature." stability: String!) repeatable on SCHEMA

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_CodeFirst_MatchesSnapshot.graphql
@@ -1,0 +1,18 @@
+schema {
+  query: Query
+}
+
+type Query {
+  field(argument: Int @requiresOptIn(feature: "objectFieldArgFeature1") @requiresOptIn(feature: "objectFieldArgFeature2")): Int @requiresOptIn(feature: "objectFieldFeature1") @requiresOptIn(feature: "objectFieldFeature2")
+}
+
+input Input {
+  field: Int @requiresOptIn(feature: "inputFieldFeature1") @requiresOptIn(feature: "inputFieldFeature2")
+}
+
+enum Enum {
+  VALUE @requiresOptIn(feature: "enumValueFeature1") @requiresOptIn(feature: "enumValueFeature2")
+}
+
+"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+directive @requiresOptIn("The name of the feature that requires opt in." feature: String!) repeatable on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_ImplementationFirst_MatchesSnapshot.graphql
@@ -1,0 +1,18 @@
+schema {
+  query: Query
+}
+
+type Query {
+  field(argument: Int @requiresOptIn(feature: "objectFieldArgFeature1") @requiresOptIn(feature: "objectFieldArgFeature2")): Int @requiresOptIn(feature: "objectFieldFeature1") @requiresOptIn(feature: "objectFieldFeature2")
+}
+
+input Input {
+  field: Int @requiresOptIn(feature: "inputFieldFeature1") @requiresOptIn(feature: "inputFieldFeature2")
+}
+
+enum Enum {
+  VALUE @requiresOptIn(feature: "enumValueFeature1") @requiresOptIn(feature: "enumValueFeature2")
+}
+
+"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+directive @requiresOptIn("The name of the feature that requires opt in." feature: String!) repeatable on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Directives/__snapshots__/RequiresOptInDirectiveTests.BuildSchemaAsync_SchemaFirst_MatchesSnapshot.graphql
@@ -1,0 +1,18 @@
+schema {
+  query: Query
+}
+
+type Query {
+  field(argument: Int @requiresOptIn(feature: "objectFieldArgFeature1") @requiresOptIn(feature: "objectFieldArgFeature2")): Int @requiresOptIn(feature: "objectFieldFeature1") @requiresOptIn(feature: "objectFieldFeature2")
+}
+
+input Input {
+  field: Int @requiresOptIn(feature: "inputFieldFeature1") @requiresOptIn(feature: "inputFieldFeature2")
+}
+
+enum Enum {
+  VALUE @requiresOptIn(feature: "enumValueFeature1") @requiresOptIn(feature: "enumValueFeature2")
+}
+
+"Indicates that the given field, argument, input field, or enum value requires giving explicit consent before being used."
+directive @requiresOptIn("The name of the feature that requires opt in." feature: String!) repeatable on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added opt-in features.

---

❓ Questions:

- Please check the schema error definitions in `ErrorHelper.cs`.
    - Should I be setting an error code or specified by?
- I'm returning one error for each application of the directive, is that correct?
    - In theory, we could be including information about the directive syntax position, arguments, etc.

📓 Spec notes:

- Should we explicitly disallow empty and whitespace-only feature strings? `*`
- Should we disallow whitespace or other characters within feature names, or leave it completely open? `*`
- I've used `includeOptIn` instead of `includeRequiresOptIn` for introspection, as it seemed more clear, WDYT?

`*` stability strings as well.