### PR TITLE
[Fusion] Updated MergeUnionTypes to allow empty merged union type

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -560,13 +560,7 @@ internal sealed class SourceSchemaMerger
             .Where(i => !i.MemberType.HasInternalDirective())
             .GroupBy(i => i.MemberType.Name)
             // Intersection: Member type definition count matches union type definition count.
-            .Where(g => g.Count() == typeGroup.Length)
-            .ToImmutableArray();
-
-        if (unionMemberGroupByName.Length == 0)
-        {
-            return null;
-        }
+            .Where(g => g.Count() == typeGroup.Length);
 
         var unionType = new UnionTypeDefinition(name) { Description = description };
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
@@ -143,10 +143,9 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                 """
             },
             // Each union's possible types are considered in turn. Only those that are not marked
-            // @internal are included in the final composed union. This preserves the valid types
-            // from all sources while systematically filtering out anything intended for internal
-            // use only. In case there are no possible types left after filtering, the merged union
-            // is considered @internal and cannot appear in the final schema.
+            // @internal or @inaccessible are included in the final composed union. This preserves
+            // the valid types from all sources while systematically filtering out anything
+            // inaccessible or intended for internal use only.
             {
                 [
                     """
@@ -162,7 +161,11 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                     type User @internal { id: ID! }
                     """
                 ],
-                ""
+                """
+                union SearchResult
+                    @fusion__type(schema: A)
+                    @fusion__type(schema: B) =
+                """
             },
             // Union member type "User" internal in one of two schemas. No remaining member types.
             {
@@ -186,6 +189,10 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                     id: ID!
                         @fusion__field(schema: A)
                 }
+
+                union SearchResult
+                    @fusion__type(schema: A)
+                    @fusion__type(schema: B) =
                 """
             },
             // Union member type "Order" internal in one of two schemas, "Product" visible in both.


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Updated `MergeUnionTypes` to allow empty merged union type.