### PR TITLE
Fixed CS9258

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectResult.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Result/ObjectResult.cs
@@ -178,11 +178,11 @@ public sealed class ObjectResult
         {
             for (var i = 0; i < _capacity; i++)
             {
-                var field = _buffer[i];
+                var fieldResult = _buffer[i];
 
-                if (field.IsInitialized)
+                if (fieldResult.IsInitialized)
                 {
-                    yield return field.Name;
+                    yield return fieldResult.Name;
                 }
             }
         }
@@ -194,11 +194,11 @@ public sealed class ObjectResult
         {
             for (var i = 0; i < _capacity; i++)
             {
-                var field = _buffer[i];
+                var fieldResult = _buffer[i];
 
-                if (field.IsInitialized)
+                if (fieldResult.IsInitialized)
                 {
-                    yield return field.Value;
+                    yield return fieldResult.Value;
                 }
             }
         }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed CS9258.

---

> error CS9258: In language version preview, the 'field' keyword binds to a synthesized backing field for the property. To avoid generating a synthesized backing field, and to refer to the existing member, use 'this.field' or '`@field`' instead.