### PR TITLE
Used pure resolver for errors field in custom mutation payloads

### DIFF
--- a/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
+++ b/src/HotChocolate/Core/src/Types.Mutations/MutationConventionTypeInterceptor.cs
@@ -395,10 +395,10 @@ internal sealed class MutationConventionTypeInterceptor : TypeInterceptor
                 new ObjectFieldDefinition(
                     options.PayloadErrorsFieldName,
                     type: errorListTypeRef,
-                    resolver: ctx =>
+                    pureResolver: ctx =>
                     {
                         ctx.ScopedContextData.TryGetValue(Errors, out var errors);
-                        return new ValueTask<object?>(errors);
+                        return errors;
                     }));
 
             // collect error factories for middleware

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/AnnotationBasedMutations.cs
@@ -437,6 +437,21 @@ public class AnnotationBasedMutations
     }
 
     [Fact]
+    public async Task SimpleMutation_Override_Payload_WithError()
+    {
+        var schema =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddCostAnalyzer()
+                .AddMutationType<SimpleMutationPayloadOverrideWithError>()
+                .AddMutationConventions(true)
+                .ModifyOptions(o => o.StrictValidation = false)
+                .BuildSchemaAsync();
+
+        schema.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task SimpleMutation_Override_Input()
     {
         var schema =
@@ -1353,6 +1368,15 @@ public class AnnotationBasedMutations
         public DoSomethingPayload DoSomething(string something)
         {
             throw new Exception();
+        }
+    }
+
+    public class SimpleMutationPayloadOverrideWithError
+    {
+        [Error(typeof(CustomException))]
+        public DoSomethingPayload DoSomething()
+        {
+            return new DoSomethingPayload();
         }
     }
 

--- a/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleMutation_Override_Payload_WithError.graphql
+++ b/src/HotChocolate/Core/test/Types.Mutations.Tests/__snapshots__/AnnotationBasedMutations.SimpleMutation_Override_Payload_WithError.graphql
@@ -1,0 +1,23 @@
+schema {
+  mutation: SimpleMutationPayloadOverrideWithError
+}
+
+interface Error {
+  message: String!
+}
+
+type CustomError implements Error {
+  message: String!
+}
+
+type DoSomethingPayload {
+  myResult1: String
+  myResult2: String
+  errors: [DoSomethingError!]
+}
+
+type SimpleMutationPayloadOverrideWithError {
+  doSomething: DoSomethingPayload!
+}
+
+union DoSomethingError = CustomError


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Used pure resolver for errors field in custom mutation payloads.

Closes #7660