### PR TITLE
Allow missing input fields to be ignored

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/InputParser.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputParser.cs
@@ -14,6 +14,7 @@ public sealed class InputParser
     private readonly ITypeConverter _converter;
     private readonly DictionaryToObjectConverter _dictToObjConverter;
     private readonly bool _ignoreAdditionalInputFields;
+    private readonly bool _ignoreMissingInputFields;
 
     public InputParser() : this(new DefaultTypeConverter()) { }
 
@@ -22,6 +23,7 @@ public sealed class InputParser
         _converter = converter ?? throw new ArgumentNullException(nameof(converter));
         _dictToObjConverter = new DictionaryToObjectConverter(converter);
         _ignoreAdditionalInputFields = false;
+        _ignoreMissingInputFields = false;
     }
 
     public InputParser(ITypeConverter converter, InputParserOptions options)
@@ -29,6 +31,7 @@ public sealed class InputParser
         _converter = converter ?? throw new ArgumentNullException(nameof(converter));
         _dictToObjConverter = new DictionaryToObjectConverter(converter);
         _ignoreAdditionalInputFields = options.IgnoreAdditionalInputFields;
+        _ignoreMissingInputFields = options.IgnoreMissingInputFields;
     }
 
     public object? ParseLiteral(IValueNode value, IInputFieldInfo field, Type? targetType = null)
@@ -282,7 +285,7 @@ public sealed class InputParser
                     throw InvalidInputFieldNames(type, invalidFieldNames, path);
                 }
 
-                if (processedCount < type.Fields.Count)
+                if (!_ignoreMissingInputFields && processedCount < type.Fields.Count)
                 {
                     for (var i = 0; i < type.Fields.Count; i++)
                     {

--- a/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
@@ -15,7 +15,7 @@ public sealed class InputParserOptions
     public bool IgnoreAdditionalInputFields { get; set; }
 
     /// <summary>
-    /// Specifies if missing input object fields should be ignored and populated with default values.
+    /// Specifies if missing input object fields should be ignored and not populated with default values.
     /// The default is <c>false</c>.
     /// </summary>
     public bool IgnoreMissingInputFields { get; set; }

--- a/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
@@ -15,7 +15,7 @@ public sealed class InputParserOptions
     public bool IgnoreAdditionalInputFields { get; set; }
 
     /// <summary>
-    /// Specifies if missing input object fields should be populated with default values.
+    /// Specifies if missing input object fields should be ignored and populated with default values.
     /// The default is <c>false</c>.
     /// </summary>
     public bool IgnoreMissingInputFields { get; set; }

--- a/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
+++ b/src/HotChocolate/Core/src/Types/Types/InputParserOptions.cs
@@ -13,4 +13,10 @@ public sealed class InputParserOptions
     /// The default is <c>false</c>.
     /// </summary>
     public bool IgnoreAdditionalInputFields { get; set; }
+
+    /// <summary>
+    /// Specifies if missing input object fields should be populated with default values.
+    /// The default is <c>false</c>.
+    /// </summary>
+    public bool IgnoreMissingInputFields { get; set; }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/InputParserTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/InputParserTests.cs
@@ -1,3 +1,4 @@
+using HotChocolate;
 using HotChocolate.Execution;
 using HotChocolate.Language;
 using HotChocolate.Tests;
@@ -493,6 +494,34 @@ public class InputParserTests
 
         // assert
         Assert.IsType<Test4Input>(runtimeValue).MatchSnapshot();
+    }
+
+    [Fact]
+    public void Parse_InputObject_IgnoreMissingInputFields()
+    {
+        // arrange
+        var schema = SchemaBuilder.New()
+            .AddInputObjectType<Test3Input>()
+            .ModifyOptions(o => o.StrictValidation = false)
+            .Create();
+        var fieldData = new ObjectValueNode(
+            new ObjectFieldNode("field2", 123));
+
+        // act
+        var converter = new DefaultTypeConverter();
+
+        var options = new InputParserOptions
+        {
+            IgnoreMissingInputFields = true,
+        };
+
+        var parser = new InputParser(converter, options);
+        // TODO how do we test this?
+        var obj = parser.ParseLiteral(fieldData, null!, typeof(IReadOnlyDictionary<string, object?>));
+
+        // assert
+        var dict = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(obj);
+        Assert.DoesNotContain("field1", dict.Keys);
     }
 
     public class TestInput


### PR DESCRIPTION
Added an option to the `InputParser` so that it ignores missing values of an input type.

Closes #7948
