### PR TITLE
Fixed issue that closed stream when using StreamWriter in SyntaxPrinter.PrintToAsync

### DIFF
--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxPrinter.cs
@@ -60,11 +60,14 @@ public static class SyntaxPrinter
 #if NETSTANDARD2_0
         using var streamWriter = new StreamWriter(
             stream,
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true));
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
+            -1,
+            leaveOpen: true);
 #else
         await using var streamWriter = new StreamWriter(
             stream,
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true));
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
+            leaveOpen: true);
 #endif
 
         var syntaxWriter = StringSyntaxWriter.Rent();

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.FileSystem.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.FileSystem.Tests/IntegrationTests.cs
@@ -2,6 +2,7 @@ using CookieCrumble;
 using Microsoft.Extensions.DependencyInjection;
 using HotChocolate.Types;
 using HotChocolate.Execution;
+using HotChocolate.Language;
 using IO = System.IO;
 
 namespace HotChocolate.PersistedOperations.FileSystem;
@@ -81,6 +82,58 @@ public class IntegrationTests
 
         // assert
         File.Delete(cachedOperation);
+        result.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task ExecuteAutomaticPersistedOperation()
+    {
+        // arrange
+        var cacheDirectory = IO.Path.GetTempPath();
+        var documentId = Guid.NewGuid().ToString("N");
+        const string documentHash = "hash";
+
+        var executor =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType(c => c.Name("Query").Field("a").Resolve("b"))
+                .AddFileSystemOperationDocumentStorage(cacheDirectory)
+                .UseRequest(n => async c =>
+                {
+                    await n(c);
+
+                    if (c.IsPersistedDocument && c.Result is IOperationResult r)
+                    {
+                        c.Result = OperationResultBuilder
+                            .FromResult(r)
+                            .SetExtension("persistedDocument", true)
+                            .Build();
+                    }
+                })
+                .UseAutomaticPersistedOperationPipeline()
+                .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            OperationRequest
+                .FromId(documentId)
+                .WithDocument(new OperationDocument(Utf8GraphQLParser.Parse("{ __typename }")))
+                .WithDocumentHash(documentHash)
+                .WithExtensions(new Dictionary<string, object?>
+                {
+                    {
+                        "persistedQuery",
+                        new Dictionary<string, object?>
+                        {
+                            { "version", 1 },
+                            { "md5Hash", documentHash }
+                        }
+                    }
+                }));
+
+        File.Delete(IO.Path.Combine(cacheDirectory, documentHash + ".graphql"));
+
+        // assert
         result.MatchSnapshot();
     }
 }

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.FileSystem.Tests/__snapshots__/IntegrationTests.ExecuteAutomaticPersistedOperation.snap
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.FileSystem.Tests/__snapshots__/IntegrationTests.ExecuteAutomaticPersistedOperation.snap
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "__typename": "Query"
+  },
+  "extensions": {
+    "persistedQuery": {
+      "md5Hash": "hash",
+      "persisted": true
+    }
+  }
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Leave stream open when using `StreamWriter` in `SyntaxPrinter#PrintToAsync`.

Closes #7631

---

📓 Notes:

- When `FileSystemOperationDocumentStorage#SaveInternalAsync` is called with a `document` that is an instance of `OperationDocument`, `WriteToAsync` calls `PrintToAsync`, which uses a `StreamWriter` that disposes the stream. The stream is then accessed again in order to flush it, which throws.
- The stream should be disposed by the caller, so I've set `leaveOpen` to `true`.

:question: Questions:

- Is there a simpler way to create the `OperationRequest` in the test?