### PR TITLE
Added `ValidationHelper.IsExternal` method for Fusion Composition

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/ValidationHelper.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/ValidationHelper.cs
@@ -26,6 +26,11 @@ internal sealed class ValidationHelper
         return !type.Directives.ContainsName(WellKnownDirectiveNames.Inaccessible);
     }
 
+    public static bool IsExternal(IDirectivesProvider type)
+    {
+        return type.Directives.ContainsName(WellKnownDirectiveNames.External);
+    }
+
     public static bool SameTypeShape(ITypeDefinition typeA, ITypeDefinition typeB)
     {
         while (true)

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/WellKnownDirectiveNames.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/WellKnownDirectiveNames.cs
@@ -2,5 +2,6 @@ namespace HotChocolate.Fusion;
 
 internal static class WellKnownDirectiveNames
 {
+    public const string External = "external";
     public const string Inaccessible = "inaccessible";
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added `ValidationHelper.IsExternal` method for Fusion Composition.

---

This is a separate PR so that multiple validation rules can be written that utilize this method.