### PR TITLE
Fixed parameter order in OutputFieldTypesNotMergeable method

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
@@ -76,12 +76,12 @@ internal static class LogEntryHelper
             new SchemaCoordinate(directiveName, argumentName: argument.Name, ofDirective: true),
             schema: schema);
 
-    public static LogEntry OutputFieldTypesNotMergeable(string typeName, string fieldName)
+    public static LogEntry OutputFieldTypesNotMergeable(string fieldName, string typeName)
         => new(
             string.Format(
                 LogEntryHelper_OutputFieldTypesNotMergeable,
-                typeName,
-                fieldName),
+                fieldName,
+                typeName),
             LogEntryCodes.OutputFieldTypesNotMergeable,
             LogSeverity.Error,
             new SchemaCoordinate(typeName, fieldName));


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed parameter order in `OutputFieldTypesNotMergeable` method.