### PR TITLE
Added "AddDataLoader<TService, TImplementation>" overload that takes a factory

### DIFF
--- a/src/GreenDonut/src/Core/DependencyInjection/DataLoaderServiceCollectionExtensions.cs
+++ b/src/GreenDonut/src/Core/DependencyInjection/DataLoaderServiceCollectionExtensions.cs
@@ -42,6 +42,19 @@ public static class DataLoaderServiceCollectionExtensions
         return services;
     }
 
+    public static IServiceCollection AddDataLoader<TService, TImplementation>(
+        this IServiceCollection services,
+        Func<IServiceProvider, TImplementation> factory)
+        where TService : class, IDataLoader
+        where TImplementation : class, TService
+    {
+        services.TryAddDataLoaderCore();
+        services.AddSingleton(new DataLoaderRegistration(typeof(TService), typeof(TImplementation), sp => factory(sp)));
+        services.TryAddScoped<TImplementation>(sp => sp.GetDataLoader<TImplementation>());
+        services.TryAddScoped<TService>(sp => sp.GetDataLoader<TService>());
+        return services;
+    }
+
     public static IServiceCollection TryAddDataLoaderCore(
         this IServiceCollection services)
     {

--- a/src/GreenDonut/test/Core.Tests/DependencyInjection/DataLoaderServiceCollectionExtensionsTests.cs
+++ b/src/GreenDonut/test/Core.Tests/DependencyInjection/DataLoaderServiceCollectionExtensionsTests.cs
@@ -1,0 +1,56 @@
+using GreenDonut;
+using Xunit;
+using static GreenDonut.TestHelpers;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public class DataLoaderServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void ImplFactoryIsCalledWhenServiceIsResolved()
+    {
+        // arrange
+        var factoryCalled = false;
+        var fetch = CreateFetch<string, string>();
+        var services = new ServiceCollection()
+            .AddScoped<IBatchScheduler, ManualBatchScheduler>()
+            .AddDataLoader(sp =>
+            {
+                factoryCalled = true;
+                return new DataLoader<string, string>(fetch, sp.GetRequiredService<IBatchScheduler>());
+            });
+        var scope = services.BuildServiceProvider().CreateScope();
+
+        // act
+        var dataLoader = scope.ServiceProvider.GetRequiredService<DataLoader<string, string>>();
+
+        // assert
+        Assert.NotNull(dataLoader);
+        Assert.True(factoryCalled);
+    }
+
+    [Fact]
+    public void InterfaceImplFactoryIsCalledWhenServiceIsResolved()
+    {
+        // arrange
+        var factoryCalled = false;
+        var fetch = CreateFetch<string, string>();
+        var services = new ServiceCollection()
+            .AddScoped<IBatchScheduler, ManualBatchScheduler>()
+            .AddDataLoader<IDataLoader<string, string>, DataLoader<string, string>>(sp =>
+            {
+                factoryCalled = true;
+                return new DataLoader<string, string>(fetch, sp.GetRequiredService<IBatchScheduler>());
+            });
+        var scope = services.BuildServiceProvider().CreateScope();
+
+        // act
+        var dataLoader = scope.ServiceProvider.GetRequiredService<DataLoader<string, string>>();
+        var asInterface = scope.ServiceProvider.GetRequiredService<IDataLoader<string, string>>();
+
+        // assert
+        Assert.NotNull(dataLoader);
+        Assert.NotNull(asInterface);
+        Assert.True(factoryCalled);
+    }
+}


### PR DESCRIPTION
Add "AddDataLoader<TService, TImplementation>" overload that takes a factory.

Summary of the changes:

- A new overload that allows a factory to be provided for the implementation.
- Previously, this was only available when using the single generic option.

