### PR TITLE
[Fusion] Updated SetOperationTypes to remove empty operation types

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -676,14 +676,30 @@ internal sealed class SourceSchemaMerger
             mergedSchema.QueryType = (ObjectTypeDefinition?)queryType;
         }
 
-        if (mergedSchema.Types.TryGetType(TypeNames.Mutation, out var mutationType))
+        if (mergedSchema.Types.TryGetType(TypeNames.Mutation, out var mutationType)
+            && mutationType is ObjectTypeDefinition mutationObjectType)
         {
-            mergedSchema.MutationType = (ObjectTypeDefinition?)mutationType;
+            if (mutationObjectType.Fields.Count == 0)
+            {
+                mergedSchema.Types.Remove(mutationObjectType);
+            }
+            else
+            {
+                mergedSchema.MutationType = mutationObjectType;
+            }
         }
 
-        if (mergedSchema.Types.TryGetType(TypeNames.Subscription, out var subscriptionType))
+        if (mergedSchema.Types.TryGetType(TypeNames.Subscription, out var subscriptionType)
+            && subscriptionType is ObjectTypeDefinition subscriptionObjectType)
         {
-            mergedSchema.SubscriptionType = (ObjectTypeDefinition?)subscriptionType;
+            if (subscriptionObjectType.Fields.Count == 0)
+            {
+                mergedSchema.Types.Remove(subscriptionObjectType);
+            }
+            else
+            {
+                mergedSchema.SubscriptionType = subscriptionObjectType;
+            }
         }
     }
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMergerTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMergerTests.cs
@@ -18,7 +18,38 @@ public sealed class SourceSchemaMergerTests
             {
                 Types =
                 {
-                    new ObjectTypeDefinition(Query),
+                    new ObjectTypeDefinition(Query)
+                        { Fields = { new OutputFieldDefinition("field") } },
+                    new ObjectTypeDefinition(Mutation)
+                        { Fields = { new OutputFieldDefinition("field") } },
+                    new ObjectTypeDefinition(Subscription)
+                        { Fields = { new OutputFieldDefinition("field") } }
+                }
+            }
+        ]);
+
+        // act
+        var (isSuccess, _, mergedSchema, _) = merger.Merge();
+
+        // assert
+        Assert.True(isSuccess);
+        Assert.NotNull(mergedSchema.QueryType);
+        Assert.NotNull(mergedSchema.MutationType);
+        Assert.NotNull(mergedSchema.SubscriptionType);
+    }
+
+    [Fact]
+    public void Merge_WithEmptyMutationAndSubscriptionType_RemovesEmptyOperationTypes()
+    {
+        // arrange
+        var merger = new SourceSchemaMerger(
+        [
+            new SchemaDefinition
+            {
+                Types =
+                {
+                    new ObjectTypeDefinition(Query)
+                        { Fields = { new OutputFieldDefinition("field") } },
                     new ObjectTypeDefinition(Mutation),
                     new ObjectTypeDefinition(Subscription)
                 }
@@ -26,13 +57,15 @@ public sealed class SourceSchemaMergerTests
         ]);
 
         // act
-        var result = merger.Merge();
+        var (isSuccess, _, mergedSchema, _) = merger.Merge();
 
         // assert
-        Assert.True(result.IsSuccess);
-        Assert.NotNull(result.Value.QueryType);
-        Assert.NotNull(result.Value.MutationType);
-        Assert.NotNull(result.Value.SubscriptionType);
+        Assert.True(isSuccess);
+        Assert.NotNull(mergedSchema.QueryType);
+        Assert.False(mergedSchema.Types.ContainsName(Mutation));
+        Assert.Null(mergedSchema.MutationType);
+        Assert.False(mergedSchema.Types.ContainsName(Subscription));
+        Assert.Null(mergedSchema.SubscriptionType);
     }
 
     [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Updated `SetOperationTypes` to remove empty operation types.