### PR TITLE
Support nodes field for automatic mocking

### DIFF
--- a/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
@@ -196,6 +196,77 @@ public class AutomaticMockingTests
     }
 
     [Fact]
+    public async Task Object_List_Twice()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              objsA: [Object!]!
+              objsB: [Object!]!
+            }
+
+            type Object {
+              id: ID!
+              str: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              objsA {
+                id
+                str
+              }
+              objsB {
+                id
+                str
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "objsA": [
+                  {
+                    "id": "1",
+                    "str": "string"
+                  },
+                  {
+                    "id": "2",
+                    "str": "string"
+                  },
+                  {
+                    "id": "3",
+                    "str": "string"
+                  }
+                ],
+                "objsB": [
+                  {
+                    "id": "4",
+                    "str": "string"
+                  },
+                  {
+                    "id": "5",
+                    "str": "string"
+                  },
+                  {
+                    "id": "6",
+                    "str": "string"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Object_List_NullAtIndex()
     {
         // arrange

--- a/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
@@ -232,7 +232,7 @@ public class AutomaticMockingTests
                   },
                   null,
                   {
-                    "id": "2"
+                    "id": "3"
                   }
                 ]
               }
@@ -292,7 +292,7 @@ public class AutomaticMockingTests
                   },
                   null,
                   {
-                    "id": "2"
+                    "id": "3"
                   }
                 ]
               }
@@ -813,7 +813,7 @@ public class AutomaticMockingTests
                   null,
                   {
                     "__typename": "Object",
-                    "id": "2",
+                    "id": "3",
                     "str": "string",
                     "num": 123
                   }
@@ -891,7 +891,7 @@ public class AutomaticMockingTests
                   null,
                   {
                     "__typename": "Object",
-                    "id": "2",
+                    "id": "3",
                     "str": "string",
                     "num": 123
                   }
@@ -1416,7 +1416,7 @@ public class AutomaticMockingTests
                   null,
                   {
                     "__typename": "Object",
-                    "id": "2",
+                    "id": "3",
                     "str": "string"
                   }
                 ]
@@ -1487,7 +1487,7 @@ public class AutomaticMockingTests
                   null,
                   {
                     "__typename": "Object",
-                    "id": "2",
+                    "id": "3",
                     "str": "string"
                   }
                 ]
@@ -2554,6 +2554,466 @@ public class AutomaticMockingTests
                     "id": "5"
                   },
                   null
+                ]
+              }
+            }
+            """);
+    }
+
+    #endregion
+
+    #region node
+
+    [Fact]
+    public async Task NodeField()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              node(id: ID!): Node
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              node(id: "5") {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "node": {
+                  "id": "1",
+                  "name": "string"
+                }
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodeField_Null()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              node(id: ID!): Node @null
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              node(id: "5") {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "node": null
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodeField_Error()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              node(id: ID!): Node @error
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              node(id: "5") {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "errors": [
+                {
+                  "message": "Unexpected Execution Error",
+                  "locations": [
+                    {
+                      "line": 2,
+                      "column": 3
+                    }
+                  ],
+                  "path": [
+                    "node"
+                  ]
+                }
+              ],
+              "data": {
+                "node": null
+              }
+            }
+            """);
+    }
+
+    #endregion
+
+    #region nodes
+
+    [Fact]
+    public async Task NodesField()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              nodes(ids: [ID!]!): [Node]!
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              nodes(ids: ["5", "6"]) {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "nodes": [
+                  {
+                    "id": "1",
+                    "name": "string"
+                  },
+                  {
+                    "id": "2",
+                    "name": "string"
+                  },
+                  {
+                    "id": "3",
+                    "name": "string"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodesField_Null()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              nodes(ids: [ID!]!): [Node]! @null
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              nodes(ids: ["5", "6"]) {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "errors": [
+                {
+                  "message": "Cannot return null for non-nullable field.",
+                  "locations": [
+                    {
+                      "line": 2,
+                      "column": 3
+                    }
+                  ],
+                  "path": [
+                    "nodes"
+                  ],
+                  "extensions": {
+                    "code": "HC0018"
+                  }
+                }
+              ],
+              "data": null
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodesField_Error()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              nodes(ids: [ID!]!): [Node]! @error
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              nodes(ids: ["5", "6"]) {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "errors": [
+                {
+                  "message": "Unexpected Execution Error",
+                  "locations": [
+                    {
+                      "line": 2,
+                      "column": 3
+                    }
+                  ],
+                  "path": [
+                    "nodes"
+                  ]
+                }
+              ],
+              "data": null
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodesField_NullAtIndex()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              nodes(ids: [ID!]!): [Node]! @null(atIndex: 1)
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              nodes(ids: ["5", "6"]) {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "nodes": [
+                  {
+                    "id": "1",
+                    "name": "string"
+                  },
+                  null,
+                  {
+                    "id": "3",
+                    "name": "string"
+                  }
+                ]
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NodesField_ErrorAtIndex()
+    {
+        // arrange
+        var schema =
+            """
+            type Query {
+              nodes(ids: [ID!]!): [Node]! @error(atIndex: 1)
+            }
+
+            interface Node {
+              id: ID!
+            }
+
+            type Product implements Node {
+              id: ID!
+              name: String!
+            }
+            """;
+        var request =
+            """
+            query {
+              nodes(ids: ["5", "6"]) {
+                id
+                ... on Product {
+                  name
+                }
+              }
+            }
+            """;
+
+        // act
+        var result = await ExecuteRequestAgainstSchemaAsync(request, schema);
+
+        // assert
+        result.MatchInlineSnapshot(
+            """
+            {
+              "errors": [
+                {
+                  "message": "Unexpected Execution Error",
+                  "locations": [
+                    {
+                      "line": 2,
+                      "column": 3
+                    }
+                  ],
+                  "path": [
+                    "nodes",
+                    1
+                  ]
+                }
+              ],
+              "data": {
+                "nodes": [
+                  {
+                    "id": "1",
+                    "name": "string"
+                  },
+                  null,
+                  {
+                    "id": "3",
+                    "name": "string"
+                  }
                 ]
               }
             }

--- a/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/AutomaticMockingTests.cs
@@ -2604,7 +2604,7 @@ public class AutomaticMockingTests
             {
               "data": {
                 "node": {
-                  "id": "1",
+                  "id": "5",
                   "name": "string"
                 }
               }
@@ -2761,15 +2761,11 @@ public class AutomaticMockingTests
               "data": {
                 "nodes": [
                   {
-                    "id": "1",
+                    "id": "5",
                     "name": "string"
                   },
                   {
-                    "id": "2",
-                    "name": "string"
-                  },
-                  {
-                    "id": "3",
+                    "id": "6",
                     "name": "string"
                   }
                 ]
@@ -2936,14 +2932,10 @@ public class AutomaticMockingTests
               "data": {
                 "nodes": [
                   {
-                    "id": "1",
+                    "id": "5",
                     "name": "string"
                   },
-                  null,
-                  {
-                    "id": "3",
-                    "name": "string"
-                  }
+                  null
                 ]
               }
             }
@@ -3006,14 +2998,10 @@ public class AutomaticMockingTests
               "data": {
                 "nodes": [
                   {
-                    "id": "1",
+                    "id": "5",
                     "name": "string"
                   },
-                  null,
-                  {
-                    "id": "3",
-                    "name": "string"
-                  }
+                  null
                 ]
               }
             }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_EntryField_Selected_Separately.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Fragment_Other_Field_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       },
       "other": "string"

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_EntryField_Other_Field_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       },
       "other": "string"

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Fragment_Other_RootField_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_RootField_Other_RootField_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     },

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_Other_Field_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string",
         "other": "string"
       }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Fragment_SubField_Selected_Separately.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_False.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_False.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": "string",
         "other": "string"
       }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_True.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Resolve_Sequence_Skip_On_SubField_Other_Field_Selected_True.md
@@ -8,7 +8,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "other": "string"
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_EntryField.md
@@ -23,7 +23,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": null
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_SubField.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_One_Service_Errors_SubField.md
@@ -24,7 +24,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": null
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SubgraphErrorTests.Resolve_Sequence_SubField_Nullable_Parent_Nullable_Second_Service_Returns_TopLevel_Error_Without_Data.md
@@ -13,7 +13,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": null
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Node_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Node_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
@@ -24,7 +24,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": null
       }
     }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/TransportErrorTests.Resolve_Sequence_Second_Service_Offline_SubField_Nullable_Parent_Nullable.md
@@ -24,7 +24,7 @@
     "product": {
       "id": "1",
       "brand": {
-        "id": "1",
+        "id": "2",
         "name": null
       }
     }

--- a/src/HotChocolate/Fusion/test/Shared/AutomaticMocking/MockFieldMiddleware.cs
+++ b/src/HotChocolate/Fusion/test/Shared/AutomaticMocking/MockFieldMiddleware.cs
@@ -79,6 +79,15 @@ internal sealed class MockFieldMiddleware
                     context.Result = CreateObject(id);
                     return ValueTask.CompletedTask;
                 }
+
+                if(namedFieldType.IsUnionType() || namedFieldType.IsInterfaceType())
+                {
+                    var possibleTypes = context.Schema.GetPossibleTypes(namedFieldType);
+
+                    context.ValueType = possibleTypes.First();
+                    context.Result = CreateObject(id);
+                    return ValueTask.CompletedTask;
+                }
             }
 
             if (context.Selection.Arguments.ContainsName("ids"))
@@ -91,10 +100,22 @@ internal sealed class MockFieldMiddleware
                     nullableType = fieldType.InnerType();
                 }
 
-                if (nullableType.IsListType() && namedFieldType.IsObjectType())
+                if (nullableType.IsListType())
                 {
-                    context.Result = CreateListOfObjects(ids, nullIndex);
-                    return ValueTask.CompletedTask;
+                    if (namedFieldType.IsObjectType())
+                    {
+                        context.Result = CreateListOfObjects(ids, nullIndex);
+                        return ValueTask.CompletedTask;
+                    }
+
+                    if(namedFieldType.IsUnionType() || namedFieldType.IsInterfaceType())
+                    {
+                        var possibleTypes = context.Schema.GetPossibleTypes(namedFieldType);
+
+                        context.ValueType = possibleTypes.First();
+                        context.Result = CreateListOfObjects(ids, nullIndex);
+                        return ValueTask.CompletedTask;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously the `nodes` field didn't properly return items with the `ids` that were specified.

This PR fixes this and also ensures that `id` values being generated are unique within a request.