### PR TITLE
Fixed: Preserve ordering when executing batched paging queries.

### DIFF
--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/IntegrationTests.cs
@@ -211,6 +211,34 @@ public sealed class IntegrationTests(PostgreSqlResource resource)
         MatchSnapshot(result, interceptor);
     }
 
+    [Fact]
+    public async Task Query_Products_First_2_And_Brand()
+    {
+        // arrange
+        using var interceptor = new TestQueryInterceptor();
+
+        // act
+        var result = await ExecuteAsync(
+            """
+            {
+                products(first: 2) {
+                    nodes {
+                        name
+                        brand {
+                            name
+                        }
+                    }
+                }
+            }
+
+            """,
+            interceptor);
+
+        // assert
+        MatchSnapshot(result, interceptor);
+    }
+
+
     private static ServiceProvider CreateServer(string connectionString)
     {
         var services = new ServiceCollection();

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Brands/BrandQueries.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Brands/BrandQueries.cs
@@ -5,7 +5,7 @@ using HotChocolate.Types;
 using HotChocolate.Types.Pagination;
 using HotChocolate.Types.Relay;
 
-namespace HotChocolate.Data.Types;
+namespace HotChocolate.Data.Types.Brands;
 
 [QueryType]
 public static class BrandQueries
@@ -20,7 +20,7 @@ public static class BrandQueries
         => await brandService.GetBrandsAsync(pagingArgs, query, cancellationToken).ToConnectionAsync();
 
     [NodeResolver]
-    public static async Task<Brand?> GetBrandAsync(
+    public static async Task<Brand?> GetBrandByIdAsync(
         int id,
         QueryContext<Brand> query,
         BrandService brandService,

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Brands/BrandSortInputType.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Brands/BrandSortInputType.cs
@@ -1,7 +1,7 @@
 using HotChocolate.Data.Models;
 using HotChocolate.Data.Sorting;
 
-namespace HotChocolate.Data.Types;
+namespace HotChocolate.Data.Types.Brands;
 
 public sealed class BrandSortInputType : SortInputType<Brand>
 {

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductNode.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductNode.cs
@@ -1,18 +1,21 @@
 using GreenDonut.Data;
 using HotChocolate.Data.Models;
 using HotChocolate.Data.Services;
+using HotChocolate.Execution.Processing;
 using HotChocolate.Types;
 using HotChocolate.Types.Relay;
 
-namespace HotChocolate.Data.Types;
+namespace HotChocolate.Data.Types.Products;
 
 [ObjectType<Product>]
 public static partial class ProductNode
 {
+    // [BindMember(nameof(Product.Brand))]
     public static async Task<Brand?> GetBrandAsync(
-        [Parent(requires: nameof(Product.BrandId))]  Product product,
-        BrandService brandService,
+        [Parent(requires: nameof(Product.BrandId))] Product product,
         QueryContext<Brand> query,
+        ISelection selection,
+        BrandService brandService,
         CancellationToken cancellationToken)
         => await brandService.GetBrandByIdAsync(product.BrandId, query, cancellationToken);
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductQueries.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductQueries.cs
@@ -4,19 +4,19 @@ using HotChocolate.Data.Services;
 using HotChocolate.Types;
 using HotChocolate.Types.Pagination;
 
-namespace HotChocolate.Data.Types.Brands;
+namespace HotChocolate.Data.Types.Products;
 
-[ObjectType<Brand>]
-public static partial class BrandNode
+
+[QueryType]
+public static partial class ProductQueries
 {
     [UsePaging]
     [UseFiltering]
     [UseSorting]
-    public static Task<Connection<Product>> GetProductsAsync(
-        [Parent(requires: nameof(Brand.Id))] Brand brand,
+    public static async Task<Connection<Product>> GetProductsAsync(
         PagingArguments pagingArgs,
         QueryContext<Product> query,
         ProductService productService,
         CancellationToken cancellationToken)
-        => productService.GetProductsByBrandAsync(brand.Id, pagingArgs, query, cancellationToken).ToConnectionAsync();
+        => await productService.GetProductsAsync(pagingArgs, query, cancellationToken).ToConnectionAsync();
 }

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductSortInputType.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Types/Products/ProductSortInputType.cs
@@ -1,7 +1,7 @@
 using HotChocolate.Data.Models;
 using HotChocolate.Data.Sorting;
 
-namespace HotChocolate.Data.Types;
+namespace HotChocolate.Data.Types.Products;
 
 public sealed class ProductSortInputType : SortInputType<Product>
 {

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.CreateSchema.graphql
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.CreateSchema.graphql
@@ -90,8 +90,9 @@ type Query {
   node("ID of the object." id: ID!): Node @cost(weight: "10")
   "Lookup nodes by a list of IDs."
   nodes("The list of node IDs." ids: [ID!]!): [Node]! @cost(weight: "10")
+  products("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String where: ProductFilterInput @cost(weight: "10") order: [ProductSortInput!] @cost(weight: "10")): ProductsConnection @listSize(assumedSize: 50, slicingArguments: [ "first", "last" ], slicingArgumentDefaultValue: 10, sizedFields: [ "edges", "nodes" ], requireOneSlicingArgument: false) @cost(weight: "10")
   brands("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String where: BrandFilterInput @cost(weight: "10")): BrandsConnection @listSize(assumedSize: 50, slicingArguments: [ "first", "last" ], slicingArgumentDefaultValue: 10, sizedFields: [ "edges", "nodes" ], requireOneSlicingArgument: false) @cost(weight: "10")
-  brand(id: ID!): Brand @cost(weight: "10")
+  brandById(id: ID!): Brand @cost(weight: "10")
 }
 
 input BooleanOperationFilterInput {

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2.md
@@ -75,6 +75,6 @@ LEFT JOIN (
     ) AS p2
     WHERE p2.row <= 3
 ) AS p3 ON p1."BrandId" = p3."BrandId"
-ORDER BY p1."BrandId"
+ORDER BY p1."BrandId", p3."BrandId", p3."Id"
 ```
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc.md
@@ -13,8 +13,8 @@
           "products": {
             "nodes": [
               {
-                "id": "UHJvZHVjdDoxMg==",
-                "name": "Powder Pro Snowboard"
+                "id": "UHJvZHVjdDo0OA==",
+                "name": "Trailblazer 45L Backpack"
               },
               {
                 "id": "UHJvZHVjdDoyMw==",
@@ -69,12 +69,12 @@ FROM (
 LEFT JOIN (
     SELECT p2."Id", p2."Name", p2."BrandId"
     FROM (
-        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Id") AS row
+        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Name" DESC, p0."Id") AS row
         FROM "Products" AS p0
         WHERE p0."BrandId" = ANY (@__brandIds_0)
     ) AS p2
     WHERE p2.row <= 3
 ) AS p3 ON p1."BrandId" = p3."BrandId"
-ORDER BY p1."BrandId"
+ORDER BY p1."BrandId", p3."BrandId", p3."Name" DESC, p3."Id"
 ```
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc_Brand_Name.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc_Brand_Name.md
@@ -12,8 +12,8 @@
           "products": {
             "nodes": [
               {
-                "id": "UHJvZHVjdDoxMg==",
-                "name": "Powder Pro Snowboard",
+                "id": "UHJvZHVjdDo0OA==",
+                "name": "Trailblazer 45L Backpack",
                 "brand": {
                   "name": "Zephyr"
                 }
@@ -79,13 +79,13 @@ FROM (
 LEFT JOIN (
     SELECT p2."Id", p2."Name", p2."BrandId"
     FROM (
-        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Id") AS row
+        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Name" DESC, p0."Id") AS row
         FROM "Products" AS p0
         WHERE p0."BrandId" = ANY (@__brandIds_0)
     ) AS p2
     WHERE p2.row <= 3
 ) AS p3 ON p1."BrandId" = p3."BrandId"
-ORDER BY p1."BrandId"
+ORDER BY p1."BrandId", p3."BrandId", p3."Name" DESC, p3."Id"
 ```
 
 ## Query 3

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc_Brand_Name__net_8_0.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc_Brand_Name__net_8_0.md
@@ -12,8 +12,8 @@
           "products": {
             "nodes": [
               {
-                "id": "UHJvZHVjdDoxMg==",
-                "name": "Powder Pro Snowboard",
+                "id": "UHJvZHVjdDo0OA==",
+                "name": "Trailblazer 45L Backpack",
                 "brand": {
                   "name": "Zephyr"
                 }
@@ -79,13 +79,13 @@ FROM (
 LEFT JOIN (
     SELECT t1."Id", t1."Name", t1."BrandId"
     FROM (
-        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Id") AS row
+        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Name" DESC, p0."Id") AS row
         FROM "Products" AS p0
         WHERE p0."BrandId" = ANY (@__brandIds_0)
     ) AS t1
     WHERE t1.row <= 3
 ) AS t0 ON t."BrandId" = t0."BrandId"
-ORDER BY t."BrandId"
+ORDER BY t."BrandId", t0."BrandId", t0."Name" DESC, t0."Id"
 ```
 
 ## Query 3

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc__net_8_0.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2_Name_Desc__net_8_0.md
@@ -13,8 +13,8 @@
           "products": {
             "nodes": [
               {
-                "id": "UHJvZHVjdDoxMg==",
-                "name": "Powder Pro Snowboard"
+                "id": "UHJvZHVjdDo0OA==",
+                "name": "Trailblazer 45L Backpack"
               },
               {
                 "id": "UHJvZHVjdDoyMw==",
@@ -69,12 +69,12 @@ FROM (
 LEFT JOIN (
     SELECT t1."Id", t1."Name", t1."BrandId"
     FROM (
-        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Id") AS row
+        SELECT p0."Id", p0."Name", p0."BrandId", ROW_NUMBER() OVER(PARTITION BY p0."BrandId" ORDER BY p0."Name" DESC, p0."Id") AS row
         FROM "Products" AS p0
         WHERE p0."BrandId" = ANY (@__brandIds_0)
     ) AS t1
     WHERE t1.row <= 3
 ) AS t0 ON t."BrandId" = t0."BrandId"
-ORDER BY t."BrandId"
+ORDER BY t."BrandId", t0."BrandId", t0."Name" DESC, t0."Id"
 ```
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2__net_8_0.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Brands_First_2_And_Products_First_2__net_8_0.md
@@ -75,6 +75,6 @@ LEFT JOIN (
     ) AS t1
     WHERE t1.row <= 3
 ) AS t0 ON t."BrandId" = t0."BrandId"
-ORDER BY t."BrandId"
+ORDER BY t."BrandId", t0."BrandId", t0."Id"
 ```
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Products_First_2_And_Brand.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Products_First_2_And_Brand.md
@@ -1,0 +1,46 @@
+# Query_Products_First_2_And_Brand
+
+## Result
+
+```json
+{
+  "data": {
+    "products": {
+      "nodes": [
+        {
+          "name": "Zero Gravity Ski Goggles",
+          "brand": {
+            "name": "Gravitator"
+          }
+        },
+        {
+          "name": "Zenith Cycling Jersey",
+          "brand": {
+            "name": "B&R"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Query 1
+
+```sql
+-- @__p_0='3'
+SELECT p."Name", p."BrandId", p."Id"
+FROM "Products" AS p
+ORDER BY p."Name" DESC, p."Id"
+LIMIT @__p_0
+```
+
+## Query 2
+
+```sql
+-- @__ids_0={ '2', '5' } (DbType = Object)
+SELECT b."Id", b."Name"
+FROM "Brands" AS b
+WHERE b."Id" = ANY (@__ids_0)
+```
+

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Products_First_2_And_Brand__net_8_0.md
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.Query_Products_First_2_And_Brand__net_8_0.md
@@ -1,0 +1,46 @@
+# Query_Products_First_2_And_Brand
+
+## Result
+
+```json
+{
+  "data": {
+    "products": {
+      "nodes": [
+        {
+          "name": "Zero Gravity Ski Goggles",
+          "brand": {
+            "name": "Gravitator"
+          }
+        },
+        {
+          "name": "Zenith Cycling Jersey",
+          "brand": {
+            "name": "B&R"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Query 1
+
+```sql
+-- @__p_0='3'
+SELECT p."Name", p."BrandId", p."Id"
+FROM "Products" AS p
+ORDER BY p."Name" DESC, p."Id"
+LIMIT @__p_0
+```
+
+## Query 2
+
+```sql
+-- @__ids_0={ '2', '5' } (DbType = Object)
+SELECT b."Id", b."Name"
+FROM "Brands" AS b
+WHERE b."Id" = ANY (@__ids_0)
+```
+


### PR DESCRIPTION
When using paging DataLoader the ordering was dropped from the generated SQL query. EF core drops the ordering in case of GroupBy. We had an issue with the expression rewriter which stripped order from original query and moved it into the select after the groupBy.