### PR TITLE
[Fusion] Changed the return type of MergeUnionTypes to non-nullable

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -539,7 +539,7 @@ internal sealed class SourceSchemaMerger
     /// <seealso href="https://graphql.github.io/composite-schemas-spec/draft/#sec-Merge-Union-Types">
     /// Specification
     /// </seealso>
-    private UnionTypeDefinition? MergeUnionTypes(
+    private UnionTypeDefinition MergeUnionTypes(
         ImmutableArray<TypeInfo> typeGroup,
         SchemaDefinition mergedSchema)
     {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Changed the return type of `MergeUnionTypes` to non-nullable.