### PR TITLE
Fixed parsing issue in Utf8GraphQLRequestParser#ParseStringOrNull

### DIFF
--- a/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Utilities.cs
+++ b/src/HotChocolate/Language/src/Language.Web/Utf8GraphQLRequestParser.Utilities.cs
@@ -12,6 +12,7 @@ public ref partial struct Utf8GraphQLRequestParser
             case TokenKind.String:
                 if(_reader.Value.Length == 0)
                 {
+                    _reader.MoveNext();
                     return null;
                 }
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
@@ -662,6 +662,32 @@ public class GraphQLRequestParserTests
     }
 
     [Fact]
+    public void Parse_Empty_OperationName()
+    {
+        // arrange
+        var source = Encoding.UTF8.GetBytes(
+            """
+            {
+                "operationName": "",
+                "query": "{}"
+            }
+            """.NormalizeLineBreaks());
+        var parserOptions = new ParserOptions();
+        var requestParser = new Utf8GraphQLRequestParser(
+            source,
+            parserOptions,
+            new DocumentCache(),
+            new Sha256DocumentHashProvider());
+
+        // act
+        var batch = requestParser.Parse();
+
+        // assert
+        var request = Assert.Single(batch);
+        Assert.Null(request.OperationName);
+    }
+
+    [Fact]
     public void Parse_Empty_Json()
     {
         // assert


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed parsing issue in `Utf8GraphQLRequestParser#ParseStringOrNull`.

Closes #7664

---

This fixes the main issue, but IMO `ParseStringOrNull` shouldn't return `null` for an empty string.