### PR TITLE
Added ISyntaxNodeProvider to Skimmed type system member definitions

### DIFF
--- a/src/HotChocolate/Skimmed/src/Skimmed/ArgumentAssignment.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/ArgumentAssignment.cs
@@ -7,7 +7,7 @@ namespace HotChocolate.Skimmed;
 /// <summary>
 /// Represents an argument value assignment.
 /// </summary>
-public sealed class ArgumentAssignment
+public sealed class ArgumentAssignment : ISyntaxNodeProvider
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ArgumentAssignment"/> class.
@@ -102,4 +102,11 @@ public sealed class ArgumentAssignment
     /// <returns></returns>
     public override string ToString()
         => RewriteArgument(this).ToString(true);
+
+    /// <summary>
+    /// Creates an <see cref="ArgumentNode"/> from an <see cref="ArgumentAssignment"/>.
+    /// </summary>
+    public ArgumentNode ToSyntaxNode() => RewriteArgument(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteArgument(this);
 }

--- a/src/HotChocolate/Skimmed/src/Skimmed/ComplexTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/ComplexTypeDefinition.cs
@@ -1,6 +1,8 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Utilities;
 using HotChocolate.Types;
+using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
 
 namespace HotChocolate.Skimmed;
 
@@ -125,4 +127,22 @@ public abstract class ComplexTypeDefinition(string name)
 
     /// <inheritdoc />
     public abstract bool Equals(ITypeDefinition? other, TypeComparison comparison);
+
+    /// <summary>
+    /// Creates a <see cref="ComplexTypeDefinitionNodeBase"/> from a
+    /// <see cref="ComplexTypeDefinition"/>.
+    /// </summary>
+    public ComplexTypeDefinitionNodeBase ToSyntaxNode() => this switch
+    {
+        InterfaceTypeDefinition i => RewriteInterfaceType(i),
+        ObjectTypeDefinition o => RewriteObjectType(o),
+        _ => throw new ArgumentOutOfRangeException()
+    };
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => this switch
+    {
+        InterfaceTypeDefinition i => RewriteInterfaceType(i),
+        ObjectTypeDefinition o => RewriteObjectType(o),
+        _ => throw new ArgumentOutOfRangeException()
+    };
 }

--- a/src/HotChocolate/Skimmed/src/Skimmed/Contracts/IFieldDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Contracts/IFieldDefinition.cs
@@ -11,6 +11,7 @@ public interface IFieldDefinition
     , IDeprecationProvider
     , IDirectivesProvider
     , IFeatureProvider
+    , ISyntaxNodeProvider
 {
     /// <summary>
     /// Gets or sets the name of the field.

--- a/src/HotChocolate/Skimmed/src/Skimmed/Contracts/INamedTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Contracts/INamedTypeDefinition.cs
@@ -11,6 +11,7 @@ public interface INamedTypeDefinition
     , IDescriptionProvider
     , IDirectivesProvider
     , IFeatureProvider
+    , ISyntaxNodeProvider
 {
     /// <summary>
     /// Gets or sets the name of the type.

--- a/src/HotChocolate/Skimmed/src/Skimmed/Contracts/ISyntaxNodeProvider.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Contracts/ISyntaxNodeProvider.cs
@@ -1,0 +1,14 @@
+using HotChocolate.Language;
+
+namespace HotChocolate.Skimmed;
+
+/// <summary>
+/// A type system member that can be converted to an <see cref="ISyntaxNode"/>.
+/// </summary>
+public interface ISyntaxNodeProvider : ITypeSystemMemberDefinition
+{
+    /// <summary>
+    /// Creates an <see cref="ISyntaxNode"/> from an <see cref="ITypeSystemMemberDefinition"/>.
+    /// </summary>
+    ISyntaxNode ToSyntaxNode();
+}

--- a/src/HotChocolate/Skimmed/src/Skimmed/DirectiveDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/DirectiveDefinition.cs
@@ -1,7 +1,8 @@
 using HotChocolate.Features;
-using HotChocolate.Types;
+using HotChocolate.Language;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
+using DirectiveLocation = HotChocolate.Types.DirectiveLocation;
 
 namespace HotChocolate.Skimmed;
 
@@ -13,6 +14,7 @@ public class DirectiveDefinition
     , IDescriptionProvider
     , IFeatureProvider
     , ISealable
+    , ISyntaxNodeProvider
 {
     private string _name;
     private IInputFieldDefinitionCollection? _arguments;
@@ -180,6 +182,13 @@ public class DirectiveDefinition
     /// </returns>
     public override string ToString()
         => RewriteDirectiveType(this).ToString(true);
+
+    /// <summary>
+    /// Creates a <see cref="DirectiveDefinitionNode"/> from a <see cref="DirectiveDefinition"/>.
+    /// </summary>
+    public DirectiveDefinitionNode ToSyntaxNode() => RewriteDirectiveType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteDirectiveType(this);
 
     /// <summary>
     /// Creates a new directive definition.

--- a/src/HotChocolate/Skimmed/src/Skimmed/EnumTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/EnumTypeDefinition.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
@@ -120,6 +121,13 @@ public class EnumTypeDefinition(string name)
     /// </returns>
     public override string ToString()
         => RewriteEnumType(this).ToString(true);
+
+    /// <summary>
+    /// Creates an <see cref="EnumTypeDefinitionNode"/> from an <see cref="EnumTypeDefinition"/>.
+    /// </summary>
+    public EnumTypeDefinitionNode ToSyntaxNode() => RewriteEnumType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteEnumType(this);
 
     /// <inheritdoc />
     public bool Equals(ITypeDefinition? other) => Equals(other, TypeComparison.Reference);

--- a/src/HotChocolate/Skimmed/src/Skimmed/EnumValue.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/EnumValue.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
 
@@ -14,6 +15,7 @@ public sealed class EnumValue(string name)
     , IDescriptionProvider
     , IDeprecationProvider
     , ISealable
+    , ISyntaxNodeProvider
 {
     private string _name = name.EnsureGraphQLName();
     private string? _description;
@@ -140,6 +142,13 @@ public sealed class EnumValue(string name)
     /// </returns>
     public override string ToString()
         => RewriteEnumValue(this).ToString(true);
+
+    /// <summary>
+    /// Creates an <see cref="EnumValueDefinitionNode"/> from an <see cref="EnumValue"/>.
+    /// </summary>
+    public EnumValueDefinitionNode ToSyntaxNode() => RewriteEnumValue(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteEnumValue(this);
 
     /// <summary>
     /// Creates a new enum value.

--- a/src/HotChocolate/Skimmed/src/Skimmed/InputFieldDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/InputFieldDefinition.cs
@@ -182,6 +182,14 @@ public sealed class InputFieldDefinition(string name, ITypeDefinition? type = nu
         => RewriteInputField(this).ToString(true);
 
     /// <summary>
+    /// Creates an <see cref="InputValueDefinitionNode"/> from an
+    /// <see cref="InputFieldDefinition"/>.
+    /// </summary>
+    public InputValueDefinitionNode ToSyntaxNode() => RewriteInputField(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteInputField(this);
+
+    /// <summary>
     /// Creates a new instance of <see cref="InputFieldDefinition"/>.
     /// </summary>
     /// <param name="name">

--- a/src/HotChocolate/Skimmed/src/Skimmed/InputObjectTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/InputObjectTypeDefinition.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
@@ -136,6 +137,14 @@ public class InputObjectTypeDefinition(string name)
     /// </returns>
     public override string ToString()
         => RewriteInputObjectType(this).ToString(true);
+
+    /// <summary>
+    /// Creates an <see cref="InputObjectTypeDefinitionNode"/> from an
+    /// <see cref="InputObjectTypeDefinition"/>.
+    /// </summary>
+    public InputObjectTypeDefinitionNode ToSyntaxNode() => RewriteInputObjectType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteInputObjectType(this);
 
     /// <summary>
     /// Creates a new input object type definition.

--- a/src/HotChocolate/Skimmed/src/Skimmed/MissingTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/MissingTypeDefinition.cs
@@ -1,6 +1,8 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
+using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
 
 namespace HotChocolate.Skimmed;
 
@@ -57,4 +59,11 @@ public sealed class MissingTypeDefinition(string name)
         return other is MissingTypeDefinition otherMissing
             && otherMissing.Name.Equals(Name, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Creates a <see cref="NamedTypeNode"/> from a <see cref="MissingTypeDefinition"/>.
+    /// </summary>
+    public NamedTypeNode ToSyntaxNode() => RewriteMissingType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteMissingType(this);
 }

--- a/src/HotChocolate/Skimmed/src/Skimmed/OutputFieldDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/OutputFieldDefinition.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
 
@@ -175,6 +176,13 @@ public sealed class OutputFieldDefinition(string name, ITypeDefinition? type = n
     /// </returns>
     public override string ToString()
         => RewriteOutputField(this).ToString(true);
+
+    /// <summary>
+    /// Creates a <see cref="FieldDefinitionNode"/> from an <see cref="OutputFieldDefinition"/>.
+    /// </summary>
+    public FieldDefinitionNode ToSyntaxNode() => RewriteOutputField(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteOutputField(this);
 
     /// <summary>
     /// Creates a new output field definition.

--- a/src/HotChocolate/Skimmed/src/Skimmed/ScalarTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/ScalarTypeDefinition.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
@@ -115,6 +116,13 @@ public class ScalarTypeDefinition(string name)
     /// </returns>
     public override string ToString()
         => RewriteScalarType(this).ToString(true);
+
+    /// <summary>
+    /// Creates a <see cref="ScalarTypeDefinitionNode"/> from a <see cref="ScalarTypeDefinition"/>.
+    /// </summary>
+    public ScalarTypeDefinitionNode ToSyntaxNode() => RewriteScalarType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteScalarType(this);
 
     /// <inheritdoc />
     public bool Equals(ITypeDefinition? other)

--- a/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaDebugFormatter.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/Serialization/SchemaDebugFormatter.cs
@@ -117,8 +117,11 @@ internal static class SchemaDebugFormatter
     public static ArgumentNode RewriteArgument(ArgumentAssignment argument)
         => new ArgumentNode(null, new NameNode(argument.Name), argument.Value);
 
+    public static NamedTypeNode RewriteMissingType(MissingTypeDefinition type)
+        => new NamedTypeNode(type.Name);
+
     private static NameNode RewriteDirectiveLocation(Types.DirectiveLocation location)
-        => new NameNode(location.ToString());
+        => new NameNode(location.Format().ToString());
 
     public static ITypeNode RewriteTypeRef(ITypeDefinition type)
     {

--- a/src/HotChocolate/Skimmed/src/Skimmed/UnionTypeDefinition.cs
+++ b/src/HotChocolate/Skimmed/src/Skimmed/UnionTypeDefinition.cs
@@ -1,4 +1,5 @@
 using HotChocolate.Features;
+using HotChocolate.Language;
 using HotChocolate.Types;
 using HotChocolate.Utilities;
 using static HotChocolate.Skimmed.Serialization.SchemaDebugFormatter;
@@ -107,6 +108,13 @@ public class UnionTypeDefinition(string name)
     /// </returns>
     public override string ToString()
         => RewriteUnionType(this).ToString(true);
+
+    /// <summary>
+    /// Creates a <see cref="UnionTypeDefinitionNode"/> from a <see cref="UnionTypeDefinition"/>.
+    /// </summary>
+    public UnionTypeDefinitionNode ToSyntaxNode() => RewriteUnionType(this);
+
+    ISyntaxNode ISyntaxNodeProvider.ToSyntaxNode() => RewriteUnionType(this);
 
     /// <inheritdoc />
     public bool Equals(ITypeDefinition? other)

--- a/src/HotChocolate/Skimmed/test/Skimmed.Tests/ToSyntaxNodeTests.cs
+++ b/src/HotChocolate/Skimmed/test/Skimmed.Tests/ToSyntaxNodeTests.cs
@@ -1,0 +1,244 @@
+using System.Text;
+using HotChocolate.Language;
+using HotChocolate.Skimmed.Serialization;
+
+namespace HotChocolate.Skimmed;
+
+public class ToSyntaxNodeTests
+{
+    [Fact]
+    public void ObjectType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            type Foo @example {
+                field(argument: Int @example): String @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((ObjectTypeDefinition)schema.Types["Foo"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<ObjectTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            type Foo @example {
+                field(argument: Int @example): String @example
+            }
+            """);
+    }
+
+    [Fact]
+    public void InterfaceType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            interface Foo @example {
+                field(argument: Int @example): String @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((InterfaceTypeDefinition)schema.Types["Foo"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<InterfaceTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            interface Foo @example {
+                field(argument: Int @example): String @example
+            }
+            """);
+    }
+
+    [Fact]
+    public void InputObjectType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            input Foo @example {
+                field: String @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((InputObjectTypeDefinition)schema.Types["Foo"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<InputObjectTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            input Foo @example {
+                field: String @example
+            }
+            """);
+    }
+
+    [Fact]
+    public void ScalarType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl = "scalar String @example";
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((ScalarTypeDefinition)schema.Types["String"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<ScalarTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("scalar String @example");
+    }
+
+    [Fact]
+    public void UnionType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            union Example @example = A | B
+
+            type A { }
+            type B { }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((UnionTypeDefinition)schema.Types["Example"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<UnionTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("union Example @example = A | B");
+    }
+
+    [Fact]
+    public void EnumType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            enum Example @example {
+                A @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((EnumTypeDefinition)schema.Types["Example"]).ToSyntaxNode();
+
+        // assert
+        Assert.IsType<EnumTypeDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot(
+            """
+            enum Example @example {
+                A @example
+            }
+            """);
+    }
+
+    [Fact]
+    public void EnumValue_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            enum Example {
+                A @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((EnumTypeDefinition)schema.Types["Example"]).Values["A"].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<EnumValueDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("A @example");
+    }
+
+    [Fact]
+    public void DirectiveType_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl = "directive @example(argument: Int) on FIELD";
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = schema.DirectiveDefinitions["example"].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<DirectiveDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("directive @example(argument: Int) on FIELD");
+    }
+
+    [Fact]
+    public void ArgumentAssignment_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            type Foo {
+                field: String @example(argument: 123)
+            }
+
+            directive @example(argument: Int) on FIELD
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode =
+            ((ObjectTypeDefinition)schema.Types["Foo"])
+            .Fields["field"].Directives["example"].First().Arguments[0].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<ArgumentNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("argument: 123");
+    }
+
+    [Fact]
+    public void OutputField_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            type Foo {
+                field(argument: Int @example): String @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode = ((ObjectTypeDefinition)schema.Types["Foo"]).Fields["field"].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<FieldDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("field(argument: Int @example): String @example");
+    }
+
+    [Fact]
+    public void InputField_ToSyntaxNode()
+    {
+        // arrange
+        const string sdl =
+            """
+            input Foo {
+                field: String @example
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var syntaxNode =
+            ((InputObjectTypeDefinition)schema.Types["Foo"]).Fields["field"].ToSyntaxNode();
+
+        // assert
+        Assert.IsType<InputValueDefinitionNode>(syntaxNode);
+        syntaxNode.ToString().MatchInlineSnapshot("field: String @example");
+    }
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added `ISyntaxNodeProvider` to Skimmed type system member definitions.

---

Notes:

- I decided to add this to most (if not all) type system members, instead of creating an issue for the rest.
- I added `RewriteMissingType` to `SchemaDebugFormatter`, because `MissingTypeDefinition` implements `INamedTypeDefinition` which implements `ISyntaxNodeProvider`, so it also needed an implementation of `ToSyntaxNode`.
- I updated `RewriteDirectiveLocation` to format the location, otherwise it's printed in PascalCase.
