### PR TITLE
Resolved issue in SchemaParser that prevented default values parsing in Input Objects

### DIFF
--- a/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaParser.cs
@@ -434,6 +434,7 @@ public static class SchemaParser
             var field = new InputFieldDefinition(fieldNode.Name.Value);
             field.Description = fieldNode.Description?.Value;
             field.Type = schema.Types.ResolveType(fieldNode.Type);
+            field.DefaultValue = fieldNode.DefaultValue;
 
             BuildDirectiveCollection(schema, field.Directives, fieldNode.Directives);
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Resolved issue in SchemaParser that prevented default values parsing in Input Objects

Closes #7160 
