### PR TITLE
Generate set methods for dataloader state parameters

### DIFF
--- a/src/GreenDonut/src/Core/Attributes/DataLoaderStateAttribute.cs
+++ b/src/GreenDonut/src/Core/Attributes/DataLoaderStateAttribute.cs
@@ -7,10 +7,10 @@ namespace GreenDonut;
 /// The key that shall be used to map the parameter from the DataLoader state.
 /// </param>
 [AttributeUsage(AttributeTargets.Parameter)]
-public class DataLoaderStateAttribute(string key) : Attribute
+public class DataLoaderStateAttribute(string? key = null) : Attribute
 {
     /// <summary>
     /// Gets the key that shall be used to map the parameter from the DataLoader state.
     /// </summary>
-    public string Key { get; } = key;
+    public string? Key { get; } = key;
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderGenerator.cs
@@ -135,7 +135,9 @@ public sealed class DataLoaderGenerator : ISyntaxGenerator
 
         if (defaults.GenerateInterfaces)
         {
-            generator.WriteDataLoaderInterface(dataLoader.InterfaceName, isInterfacePublic, kind, keyType, valueType);
+            generator.WriteBeginDataLoaderInterface(dataLoader.InterfaceName, isInterfacePublic, kind, keyType, valueType);
+            generator.WriteDataLoaderInterfaceStateMethods(dataLoader.InterfaceName, dataLoader.Parameters);
+            generator.WriteEndDataLoaderInterface();
         }
 
         generator.WriteBeginDataLoaderClass(
@@ -153,6 +155,7 @@ public sealed class DataLoaderGenerator : ISyntaxGenerator
             valueType,
             dataLoader.GetLookups(keyType, valueType));
         generator.WriteLine();
+        generator.WriteDataLoaderStateMethods(defaults.GenerateInterfaces ? dataLoader.InterfaceName : dataLoader.Name, dataLoader.Parameters);
         generator.WriteDataLoaderLoadMethod(
             dataLoader.ContainingType,
             dataLoader.MethodSymbol,
@@ -279,4 +282,6 @@ public sealed class DataLoaderGenerator : ISyntaxGenerator
 
     private static string ToTypeNameNoGenerics(ITypeSymbol typeSymbol)
         => $"{typeSymbol.ContainingNamespace}.{typeSymbol.Name}";
+
+
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Helpers/DataLoaderAttributeHelper.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Helpers/DataLoaderAttributeHelper.cs
@@ -86,7 +86,7 @@ public static class DataLoaderAttributeHelper
                 return keyProperty.Value?.ToString();
             }
 
-            return null;
+            return parameter.Name;
         }
 
         return null;

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/Types/AuthorNode.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/Types/AuthorNode.cs
@@ -16,6 +16,12 @@ public static partial class AuthorNode
         CancellationToken cancellationToken)
         => await dataLoader.LoadAsync(author.Id, cancellationToken);
 
+    public static async Task<string?> GetSomeMoreInfo(
+        [Parent] Author author,
+        ISomeInfoWithServiceAndStateByIdDataLoader dataLoader,
+        CancellationToken cancellationToken)
+        => await dataLoader.WithState("xyz").WithFooId(Guid.NewGuid()).WithTenantId(12).LoadAsync(author.Id, cancellationToken);
+
     public static string GetAdditionalInfo(
         [Parent("Id")] Author author,
         string someArg)

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/Types/DataLoaders.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/Types/DataLoaders.cs
@@ -56,6 +56,8 @@ public static class DataLoaders
         IReadOnlyList<int> keys,
         ChapterRepository repository,
         [DataLoaderState("key")] string? state,
+        [DataLoaderState] int tenantId,
+        [DataLoaderState] Guid fooId,
         CancellationToken ct)
         => await Task.FromResult(keys.ToDictionary(k => k, k => k + " - some info"));
 

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_Optional_State_MatchesSnapshot.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_Optional_State_MatchesSnapshot.md
@@ -18,6 +18,7 @@ namespace TestNamespace
     public interface IEntityByIdDataLoader
         : global::GreenDonut.IDataLoader<int, string>
     {
+        IEntityByIdDataLoader WithState(string state);
     }
 
     public sealed partial class EntityByIdDataLoader
@@ -34,6 +35,12 @@ namespace TestNamespace
         {
             _services = services ??
                 throw new global::System.ArgumentNullException(nameof(services));
+        }
+
+        public IEntityByIdDataLoader WithState(string state)
+        {
+            this.ContextData = this.ContextData.SetItem("key", state);
+            return this;
         }
 
         protected override async global::System.Threading.Tasks.ValueTask FetchAsync(

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_Required_State_MatchesSnapshot.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_Required_State_MatchesSnapshot.md
@@ -18,6 +18,7 @@ namespace TestNamespace
     public interface IEntityByIdDataLoader
         : global::GreenDonut.IDataLoader<int, string>
     {
+        IEntityByIdDataLoader WithState(string state);
     }
 
     public sealed partial class EntityByIdDataLoader
@@ -34,6 +35,12 @@ namespace TestNamespace
         {
             _services = services ??
                 throw new global::System.ArgumentNullException(nameof(services));
+        }
+
+        public IEntityByIdDataLoader WithState(string state)
+        {
+            this.ContextData = this.ContextData.SetItem("key", state);
+            return this;
         }
 
         protected override async global::System.Threading.Tasks.ValueTask FetchAsync(

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_State_With_Default_MatchesSnapshot.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/DataLoaderTests.GenerateSource_BatchDataLoader_With_State_With_Default_MatchesSnapshot.md
@@ -18,6 +18,7 @@ namespace TestNamespace
     public interface IEntityByIdDataLoader
         : global::GreenDonut.IDataLoader<int, string>
     {
+        IEntityByIdDataLoader WithState(string state);
     }
 
     public sealed partial class EntityByIdDataLoader
@@ -34,6 +35,12 @@ namespace TestNamespace
         {
             _services = services ??
                 throw new global::System.ArgumentNullException(nameof(services));
+        }
+
+        public IEntityByIdDataLoader WithState(string state)
+        {
+            this.ContextData = this.ContextData.SetItem("key", state);
+            return this;
         }
 
         protected override async global::System.Threading.Tasks.ValueTask FetchAsync(

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/IntegrationTests.Schema.graphql
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/IntegrationTests.Schema.graphql
@@ -24,6 +24,7 @@ type Address {
 type Author implements Entity & Node {
   books("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): BooksConnection
   someInfo: String
+  someMoreInfo: String
   additionalInfo(someArg: String!): String!
   additionalInfo1(someArg1: String! someArg2: String!): String!
   authorsPure: [Author!]!


### PR DESCRIPTION
Reduce the need of using magic strings when setting state variables in the dataloaders and generate set methods on the for each variable which avoids passing wrong keys and increase discoverability for the consumer of the dataloader 

Instead of the following

```csharp
someDataLoader
    .SetState("foo", 1)
    .SetState("bar", "xyz") 
    .LoadAsync(...);
``` 

An equivalent typed api

```csharp 
someDataLoader
    .WithFoo(1)
    .WithBar("xyz")
    .LoadAsync(...);
```

Also make the key of the `DataLoaderStateAttribute` optional and use the name of the parameter as state key if not provided explicitly. This avoids unnecessary typing of string when creating the dataloader methods.