### PR TITLE
Fix xml method description when dictionary args present

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/XmlDocumentationProvider.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/XmlDocumentationProvider.cs
@@ -405,7 +405,8 @@ public class XmlDocumentationProvider : IDocumentationProvider
                             "(`[0-9]+)|(, .*?PublicKeyToken=[0-9a-z]*)",
                             string.Empty)
                         .Replace("[[", "{")
-                        .Replace("]]", "}"))
+                        .Replace("]]", "}")
+                        .Replace("],[", ","))
                     .ToArray());
 
                 if (!string.IsNullOrEmpty(paramTypesList))

--- a/src/HotChocolate/Core/test/Types.Tests.Documentation/WithDictionaryArgs.cs
+++ b/src/HotChocolate/Core/test/Types.Tests.Documentation/WithDictionaryArgs.cs
@@ -1,0 +1,11 @@
+namespace HotChocolate.Types.Descriptors;
+
+public class WithDictionaryArgs
+{
+    /// <summary>
+    /// This is a method description
+    /// </summary>
+    /// <param name="args">Args description</param>
+    /// <returns></returns>
+    public string Method(Dictionary<string, string>? args = null) => string.Empty;
+}

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
@@ -428,6 +428,6 @@ public class XmlDocumentationProviderTests
             typeof(WithDictionaryArgs).GetMethod(nameof(WithDictionaryArgs.Method))!);
 
         // assert
-        Assert.Equal(methodDescription, "This is a method description");
+        Assert.Equal("This is a method description", methodDescription);
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Descriptors/Conventions/XmlDocumentationProviderTests.cs
@@ -414,4 +414,20 @@ public class XmlDocumentationProviderTests
         // assert
         methodDescription.MatchSnapshot();
     }
+
+    [Fact]
+    public void When_method_has_dictionary_args_then_it_is_found()
+    {
+        // arrange
+        var documentationProvider = new XmlDocumentationProvider(
+            new XmlDocumentationFileResolver(),
+            new NoOpStringBuilderPool());
+
+        // act
+        var methodDescription = documentationProvider.GetDescription(
+            typeof(WithDictionaryArgs).GetMethod(nameof(WithDictionaryArgs.Method))!);
+
+        // assert
+        Assert.Equal(methodDescription, "This is a method description");
+    }
 }


### PR DESCRIPTION
Fixes issue where XML method descriptions could not be retrieved when the method included a `Dictionary` as one of the parameters.

Closes #7764 
