### PR TITLE
Allowed built-in scalars and directives to be parsed by the SchemaParser

### DIFF
--- a/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaParser.cs
@@ -38,19 +38,17 @@ public static class SchemaParser
         {
             if (definition is DirectiveDefinitionNode def)
             {
-                if (BuiltIns.IsBuiltInDirective(def.Name.Value))
-                {
-                    // If a built-in directive is redefined in the schema, we just ignore it.
-                    continue;
-                }
-
                 if (schema.DirectiveDefinitions.ContainsName(def.Name.Value))
                 {
                     // TODO : parsing error
                     throw new Exception("duplicate");
                 }
 
-                schema.DirectiveDefinitions.Add(new DirectiveDefinition(def.Name.Value));
+                schema.DirectiveDefinitions.Add(
+                    new DirectiveDefinition(def.Name.Value)
+                    {
+                        IsSpecDirective = BuiltIns.IsBuiltInDirective(def.Name.Value)
+                    });
             }
         }
     }
@@ -61,11 +59,6 @@ public static class SchemaParser
         {
             if (definition is ITypeDefinitionNode typeDef)
             {
-                if (BuiltIns.IsBuiltInScalar(typeDef.Name.Value))
-                {
-                    continue;
-                }
-
                 if (schema.Types.ContainsName(typeDef.Name.Value))
                 {
                     // TODO : parsing error
@@ -91,7 +84,11 @@ public static class SchemaParser
                         break;
 
                     case ScalarTypeDefinitionNode:
-                        schema.Types.Add(new ScalarTypeDefinition(typeDef.Name.Value));
+                        schema.Types.Add(
+                            new ScalarTypeDefinition(typeDef.Name.Value)
+                            {
+                                IsSpecScalar = BuiltIns.IsBuiltInScalar(typeDef.Name.Value)
+                            });
                         break;
 
                     case UnionTypeDefinitionNode:
@@ -196,11 +193,6 @@ public static class SchemaParser
                         break;
 
                     case ScalarTypeDefinitionNode typeDef:
-                        if (BuiltIns.IsBuiltInScalar(typeDef.Name.Value))
-                        {
-                            continue;
-                        }
-
                         BuildScalarType(
                             schema,
                             (ScalarTypeDefinition)schema.Types[typeDef.Name.Value],
@@ -545,11 +537,6 @@ public static class SchemaParser
         {
             if (definition is DirectiveDefinitionNode directiveDef)
             {
-                if (BuiltIns.IsBuiltInDirective(directiveDef.Name.Value))
-                {
-                    continue;
-                }
-
                 BuildDirectiveType(
                     schema,
                     schema.DirectiveDefinitions[directiveDef.Name.Value],

--- a/src/HotChocolate/Skimmed/test/Skimmed.Tests/SchemaParserTests.cs
+++ b/src/HotChocolate/Skimmed/test/Skimmed.Tests/SchemaParserTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using HotChocolate.Skimmed.Serialization;
+using HotChocolate.Types;
 
 namespace HotChocolate.Skimmed;
 
@@ -117,5 +118,47 @@ public class SchemaParserTests
                         Assert.Equal("Bar", fieldType.Name);
                     });
             });
+    }
+
+    [Fact]
+    public void Parse_With_Custom_BuiltIn_Scalar_Type()
+    {
+        // arrange
+        var sdl =
+            """
+            "Custom description"
+            scalar String @custom
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var scalar = schema.Types["String"];
+
+        // assert
+        Assert.Equal("Custom description", scalar.Description);
+        Assert.True(scalar.Directives.ContainsName("custom"));
+    }
+
+    [Fact]
+    public void Parse_With_Custom_BuiltIn_Directive()
+    {
+        // arrange
+        var sdl =
+            """
+            "Custom description"
+            directive @skip("Custom argument description" ifCustom: String! @custom) on ENUM_VALUE
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var directive = schema.DirectiveDefinitions["skip"];
+        var argument = directive.Arguments["ifCustom"];
+
+        // assert
+        Assert.Equal("Custom description", directive.Description);
+        Assert.Equal("Custom argument description", argument.Description);
+        Assert.Equal("String", argument.Type.NamedType().Name);
+        Assert.True(argument.Directives.ContainsName("custom"));
+        Assert.Equal(DirectiveLocation.EnumValue, directive.Locations);
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Allowed built-in scalars and directives to be parsed by the `SchemaParser`.