### PR TITLE
[Fusion] Fail Query Plan generation early

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Planning/Pipeline/ExecutionStepDiscoveryMiddleware.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/Pipeline/ExecutionStepDiscoveryMiddleware.cs
@@ -797,9 +797,9 @@ internal sealed class ExecutionStepDiscoveryMiddleware(
 
         while (current is not null)
         {
-            var typeMetadata = _config.GetType<ObjectTypeMetadata>(path.Selection.DeclaringType.Name);
+            var typeMetadata = _config.GetType<ObjectTypeMetadata>(current.Selection.DeclaringType.Name);
 
-            if (!typeMetadata.Fields[path.Selection.Field.Name].Bindings.ContainsSubgraph(subgraphName))
+            if (!typeMetadata.Fields[current.Selection.Field.Name].Bindings.ContainsSubgraph(subgraphName))
             {
                 return false;
             }

--- a/src/HotChocolate/Fusion/src/Core/Planning/Steps/SelectionExecutionStep.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/Steps/SelectionExecutionStep.cs
@@ -22,7 +22,7 @@ internal sealed class SelectionExecutionStep : ExecutionStep
     /// <param name="subgraphName">
     /// The name of the subgraph from which this execution step will fetch data.
     /// </param>
-    /// <param name="selectionSet">
+    /// <param name="selectionSetType">
     /// The selection set that is part of this execution step.
     /// </param>
     /// <param name="selectionSetTypeMetadata">
@@ -31,9 +31,9 @@ internal sealed class SelectionExecutionStep : ExecutionStep
     public SelectionExecutionStep(
         int id,
         string subgraphName,
-        IObjectType selectionSet,
+        IObjectType selectionSetType,
         ObjectTypeMetadata selectionSetTypeMetadata)
-        : this(id, subgraphName, null, null, selectionSet, selectionSetTypeMetadata)
+        : this(id, subgraphName, null, null, selectionSetType, selectionSetTypeMetadata)
     {
     }
 
@@ -52,7 +52,7 @@ internal sealed class SelectionExecutionStep : ExecutionStep
     /// <param name="parentSelectionPath">
     /// The selection path from which this execution step was spawned.
     /// </param>
-    /// <param name="selectionSet">
+    /// <param name="selectionSetType">
     /// The selection set that is part of this execution step.
     /// </param>
     /// <param name="selectionSetTypeMetadata">
@@ -63,9 +63,9 @@ internal sealed class SelectionExecutionStep : ExecutionStep
         string subgraphName,
         ISelection? parentSelection,
         SelectionPath? parentSelectionPath,
-        IObjectType selectionSet,
+        IObjectType selectionSetType,
         ObjectTypeMetadata selectionSetTypeMetadata)
-        : base(id, parentSelection, selectionSet, selectionSetTypeMetadata)
+        : base(id, parentSelection, selectionSetType, selectionSetTypeMetadata)
     {
         SubgraphName = subgraphName;
         ParentSelectionPath = parentSelectionPath;

--- a/src/HotChocolate/Fusion/src/Core/Planning/Steps/SelectionPath.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/Steps/SelectionPath.cs
@@ -35,8 +35,8 @@ internal sealed class SelectionPath
 
         while (current is not null)
         {
-            sb.Append('/');
-            sb.Append(Selection.ResponseName);
+            sb.Insert(0, '/');
+            sb.Insert(1, current.Selection.ResponseName);
             current = current.Parent;
         }
 


### PR DESCRIPTION
There was a bug in the `EnsureStepCanBeResolvedFromRoot` safe-guard which only checked the first part of the path, which would lead to either invalid query plans that would fail at runtime or an error further down the line in the query plan generation which obscures the reason for the failure.