### PR TITLE
Renamed "EnumTypesInconsistentRule" to "EnumValuesMismatchRule"

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
@@ -3,7 +3,7 @@ namespace HotChocolate.Fusion.Logging;
 public static class LogEntryCodes
 {
     public const string DisallowedInaccessible = "DISALLOWED_INACCESSIBLE";
-    public const string EnumTypesInconsistent = "ENUM_TYPES_INCONSISTENT";
+    public const string EnumValuesMismatch = "ENUM_VALUES_MISMATCH";
     public const string ExternalArgumentDefaultMismatch = "EXTERNAL_ARGUMENT_DEFAULT_MISMATCH";
     public const string ExternalMissingOnBase = "EXTERNAL_MISSING_ON_BASE";
     public const string ExternalOnInterface = "EXTERNAL_ON_INTERFACE";

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryHelper.cs
@@ -100,18 +100,18 @@ internal static class LogEntryHelper
             schema);
     }
 
-    public static LogEntry EnumTypesInconsistent(
+    public static LogEntry EnumValuesMismatch(
         EnumTypeDefinition enumType,
         string enumValue,
         SchemaDefinition schema)
     {
         return new LogEntry(
             string.Format(
-                LogEntryHelper_EnumTypesInconsistent,
+                LogEntryHelper_EnumValuesMismatch,
                 enumType.Name,
                 schema.Name,
                 enumValue),
-            LogEntryCodes.EnumTypesInconsistent,
+            LogEntryCodes.EnumValuesMismatch,
             LogSeverity.Error,
             new SchemaCoordinate(enumType.Name),
             enumType,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PreMergeValidation/Rules/EnumValuesMismatchRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PreMergeValidation/Rules/EnumValuesMismatchRule.cs
@@ -18,10 +18,10 @@ namespace HotChocolate.Fusion.PreMergeValidation.Rules;
 /// exact match in their values.
 /// </para>
 /// </summary>
-/// <seealso href="https://graphql.github.io/composite-schemas-spec/draft/#sec-Enum-Types-Inconsistent">
+/// <seealso href="https://graphql.github.io/composite-schemas-spec/draft/#sec-Enum-Values-Mismatch">
 /// Specification
 /// </seealso>
-internal sealed class EnumTypesInconsistentRule : IEventHandler<EnumTypeGroupEvent>
+internal sealed class EnumValuesMismatchRule : IEventHandler<EnumTypeGroupEvent>
 {
     public void Handle(EnumTypeGroupEvent @event, CompositionContext context)
     {
@@ -44,8 +44,7 @@ internal sealed class EnumTypesInconsistentRule : IEventHandler<EnumTypeGroupEve
             {
                 if (!enumType.Values.ContainsName(enumValue))
                 {
-                    context.Log.Write(
-                        EnumTypesInconsistent(enumType, enumValue, schema));
+                    context.Log.Write(EnumValuesMismatch(enumType, enumValue, schema));
                 }
             }
         }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.Designer.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.Designer.cs
@@ -116,9 +116,9 @@ namespace HotChocolate.Fusion.Properties {
         /// <summary>
         ///   Looks up a localized string similar to The enum type &apos;{0}&apos; in schema &apos;{1}&apos; must define the value &apos;{2}&apos;..
         /// </summary>
-        internal static string LogEntryHelper_EnumTypesInconsistent {
+        internal static string LogEntryHelper_EnumValuesMismatch {
             get {
-                return ResourceManager.GetString("LogEntryHelper_EnumTypesInconsistent", resourceCulture);
+                return ResourceManager.GetString("LogEntryHelper_EnumValuesMismatch", resourceCulture);
             }
         }
         

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.resx
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Properties/CompositionResources.resx
@@ -36,7 +36,7 @@
   <data name="LogEntryHelper_DisallowedInaccessibleDirectiveArgument" xml:space="preserve">
     <value>The built-in directive argument '{0}' in schema '{1}' is not accessible.</value>
   </data>
-  <data name="LogEntryHelper_EnumTypesInconsistent" xml:space="preserve">
+  <data name="LogEntryHelper_EnumValuesMismatch" xml:space="preserve">
     <value>The enum type '{0}' in schema '{1}' must define the value '{2}'.</value>
   </data>
   <data name="LogEntryHelper_ExternalArgumentDefaultMismatch" xml:space="preserve">

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -47,7 +47,7 @@ internal sealed class SourceSchemaMerger
     private static readonly List<object> _preMergeValidationRules =
     [
         new DisallowedInaccessibleElementsRule(),
-        new EnumTypesInconsistentRule(),
+        new EnumValuesMismatchRule(),
         new ExternalArgumentDefaultMismatchRule(),
         new ExternalMissingOnBaseRule(),
         new ExternalOnInterfaceRule(),

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/EnumValuesMismatchRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PreMergeValidation/Rules/EnumValuesMismatchRuleTests.cs
@@ -4,9 +4,9 @@ using HotChocolate.Fusion.PreMergeValidation.Rules;
 
 namespace HotChocolate.Composition.PreMergeValidation.Rules;
 
-public sealed class EnumTypesInconsistentRuleTests : CompositionTestBase
+public sealed class EnumValuesMismatchRuleTests : CompositionTestBase
 {
-    private readonly PreMergeValidator _preMergeValidator = new([new EnumTypesInconsistentRule()]);
+    private readonly PreMergeValidator _preMergeValidator = new([new EnumValuesMismatchRule()]);
 
     [Theory]
     [MemberData(nameof(ValidExamplesData))]
@@ -36,7 +36,7 @@ public sealed class EnumTypesInconsistentRuleTests : CompositionTestBase
         // assert
         Assert.True(result.IsFailure);
         Assert.Equal(errorMessages, context.Log.Select(e => e.Message).ToArray());
-        Assert.True(context.Log.All(e => e.Code == "ENUM_TYPES_INCONSISTENT"));
+        Assert.True(context.Log.All(e => e.Code == "ENUM_VALUES_MISMATCH"));
         Assert.True(context.Log.All(e => e.Severity == LogSeverity.Error));
     }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Renamed "EnumTypesInconsistentRule" to "EnumValuesMismatchRule".