### PR TITLE
Added migration section for LocalDate/LocalTime/Date enforced format

### DIFF
--- a/website/src/docs/hotchocolate/v15/migrating/migrate-from-14-to-15.md
+++ b/website/src/docs/hotchocolate/v15/migrating/migrate-from-14-to-15.md
@@ -33,6 +33,14 @@ For example, the `DateTime` `2018-06-11 02:46:14` in a time zone of `04:00` will
 
 Use the `LocalDate` type if you do not want the date to be converted to universal time.
 
+## LocalDate, LocalTime, and Date scalars enforce a specific format
+
+- `LocalDate`: `yyyy-MM-dd`
+- `LocalTime`: `HH:mm:ss`
+- `Date`: `yyyy-MM-dd`
+
+Please ensure that your clients are sending date/time strings in the correct format to avoid errors.
+
 # Deprecations
 
 Things that will continue to function this release, but we encourage you to move away from.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added migration section for `LocalDate`/`LocalTime`/`Date` enforced format.