### PR TITLE
Updated Fusion-vnext test projects to use xUnit v3 instead of TUnit

### DIFF
--- a/src/HotChocolate/Fusion-vnext/test/Directory.Build.props
+++ b/src/HotChocolate/Fusion-vnext/test/Directory.Build.props
@@ -2,26 +2,32 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutput>$(OutputPath)coverage.cobertura.xml</CoverletOutput>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <CollectCoverage>true</CollectCoverage>
-    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <CoverletOutput>$(OutputPath)coverage.cobertura.xml</CoverletOutput>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
     <Using Include="CookieCrumble" />
-    <Using Include="CookieCrumble.TUnit" />
+    <Using Include="CookieCrumble.Xunit3" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\CookieCrumble\src\CookieCrumble.TUnit\CookieCrumble.TUnit.csproj" />
+    <ProjectReference Include="..\..\..\..\CookieCrumble\src\CookieCrumble.Xunit3\CookieCrumble.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
 </Project>

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/ExternalMissingOnBaseRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/ExternalMissingOnBaseRuleTests.cs
@@ -8,9 +8,9 @@ namespace HotChocolate.Composition.PreMergeValidation.Rules;
 
 public sealed class ExternalMissingOnBaseRuleTests
 {
-    [Test]
-    [MethodDataSource(nameof(ValidExamplesData))]
-    public async Task Examples_Valid(string[] sdl)
+    [Theory]
+    [MemberData(nameof(ValidExamplesData))]
+    public void Examples_Valid(string[] sdl)
     {
         // arrange
         var log = new CompositionLog();
@@ -21,13 +21,13 @@ public sealed class ExternalMissingOnBaseRuleTests
         var result = preMergeValidator.Validate(context);
 
         // assert
-        await Assert.That(result.IsSuccess).IsTrue();
-        await Assert.That(log.IsEmpty).IsTrue();
+        Assert.True(result.IsSuccess);
+        Assert.True(log.IsEmpty);
     }
 
-    [Test]
-    [MethodDataSource(nameof(InvalidExamplesData))]
-    public async Task Examples_Invalid(string[] sdl)
+    [Theory]
+    [MemberData(nameof(InvalidExamplesData))]
+    public void Examples_Invalid(string[] sdl)
     {
         // arrange
         var log = new CompositionLog();
@@ -38,80 +38,83 @@ public sealed class ExternalMissingOnBaseRuleTests
         var result = preMergeValidator.Validate(context);
 
         // assert
-        await Assert.That(result.IsFailure).IsTrue();
-        await Assert.That(log.Count()).IsEqualTo(1);
-        await Assert.That(log.First().Code).IsEqualTo("EXTERNAL_MISSING_ON_BASE");
-        await Assert.That(log.First().Severity).IsEqualTo(LogSeverity.Error);
+        Assert.True(result.IsFailure);
+        Assert.Single(log);
+        Assert.Equal("EXTERNAL_MISSING_ON_BASE", log.First().Code);
+        Assert.Equal(LogSeverity.Error, log.First().Severity);
     }
 
-    public static IEnumerable<Func<string[]>> ValidExamplesData()
+    public static TheoryData<string[]> ValidExamplesData()
     {
-        return
-        [
+        return new TheoryData<string[]>
+        {
             // Here, the `name` field on Product is defined in source schema A and marked as
             // @external in source schema B, which is valid because there is a base definition in
             // source schema A.
-            () =>
-            [
-                """
-                # Source schema A
-                type Product {
-                    id: ID
-                    name: String
-                }
-                """,
-                """
-                # Source schema B
-                type Product {
-                    id: ID
-                    name: String @external
-                }
-                """
-            ]
-        ];
+            {
+                [
+                    """
+                    # Source schema A
+                    type Product {
+                        id: ID
+                        name: String
+                    }
+                    """,
+                    """
+                    # Source schema B
+                    type Product {
+                        id: ID
+                        name: String @external
+                    }
+                    """
+                ]
+            }
+        };
     }
 
-    public static IEnumerable<Func<string[]>> InvalidExamplesData()
+    public static TheoryData<string[]> InvalidExamplesData()
     {
-        return
-        [
+        return new TheoryData<string[]>
+        {
             // In this example, the `name` field on Product is marked as @external in source schema
             // B but has no non-@external declaration in any other source schema, violating the
             // rule.
-            () =>
-            [
-                """
-                # Source schema A
-                type Product {
-                    id: ID
-                }
-                """,
-                """
-                # Source schema B
-                type Product {
-                    id: ID
-                    name: String @external
-                }
-                """
-            ],
+            {
+                [
+                    """
+                    # Source schema A
+                    type Product {
+                        id: ID
+                    }
+                    """,
+                    """
+                    # Source schema B
+                    type Product {
+                        id: ID
+                        name: String @external
+                    }
+                    """
+                ]
+            },
             // The `name` field is external in both source schemas.
-            () =>
-            [
-                """
-                # Source schema A
-                type Product {
-                    id: ID
-                    name: String @external
-                }
-                """,
-                """
-                # Source schema B
-                type Product {
-                    id: ID
-                    name: String @external
-                }
-                """
-            ]
-        ];
+            {
+                [
+                    """
+                    # Source schema A
+                    type Product {
+                        id: ID
+                        name: String @external
+                    }
+                    """,
+                    """
+                    # Source schema B
+                    type Product {
+                        id: ID
+                        name: String @external
+                    }
+                    """
+                ]
+            }
+        };
     }
 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/OutputFieldTypesMergeableRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/OutputFieldTypesMergeableRuleTests.cs
@@ -8,9 +8,9 @@ namespace HotChocolate.Composition.PreMergeValidation.Rules;
 
 public sealed class OutputFieldTypesMergeableRuleTests
 {
-    [Test]
-    [MethodDataSource(nameof(ValidExamplesData))]
-    public async Task Examples_Valid(string[] sdl)
+    [Theory]
+    [MemberData(nameof(ValidExamplesData))]
+    public void Examples_Valid(string[] sdl)
     {
         // arrange
         var log = new CompositionLog();
@@ -21,13 +21,13 @@ public sealed class OutputFieldTypesMergeableRuleTests
         var result = preMergeValidator.Validate(context);
 
         // assert
-        await Assert.That(result.IsSuccess).IsTrue();
-        await Assert.That(log.IsEmpty).IsTrue();
+        Assert.True(result.IsSuccess);
+        Assert.True(log.IsEmpty);
     }
 
-    [Test]
-    [MethodDataSource(nameof(InvalidExamplesData))]
-    public async Task Examples_Invalid(string[] sdl)
+    [Theory]
+    [MemberData(nameof(InvalidExamplesData))]
+    public void Examples_Invalid(string[] sdl)
     {
         // arrange
         var log = new CompositionLog();
@@ -38,103 +38,108 @@ public sealed class OutputFieldTypesMergeableRuleTests
         var result = preMergeValidator.Validate(context);
 
         // assert
-        await Assert.That(result.IsFailure).IsTrue();
-        await Assert.That(log.Count()).IsEqualTo(1);
-        await Assert.That(log.First().Code).IsEqualTo("OUTPUT_FIELD_TYPES_NOT_MERGEABLE");
-        await Assert.That(log.First().Severity).IsEqualTo(LogSeverity.Error);
+        Assert.True(result.IsFailure);
+        Assert.Single(log);
+        Assert.Equal("OUTPUT_FIELD_TYPES_NOT_MERGEABLE", log.First().Code);
+        Assert.Equal(LogSeverity.Error, log.First().Severity);
     }
 
-    public static IEnumerable<Func<string[]>> ValidExamplesData()
+    public static TheoryData<string[]> ValidExamplesData()
     {
-        return
-        [
+        return new TheoryData<string[]>
+        {
             // Fields with the same type are mergeable.
-            () =>
-            [
-                """
-                type User {
-                    birthdate: String
-                }
-                """,
-                """
-                type User {
-                    birthdate: String
-                }
-                """
-            ],
+            {
+                [
+                    """
+                    type User {
+                        birthdate: String
+                    }
+                    """,
+                    """
+                    type User {
+                        birthdate: String
+                    }
+                    """
+                ]
+            },
             // Fields with different nullability are mergeable, resulting in a merged field with a
             // nullable type.
-            () =>
-            [
-                """
-                type User {
-                    birthdate: String!
-                }
-                """,
-                """
-                type User {
-                    birthdate: String
-                }
-                """
-            ],
-            () =>
-            [
-                """
-                type User {
-                    tags: [String!]
-                }
-                """,
-                """
-                type User {
-                    tags: [String]!
-                }
-                """,
-                """
-                type User {
-                    tags: [String]
-                }
-                """
-            ]
-        ];
+            {
+                [
+                    """
+                    type User {
+                        birthdate: String!
+                    }
+                    """,
+                    """
+                    type User {
+                        birthdate: String
+                    }
+                    """
+                ]
+            },
+            {
+                [
+                    """
+                    type User {
+                        tags: [String!]
+                    }
+                    """,
+                    """
+                    type User {
+                        tags: [String]!
+                    }
+                    """,
+                    """
+                    type User {
+                        tags: [String]
+                    }
+                    """
+                ]
+            }
+        };
     }
 
-    public static IEnumerable<Func<string[]>> InvalidExamplesData()
+    public static TheoryData<string[]> InvalidExamplesData()
     {
-        return
-        [
+        return new TheoryData<string[]>
+        {
             // Fields are not mergeable if the named types are different in kind or name.
-            () =>
-            [
-                """
-                type User {
-                    birthdate: String!
-                }
-                """,
-                """
-                type User {
-                    birthdate: DateTime!
-                }
-                """
-            ],
-            () =>
-            [
-                """
-                type User {
-                    tags: [Tag]
-                }
+            {
+                [
+                    """
+                    type User {
+                        birthdate: String!
+                    }
+                    """,
+                    """
+                    type User {
+                        birthdate: DateTime!
+                    }
+                    """
+                ]
+            },
+            {
+                [
+                    """
+                    type User {
+                        tags: [Tag]
+                    }
 
-                type Tag {
-                    value: String
-                }
-                """,
-                """
-                type User {
-                    tags: [Tag]
-                }
+                    type Tag {
+                        value: String
+                    }
+                    """,
+                    """
+                    type User {
+                        tags: [Tag]
+                    }
 
-                scalar Tag
-                """
-            ]
-        ];
+                    scalar Tag
+                    """
+                ]
+            }
+        };
     }
 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/ValidationHelperTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/ValidationHelperTests.cs
@@ -6,18 +6,18 @@ namespace HotChocolate.Composition;
 
 public sealed class ValidationHelperTests
 {
-    [Test]
-    [Arguments("Int", "Int")]
-    [Arguments("[Int]", "[Int]")]
-    [Arguments("[[Int]]", "[[Int]]")]
+    [Theory]
+    [InlineData("Int", "Int")]
+    [InlineData("[Int]", "[Int]")]
+    [InlineData("[[Int]]", "[[Int]]")]
     // Different nullability.
-    [Arguments("Int", "Int!")]
-    [Arguments("[Int]", "[Int!]")]
-    [Arguments("[Int]", "[Int!]!")]
-    [Arguments("[[Int]]", "[[Int!]]")]
-    [Arguments("[[Int]]", "[[Int!]!]")]
-    [Arguments("[[Int]]", "[[Int!]!]!")]
-    public async Task SameTypeShape_True(string sdlTypeA, string sdlTypeB)
+    [InlineData("Int", "Int!")]
+    [InlineData("[Int]", "[Int!]")]
+    [InlineData("[Int]", "[Int!]!")]
+    [InlineData("[[Int]]", "[[Int!]]")]
+    [InlineData("[[Int]]", "[[Int!]!]")]
+    [InlineData("[[Int]]", "[[Int!]!]!")]
+    public void SameTypeShape_True(string sdlTypeA, string sdlTypeB)
     {
         // arrange
         var schema1 = SchemaParser.Parse($$"""type Test { field: {{sdlTypeA}} }""");
@@ -29,27 +29,27 @@ public sealed class ValidationHelperTests
         var result = ValidationHelper.SameTypeShape(typeA, typeB);
 
         // assert
-        await Assert.That(result).IsTrue();
+        Assert.True(result);
     }
 
-    [Test]
+    [Theory]
     // Different type kind.
-    [Arguments("Tag", "Tag")]
-    [Arguments("[Tag]", "[Tag]")]
-    [Arguments("[[Tag]]", "[[Tag]]")]
+    [InlineData("Tag", "Tag")]
+    [InlineData("[Tag]", "[Tag]")]
+    [InlineData("[[Tag]]", "[[Tag]]")]
     // Different type name.
-    [Arguments("String", "DateTime")]
-    [Arguments("[String]", "[DateTime]")]
-    [Arguments("[[String]]", "[[DateTime]]")]
+    [InlineData("String", "DateTime")]
+    [InlineData("[String]", "[DateTime]")]
+    [InlineData("[[String]]", "[[DateTime]]")]
     // Different depth.
-    [Arguments("String", "[String]")]
-    [Arguments("String", "[[String]]")]
-    [Arguments("[String]", "[[String]]")]
-    [Arguments("[[String]]", "[[[String]]]")]
+    [InlineData("String", "[String]")]
+    [InlineData("String", "[[String]]")]
+    [InlineData("[String]", "[[String]]")]
+    [InlineData("[[String]]", "[[[String]]]")]
     // Different depth and nullability.
-    [Arguments("String", "[String!]")]
-    [Arguments("String", "[String!]!")]
-    public async Task SameTypeShape_False(string sdlTypeA, string sdlTypeB)
+    [InlineData("String", "[String!]")]
+    [InlineData("String", "[String!]!")]
+    public void SameTypeShape_False(string sdlTypeA, string sdlTypeB)
     {
         // arrange
         var schema1 = SchemaParser.Parse(
@@ -73,6 +73,6 @@ public sealed class ValidationHelperTests
         var result = ValidationHelper.SameTypeShape(typeA, typeB);
 
         // assert
-        await Assert.That(result).IsFalse();
+        Assert.False(result);
     }
 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipAndIncludeTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipAndIncludeTests.cs
@@ -5,7 +5,7 @@ namespace HotChocolate.Fusion;
 // TODO: Test shared skip selection with one selection having an include - should fail today incorrectly!
 public class SkipAndIncludeTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField()
     {
         // arrange
@@ -32,7 +32,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_With_Same_Variable()
     {
         // arrange
@@ -59,7 +59,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_False()
     {
         // arrange
@@ -86,7 +86,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_True()
     {
         // arrange
@@ -113,7 +113,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_True_Include_False()
     {
         // arrange
@@ -140,7 +140,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_False_Include_True()
     {
         // arrange
@@ -167,7 +167,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_True_Include_True()
     {
         // arrange
@@ -194,7 +194,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Skip_False_Include_False()
     {
         // arrange
@@ -221,7 +221,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected()
     {
         // arrange
@@ -243,7 +243,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_With_Same_Variable()
     {
         // arrange
@@ -265,7 +265,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_False()
     {
         // arrange
@@ -287,7 +287,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_True()
     {
         // arrange
@@ -309,7 +309,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_True_Include_False()
     {
         // arrange
@@ -331,7 +331,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_False_Include_True()
     {
         // arrange
@@ -353,7 +353,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_True_Include_True()
     {
         // arrange
@@ -375,7 +375,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_RootField_Only_Skipped_Field_Selected_Skip_False_Include_False()
     {
         // arrange
@@ -397,7 +397,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField()
     {
         // arrange
@@ -420,7 +420,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_With_Same_Variable()
     {
         // arrange
@@ -443,7 +443,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_False()
     {
         // arrange
@@ -466,7 +466,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_True()
     {
         // arrange
@@ -489,7 +489,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_True_Include_False()
     {
         // arrange
@@ -512,7 +512,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_False_Include_True()
     {
         // arrange
@@ -535,7 +535,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_True_Include_True()
     {
         // arrange
@@ -558,7 +558,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Skip_False_Include_False()
     {
         // arrange
@@ -581,7 +581,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected()
     {
         // arrange
@@ -603,7 +603,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_False()
     {
         // arrange
@@ -625,7 +625,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_True()
     {
         // arrange
@@ -647,7 +647,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_With_Same_Variable()
     {
         // arrange
@@ -669,7 +669,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_True_Include_False()
     {
         // arrange
@@ -691,7 +691,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_False_Include_True()
     {
         // arrange
@@ -713,7 +713,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_True_Include_True()
     {
         // arrange
@@ -735,7 +735,7 @@ public class SkipAndIncludeTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skip_And_Include_On_SubField_Only_Skipped_Field_Selected_Skip_False_Include_False()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipFragmentTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipFragmentTests.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Fusion;
 
 public class SkipFragmentTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_Same_Selection_Without_Skip_In_Fragment()
     {
         // arrange
@@ -33,7 +33,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_Same_Skipped_Selection_In_Fragment()
     {
         // arrange
@@ -62,7 +62,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_Same_Skipped_Selection_With_Different_Skip_In_Fragment()
     {
         // arrange
@@ -91,7 +91,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragment()
     {
         // arrange
@@ -117,7 +117,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragment_If_True()
     {
         // arrange
@@ -143,7 +143,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragment_Other_Not_Skipped_Root_Fragment_From_Same_Subgraph()
     {
         // arrange
@@ -178,7 +178,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragment_Other_Not_Skipped_Root_Fragment_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -213,8 +213,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragment_Other_Not_Skipped_Root_Fragment_From_Different_Subgraph()
     {
         // arrange
@@ -247,8 +246,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragment_Other_Not_Skipped_Root_Fragment_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -281,8 +279,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragment_With_Selections_From_Two_Subgraphs()
     {
         // arrange
@@ -311,7 +308,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragment_With_Selections_From_Two_Subgraphs_If_True()
     {
         // arrange
@@ -340,7 +337,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragments_With_Same_Root_Selection_From_Same_Subgraph()
     {
         // arrange
@@ -374,7 +371,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Fragments_With_Same_Root_Selection_From_Same_Subgraph_Same_Variable()
     {
         // arrange
@@ -408,8 +405,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragments_With_Different_Root_Selection_From_Different_Subgraphs()
     {
         // arrange
@@ -442,8 +438,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragments_With_Different_Root_Selection_From_Different_Subgraphs_Same_Variable()
     {
         // arrange
@@ -476,8 +471,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragments_With_Shared_Viewer_Selection_And_Sub_Selections_From_Two_Subgraphs_Each()
     {
         // arrange
@@ -520,8 +514,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Fragments_With_Shared_Viewer_Selection_And_Sub_Selections_From_Two_Subgraphs_Each_Same_Variable()
     {
         // arrange
@@ -564,7 +557,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Same_Selection_Without_Skip_In_Fragment()
     {
         // arrange
@@ -591,7 +584,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Same_Skipped_Selection_In_Fragment()
     {
         // arrange
@@ -618,7 +611,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Same_Skipped_Selection_With_Different_Skip_In_Fragment()
     {
         // arrange
@@ -645,7 +638,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment()
     {
         // arrange
@@ -671,7 +664,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_If_True()
     {
         // arrange
@@ -697,7 +690,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_Other_Not_Skipped_Sub_Fragment_From_Same_Subgraph()
     {
         // arrange
@@ -728,7 +721,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_Other_Not_Skipped_Sub_Fragment_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -759,7 +752,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_Other_Not_Skipped_Sub_Fragment_From_Different_Subgraph()
     {
         // arrange
@@ -790,7 +783,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_Other_Not_Skipped_Sub_Fragment_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -821,7 +814,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Sub_Fragment_From_Same_Subgraph()
     {
         // arrange
@@ -852,7 +845,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Sub_Fragment_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -883,7 +876,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Same_And_Different_Subgraph()
     {
         // arrange
@@ -910,7 +903,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Same_And_Different_Subgraph_If_True()
     {
         // arrange
@@ -937,7 +930,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -964,7 +957,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -995,7 +988,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Different_Selection_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -1026,8 +1019,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Doesn't work yet")]
+    [Fact(Skip = "Doesn't work yet")]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Selection_With_Same_Entry_Selection()
     {
         // arrange
@@ -1062,8 +1054,7 @@ public class SkipFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Doesn't work yet")]
+    [Fact(Skip = "Doesn't work yet")]
     public void Skipped_Sub_Fragment_From_Different_Subgraph_Other_Not_Skipped_Selection_With_Same_Entry_Selection_If_True()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ConditionTests/SkipTests.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Fusion;
 
 public class SkipTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection()
     {
         // arrange
@@ -26,7 +26,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_If_True()
     {
         // arrange
@@ -48,7 +48,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selections_From_Same_Subgraph()
     {
         // arrange
@@ -75,7 +75,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selections_From_Same_Subgraph_Same_Variable()
     {
         // arrange
@@ -102,8 +102,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Selections_From_Different_Subgraphs()
     {
         // arrange
@@ -128,8 +127,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Selections_From_Different_Subgraphs_Same_Variable()
     {
         // arrange
@@ -154,8 +152,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Shared_Viewer_Root_Selection_With_Sub_Selections_From_Different_Subgraphs()
     {
         // arrange
@@ -182,8 +179,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Shared_byId_Root_Selection_With_Sub_Selections_From_Different_Subgraphs()
     {
         // arrange
@@ -206,7 +202,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_Other_Not_Skipped_Root_Selection_From_Same_Subgraph()
     {
         // arrange
@@ -233,7 +229,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Root_Selection_Other_Not_Skipped_Root_Selection_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -260,8 +256,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Selection_Other_Not_Skipped_Root_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -286,8 +281,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Skipped_Root_Selection_Other_Not_Skipped_Root_Selection_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -312,7 +306,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection()
     {
         // arrange
@@ -334,7 +328,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_If_True()
     {
         // arrange
@@ -356,7 +350,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Other_Not_Skipped_Sub_Selection_From_Same_Subgraph()
     {
         // arrange
@@ -379,7 +373,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Other_Not_Skipped_Sub_Selection_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -402,7 +396,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Other_Not_Skipped_Sub_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -425,7 +419,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_Other_Not_Skipped_Sub_Selection_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -448,7 +442,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -470,7 +464,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph_If_True()
     {
         // arrange
@@ -492,7 +486,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph_Other_Not_Skipped_Sub_Selection_From_First_Subgraph()
     {
         // arrange
@@ -515,7 +509,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph_Other_Not_Skipped_Sub_Selection_From_First_Subgraph_If_True()
     {
         // arrange
@@ -538,7 +532,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph_Other_Not_Skipped_Sub_Selection_From_Same_Subgraph()
     {
         // arrange
@@ -565,7 +559,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_From_Different_Subgraph_Other_Not_Skipped_Sub_Selection_From_Same_Subgraph_If_True()
     {
         // arrange
@@ -592,7 +586,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_That_Provides_Data_For_Lookup_On_Different_Subgraph()
     {
         // arrange
@@ -617,7 +611,7 @@ public class SkipTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Skipped_Sub_Selection_That_Provides_Data_For_Lookup_On_Different_Subgraph_If_True()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/FragmentTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/FragmentTests.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Fusion;
 
 public class FragmentTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Fragment_On_Root()
     {
         // arrange
@@ -30,7 +30,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Root_Next_To_Same_Selection()
     {
         // arrange
@@ -59,7 +59,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Root_Next_To_Same_Selection_With_Different_Sub_Selection()
     {
         // arrange
@@ -88,7 +88,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Root_Next_To_Different_Selection()
     {
         // arrange
@@ -119,8 +119,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Fragment_On_Root_Next_To_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -149,7 +148,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Root_With_Same_Selection()
     {
         // arrange
@@ -182,7 +181,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Root_With_Different_Selection()
     {
         // arrange
@@ -217,8 +216,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Two_Fragments_On_Root_With_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -251,7 +249,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Sub_Selection()
     {
         // arrange
@@ -277,7 +275,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Sub_Selection_Next_To_Same_Selection()
     {
         // arrange
@@ -304,7 +302,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Sub_Selection_Next_To_Different_Selection()
     {
         // arrange
@@ -331,7 +329,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Fragment_On_Sub_Selection_Next_To_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -358,7 +356,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Same_Selection()
     {
         // arrange
@@ -389,7 +387,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Different_Selection()
     {
         // arrange
@@ -420,7 +418,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -451,7 +449,7 @@ public class FragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Different_But_Same_Entry_Selection_From_Different_Subgraph()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/InlineFragmentTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/InlineFragmentTests.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Fusion;
 
 public class InlineFragmentTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void InlineFragment_On_Root()
     {
         // arrange
@@ -28,7 +28,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Root_Next_To_Same_Selection()
     {
         // arrange
@@ -55,7 +55,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Root_Next_To_Same_Selection_With_Different_Sub_Selection()
     {
         // arrange
@@ -82,7 +82,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Root_Next_To_Different_Selection()
     {
         // arrange
@@ -111,8 +111,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void InlineFragment_On_Root_Next_To_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -139,7 +138,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_InlineFragments_On_Root_With_Same_Selection()
     {
         // arrange
@@ -168,7 +167,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_InlineFragments_On_Root_With_Different_Selection()
     {
         // arrange
@@ -199,8 +198,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
-    [Skip("Not yet supported by the planner")]
+    [Fact(Skip = "Not yet supported by the planner")]
     public void Two_InlineFragments_On_Root_With_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -229,7 +227,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Sub_Selection()
     {
         // arrange
@@ -253,7 +251,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Sub_Selection_Next_To_Same_Selection()
     {
         // arrange
@@ -278,7 +276,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Sub_Selection_Next_To_Different_Selection()
     {
         // arrange
@@ -303,7 +301,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void InlineFragment_On_Sub_Selection_Next_To_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -328,7 +326,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Same_Selection()
     {
         // arrange
@@ -355,7 +353,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Different_Selection()
     {
         // arrange
@@ -382,7 +380,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Two_Fragments_On_Sub_Selection_With_Different_Selection_From_Different_Subgraph()
     {
         // arrange
@@ -409,7 +407,7 @@ public class InlineFragmentTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Merge_Fields_With_Alias()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/LookupRequirementsTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/LookupRequirementsTests.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Fusion;
 
 public class LookupRequirementsTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Key_Has_Requirement_To_Schema_That_Is_Not_In_Context()
     {
         var schema = CreateCompositeSchema(

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ModuleInitializer.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/ModuleInitializer.cs
@@ -8,7 +8,7 @@ internal static class ModuleInitializer
     [ModuleInitializer]
     public static void Initialize()
     {
-        CookieCrumbleTUnit.Initialize();
+        CookieCrumbleXunit3.Initialize();
         Snapshot.RegisterFormatter(new GraphQLSnapshotValueFormatter());
     }
 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/OperationPlannerTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/OperationPlannerTests.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Fusion;
 
 public class OperationPlannerTests : FusionTestBase
 {
-    [Test]
+    [Fact]
     public void Plan_Simple_Operation_1_Source_Schema()
     {
         // arrange
@@ -34,7 +34,7 @@ public class OperationPlannerTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Plan_Simple_Operation_2_Source_Schema()
     {
         // arrange
@@ -62,7 +62,7 @@ public class OperationPlannerTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Plan_Simple_Operation_3_Source_Schema()
     {
         // arrange
@@ -105,7 +105,7 @@ public class OperationPlannerTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Plan_Simple_Operation_3_Source_Schema_And_Single_Variable()
     {
         // arrange
@@ -148,7 +148,7 @@ public class OperationPlannerTests : FusionTestBase
         plan.MatchSnapshot();
     }
 
-    [Test]
+    [Fact]
     public void Plan_With_Conditional_InlineFragment()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/InlineFragmentOperationRewriterTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/InlineFragmentOperationRewriterTests.cs
@@ -5,7 +5,7 @@ namespace HotChocolate.Fusion.Planning;
 
 public class InlineFragmentOperationRewriterTests
 {
-    [Test]
+    [Fact]
     public void Inline_Into_ProductById_SelectionSet()
     {
         // arrange
@@ -42,7 +42,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Inline_Into_ProductById_SelectionSet_2_Levels()
     {
         // arrange
@@ -83,7 +83,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Inline_Inline_Fragment_Into_ProductById_SelectionSet_1()
     {
         // arrange
@@ -118,7 +118,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Inline_Into_ProductById_SelectionSet_3_Levels()
     {
         // arrange
@@ -161,7 +161,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Do_Not_Inline_Inline_Fragment_Into_ProductById_SelectionSet()
     {
         // arrange
@@ -200,7 +200,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Deduplicate_Fields()
     {
         // arrange
@@ -239,7 +239,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Leafs_With_Different_Directives_Do_Not_Merge()
     {
         // arrange
@@ -280,7 +280,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Composites_Without_Directives_Are_Merged()
     {
         // arrange
@@ -335,7 +335,7 @@ public class InlineFragmentOperationRewriterTests
             """);
     }
 
-    [Test]
+    [Fact]
     public void Merge_Fields_With_Aliases()
     {
         // arrange

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/MergeSelectionSetRewriterTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/MergeSelectionSetRewriterTests.cs
@@ -6,7 +6,7 @@ namespace HotChocolate.Fusion.Planning;
 
 public class MergeSelectionSetRewriterTests
 {
-    [Test]
+    [Fact]
     public void Merge_Two_SelectionSets()
     {
         // arrange


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated Fusion-vnext test projects to use xUnit v3 instead of TUnit.