### PR TITLE
Removed unnecessary properties from Fusion-vnext property files

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Directory.Build.props
+++ b/src/HotChocolate/Fusion-vnext/src/Directory.Build.props
@@ -3,13 +3,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Nullable.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);CA1812</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <IsAotCompatible>true</IsAotCompatible>
+    <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/HotChocolate/Fusion-vnext/test/Directory.Build.props
+++ b/src/HotChocolate/Fusion-vnext/test/Directory.Build.props
@@ -2,11 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Removed unnecessary properties from Fusion-vnext property files.