### PR TITLE
[Fusion] Used `@fusion__inaccessible` in the execution schema

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Definitions/FusionInaccessibleDirectiveDefinition.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Definitions/FusionInaccessibleDirectiveDefinition.cs
@@ -4,9 +4,9 @@ using static HotChocolate.Fusion.WellKnownDirectiveNames;
 
 namespace HotChocolate.Fusion.Definitions;
 
-internal sealed class InaccessibleDirectiveDefinition : DirectiveDefinition
+internal sealed class FusionInaccessibleDirectiveDefinition : DirectiveDefinition
 {
-    public InaccessibleDirectiveDefinition() : base(Inaccessible)
+    public FusionInaccessibleDirectiveDefinition() : base(FusionInaccessible)
     {
         Locations =
             DirectiveLocation.ArgumentDefinition

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Extensions/DirectivesProviderExtensions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Extensions/DirectivesProviderExtensions.cs
@@ -37,6 +37,11 @@ internal static class DirectivesProviderExtensions
         return type.Directives.ContainsName(DirectiveNames.External);
     }
 
+    public static bool HasFusionInaccessibleDirective(this IDirectivesProvider type)
+    {
+        return type.Directives.ContainsName(DirectiveNames.FusionInaccessible);
+    }
+
     public static bool HasInaccessibleDirective(this IDirectivesProvider type)
     {
         return type.Directives.ContainsName(DirectiveNames.Inaccessible);

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedEnumTypeRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedEnumTypeRule.cs
@@ -17,12 +17,12 @@ internal sealed class EmptyMergedEnumTypeRule : IEventHandler<EnumTypeEvent>
     {
         var (enumType, schema) = @event;
 
-        if (enumType.HasInaccessibleDirective())
+        if (enumType.HasFusionInaccessibleDirective())
         {
             return;
         }
 
-        var accessibleValues = enumType.Values.Where(v => !v.HasInaccessibleDirective());
+        var accessibleValues = enumType.Values.Where(v => !v.HasFusionInaccessibleDirective());
 
         if (!accessibleValues.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedInputObjectTypeRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedInputObjectTypeRule.cs
@@ -21,12 +21,12 @@ internal sealed class EmptyMergedInputObjectTypeRule : IEventHandler<InputTypeEv
     {
         var (inputType, schema) = @event;
 
-        if (inputType.HasInaccessibleDirective())
+        if (inputType.HasFusionInaccessibleDirective())
         {
             return;
         }
 
-        var accessibleFields = inputType.Fields.Where(f => !f.HasInaccessibleDirective());
+        var accessibleFields = inputType.Fields.Where(f => !f.HasFusionInaccessibleDirective());
 
         if (!accessibleFields.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedInterfaceTypeRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedInterfaceTypeRule.cs
@@ -17,12 +17,12 @@ internal sealed class EmptyMergedInterfaceTypeRule : IEventHandler<InterfaceType
     {
         var (interfaceType, schema) = @event;
 
-        if (interfaceType.HasInaccessibleDirective())
+        if (interfaceType.HasFusionInaccessibleDirective())
         {
             return;
         }
 
-        var accessibleFields = interfaceType.Fields.Where(f => !f.HasInaccessibleDirective());
+        var accessibleFields = interfaceType.Fields.Where(f => !f.HasFusionInaccessibleDirective());
 
         if (!accessibleFields.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedObjectTypeRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedObjectTypeRule.cs
@@ -21,12 +21,12 @@ internal sealed class EmptyMergedObjectTypeRule : IEventHandler<ObjectTypeEvent>
     {
         var (objectType, schema) = @event;
 
-        if (schema.IsRootOperationType(objectType) || objectType.HasInaccessibleDirective())
+        if (schema.IsRootOperationType(objectType) || objectType.HasFusionInaccessibleDirective())
         {
             return;
         }
 
-        var accessibleFields = objectType.Fields.Where(f => !f.HasInaccessibleDirective());
+        var accessibleFields = objectType.Fields.Where(f => !f.HasFusionInaccessibleDirective());
 
         if (!accessibleFields.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedUnionTypeRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/EmptyMergedUnionTypeRule.cs
@@ -17,12 +17,12 @@ internal sealed class EmptyMergedUnionTypeRule : IEventHandler<UnionTypeEvent>
     {
         var (unionType, schema) = @event;
 
-        if (unionType.HasInaccessibleDirective())
+        if (unionType.HasFusionInaccessibleDirective())
         {
             return;
         }
 
-        var accessibleTypes = unionType.Types.Where(t => !t.HasInaccessibleDirective());
+        var accessibleTypes = unionType.Types.Where(t => !t.HasFusionInaccessibleDirective());
 
         if (!accessibleTypes.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/NoQueriesRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/NoQueriesRule.cs
@@ -30,7 +30,7 @@ internal sealed class NoQueriesRule : IEventHandler<ObjectTypeEvent>
             return;
         }
 
-        var accessibleFields = objectType.Fields.Where(f => !f.HasInaccessibleDirective());
+        var accessibleFields = objectType.Fields.Where(f => !f.HasFusionInaccessibleDirective());
 
         if (!accessibleFields.Any())
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -162,12 +162,13 @@ internal sealed class SourceSchemaMerger
         mergedArgument.Type = mergedArgument.Type.ReplaceNameType(
             _ => GetOrCreateType(mergedSchema, mergedArgument.Type));
 
+        AddFusionInputFieldDirectives(mergedArgument, argumentGroup);
+
         if (argumentGroup.Any(i => i.Argument.HasInaccessibleDirective()))
         {
-            mergedArgument.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            mergedArgument.Directives.Add(
+                new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionInputFieldDirectives(mergedArgument, argumentGroup);
 
         return mergedArgument;
     }
@@ -195,12 +196,12 @@ internal sealed class SourceSchemaMerger
 
         enumType.Description = description;
 
+        AddFusionTypeDirectives(enumType, typeGroup);
+
         if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
         {
-            enumType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            enumType.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionTypeDirectives(enumType, typeGroup);
 
         // [EnumValueName: [{EnumValue, EnumType, Schema}, ...], ...].
         var enumValueGroupByName = typeGroup
@@ -235,12 +236,12 @@ internal sealed class SourceSchemaMerger
 
         var enumValue = new EnumValue(valueName) { Description = description };
 
+        AddFusionEnumValueDirectives(enumValue, enumValueGroup);
+
         if (enumValueGroup.Any(i => i.EnumValue.HasInaccessibleDirective()))
         {
-            enumValue.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            enumValue.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionEnumValueDirectives(enumValue, enumValueGroup);
 
         return enumValue;
     }
@@ -269,12 +270,13 @@ internal sealed class SourceSchemaMerger
 
         inputObjectType.Description = description;
 
+        AddFusionTypeDirectives(inputObjectType, typeGroup);
+
         if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
         {
-            inputObjectType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            inputObjectType.Directives.Add(
+                new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionTypeDirectives(inputObjectType, typeGroup);
 
         // [FieldName: [{Field, Type, Schema}, ...], ...].
         var fieldGroupByName = typeGroup
@@ -326,12 +328,12 @@ internal sealed class SourceSchemaMerger
             Type = fieldType.ReplaceNameType(_ => GetOrCreateType(mergedSchema, fieldType))
         };
 
+        AddFusionInputFieldDirectives(inputField, inputFieldGroup);
+
         if (inputFieldGroup.Any(i => i.Field.HasInaccessibleDirective()))
         {
-            inputField.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            inputField.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionInputFieldDirectives(inputField, inputFieldGroup);
 
         return inputField;
     }
@@ -374,13 +376,14 @@ internal sealed class SourceSchemaMerger
                 GetOrCreateType<InterfaceTypeDefinition>(mergedSchema, interfaceName));
         }
 
-        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
-        {
-            interfaceType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
-        }
-
         AddFusionTypeDirectives(interfaceType, typeGroup);
         AddFusionImplementsDirectives(interfaceType, [.. interfaceGroupByName.SelectMany(g => g)]);
+
+        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
+        {
+            interfaceType.Directives.Add(
+                new Directive(new FusionInaccessibleDirectiveDefinition()));
+        }
 
         // [FieldName: [{Field, Type, Schema}, ...], ...].
         var fieldGroupByName = typeGroup
@@ -449,13 +452,13 @@ internal sealed class SourceSchemaMerger
                 GetOrCreateType<InterfaceTypeDefinition>(mergedSchema, interfaceName));
         }
 
-        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
-        {
-            objectType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
-        }
-
         AddFusionTypeDirectives(objectType, typeGroup);
         AddFusionImplementsDirectives(objectType, [.. interfaceGroupByName.SelectMany(g => g)]);
+
+        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
+        {
+            objectType.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
+        }
 
         // [FieldName: [{Field, Type, Schema}, ...], ...].
         var fieldGroupByName = typeGroup
@@ -536,13 +539,13 @@ internal sealed class SourceSchemaMerger
             }
         }
 
-        if (fieldGroup.Any(i => i.Field.HasInaccessibleDirective()))
-        {
-            outputField.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
-        }
-
         AddFusionFieldDirectives(outputField, fieldGroup);
         AddFusionRequiresDirectives(outputField, fieldGroup);
+
+        if (fieldGroup.Any(i => i.Field.HasInaccessibleDirective()))
+        {
+            outputField.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
+        }
 
         return outputField;
     }
@@ -571,12 +574,12 @@ internal sealed class SourceSchemaMerger
 
         scalarType.Description = description;
 
+        AddFusionTypeDirectives(scalarType, typeGroup);
+
         if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
         {
-            scalarType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
+            scalarType.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
-
-        AddFusionTypeDirectives(scalarType, typeGroup);
 
         return scalarType;
     }
@@ -604,11 +607,6 @@ internal sealed class SourceSchemaMerger
 
         unionType.Description = description;
 
-        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
-        {
-            unionType.Directives.Add(new Directive(new InaccessibleDirectiveDefinition()));
-        }
-
         AddFusionTypeDirectives(unionType, typeGroup);
 
         // [UnionMemberName: [{MemberType, UnionType, Schema}, ...], ...].
@@ -626,6 +624,11 @@ internal sealed class SourceSchemaMerger
             AddFusionUnionMemberDirectives(unionType, [.. memberGroup]);
 
             unionType.Types.Add(GetOrCreateType<ObjectTypeDefinition>(mergedSchema, memberName));
+        }
+
+        if (typeGroup.Any(i => i.Type.HasInaccessibleDirective()))
+        {
+            unionType.Directives.Add(new Directive(new FusionInaccessibleDirectiveDefinition()));
         }
 
         return unionType;

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/WellKnownDirectiveNames.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/WellKnownDirectiveNames.cs
@@ -6,6 +6,7 @@ internal static class WellKnownDirectiveNames
     public const string FusionEnumValue = "fusion__enumValue";
     public const string FusionField = "fusion__field";
     public const string FusionImplements = "fusion__implements";
+    public const string FusionInaccessible = "fusion__inaccessible";
     public const string FusionInputField = "fusion__inputField";
     public const string FusionLookup = "fusion__lookup";
     public const string FusionRequires = "fusion__requires";

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Argument.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Argument.Tests.cs
@@ -105,9 +105,9 @@ public sealed class SourceSchemaMergerArgumentTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B) {
                     field(limit: Int
-                        @inaccessible
                         @fusion__inputField(schema: A)
-                        @fusion__inputField(schema: B)): Int
+                        @fusion__inputField(schema: B)
+                        @fusion__inaccessible): Int
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)
                 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Enum.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Enum.Tests.cs
@@ -83,14 +83,14 @@ public sealed class SourceSchemaMergerEnumTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B) {
                     ACTIVE
-                        @inaccessible
                         @fusion__enumValue(schema: A)
+                        @fusion__inaccessible
                     INACTIVE
                         @fusion__enumValue(schema: A)
                         @fusion__enumValue(schema: B)
                     PENDING
-                        @inaccessible
                         @fusion__enumValue(schema: B)
+                        @fusion__inaccessible
                 }
                 """
             },
@@ -113,9 +113,9 @@ public sealed class SourceSchemaMergerEnumTests : CompositionTestBase
                 ],
                 """
                 enum Status
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     ACTIVE
                         @fusion__enumValue(schema: A)
                     INACTIVE

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.EnumValue.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.EnumValue.Tests.cs
@@ -50,8 +50,8 @@ public sealed class SourceSchemaMergerEnumValueTests : CompositionTestBase
                     ACTIVE
                         @fusion__enumValue(schema: A)
                     INACTIVE
-                        @inaccessible
                         @fusion__enumValue(schema: B)
+                        @fusion__inaccessible
                 }
                 """
             },

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputField.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputField.Tests.cs
@@ -81,9 +81,9 @@ public sealed class SourceSchemaMergerInputFieldTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B) {
                     minTotal: Int
-                        @inaccessible
                         @fusion__inputField(schema: A)
                         @fusion__inputField(schema: B)
+                        @fusion__inaccessible
                 }
                 """
             },

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputObject.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputObject.Tests.cs
@@ -111,9 +111,9 @@ public sealed class SourceSchemaMergerInputObjectTests : CompositionTestBase
                 ],
                 """
                 input OrderInput
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     id: ID!
                         @fusion__inputField(schema: A)
                         @fusion__inputField(schema: B)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Interface.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Interface.Tests.cs
@@ -114,9 +114,9 @@ public sealed class SourceSchemaMergerInterfaceTests : CompositionTestBase
                 ],
                 """
                 interface Product
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     id: ID!
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)
@@ -168,9 +168,9 @@ public sealed class SourceSchemaMergerInterfaceTests : CompositionTestBase
                 }
 
                 interface I2
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     id: ID!
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Object.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Object.Tests.cs
@@ -146,9 +146,9 @@ public sealed class SourceSchemaMergerObjectTests : CompositionTestBase
                 ],
                 """
                 type Product
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     id: ID!
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)
@@ -211,9 +211,9 @@ public sealed class SourceSchemaMergerObjectTests : CompositionTestBase
                 }
 
                 interface I2
-                    @inaccessible
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) {
+                    @fusion__type(schema: B)
+                    @fusion__inaccessible {
                     id: ID!
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.OutputField.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.OutputField.Tests.cs
@@ -109,9 +109,9 @@ public sealed class SourceSchemaMergerOutputFieldTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B) {
                     discountPercentage(percent: Int
-                        @inaccessible
                         @fusion__inputField(schema: A)
-                        @fusion__inputField(schema: B)): Int
+                        @fusion__inputField(schema: B)
+                        @fusion__inaccessible): Int
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)
                 }
@@ -222,9 +222,9 @@ public sealed class SourceSchemaMergerOutputFieldTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B) {
                     discountPercentage: Int
-                        @inaccessible
                         @fusion__field(schema: A)
                         @fusion__field(schema: B)
+                        @fusion__inaccessible
                 }
                 """
             },

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
@@ -62,9 +62,9 @@ public sealed class SourceSchemaMergerScalarTests : CompositionTestBase
                 ],
                 """
                 scalar Date
-                    @inaccessible
                     @fusion__type(schema: A)
                     @fusion__type(schema: B)
+                    @fusion__inaccessible
                 """
             },
             // The final description is determined by the first non-null description found in the

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
@@ -100,11 +100,11 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                 }
 
                 union SearchResult
-                    @inaccessible
                     @fusion__type(schema: A)
                     @fusion__type(schema: B)
                     @fusion__unionMember(schema: A, member: "User")
-                    @fusion__unionMember(schema: B, member: "User") = User
+                    @fusion__unionMember(schema: B, member: "User")
+                    @fusion__inaccessible = User
                 """
             },
             // The first non-empty description that is found is used as the description for the


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Used `@fusion__inaccessible` in the execution schema.