### PR TITLE
Possible fix for issue #7930 HotChocolate.Types.Filters Null Reference issue

### DIFF
--- a/src/HotChocolate/Filters/src/Types.Filters/QueryableFilterVisitor.cs
+++ b/src/HotChocolate/Filters/src/Types.Filters/QueryableFilterVisitor.cs
@@ -112,7 +112,7 @@ namespace HotChocolate.Types.Filters
 
                 while (operations.Count != 0)
                 {
-                    combined = combine(combined, operations.Dequeue());
+                    combined = combine(operations.Dequeue(), combined);
                 }
 
                 return true;


### PR DESCRIPTION
Changed order of operations during combine

- If filter condition is complex, expression for IQueryable could have mistakes. For example 
- ($r.ItemSetting).Data == 123 && $r.ItemSetting != null
- first it checks property value, and only then checks object is not null.

- In my case (described in original topic) fix changed order and issue is gone

Closes #7930

Original post with details and issue explanation - https://github.com/ChilliCream/graphql-platform/discussions/7850
