### PR TITLE
Combining the CompilationProvider is an anti-pattern, create an IncrementalValueProvider for the assembly name instead.

### DIFF
--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderGenerator.cs
@@ -11,7 +11,7 @@ public sealed class DataLoaderGenerator : ISyntaxGenerator
 {
     public void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         var dataLoaderDefaults = syntaxInfos.GetDataLoaderDefaults();

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderModuleGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/DataLoaderModuleGenerator.cs
@@ -10,7 +10,7 @@ public sealed class DataLoaderModuleGenerator : ISyntaxGenerator
 {
     public void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         var module = GetDataLoaderModuleInfo(syntaxInfos);

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/ISyntaxGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/ISyntaxGenerator.cs
@@ -8,6 +8,6 @@ public interface ISyntaxGenerator
 {
     void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos);
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/MiddlewareGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/MiddlewareGenerator.cs
@@ -12,7 +12,7 @@ public sealed class MiddlewareGenerator : ISyntaxGenerator
 
     public void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         if (syntaxInfos.IsEmpty)
@@ -20,7 +20,7 @@ public sealed class MiddlewareGenerator : ISyntaxGenerator
             return;
         }
 
-        var module = syntaxInfos.GetModuleInfo(compilation.AssemblyName, out _);
+        var module = syntaxInfos.GetModuleInfo(assemblyName, out _);
 
         // the generator is disabled.
         if(module.Options == ModuleOptions.Disabled)

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/TypeModuleSyntaxGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/TypeModuleSyntaxGenerator.cs
@@ -11,13 +11,13 @@ public sealed class TypeModuleSyntaxGenerator : ISyntaxGenerator
 {
     public void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
-        => Execute(context, compilation, syntaxInfos);
+        => Execute(context, assemblyName, syntaxInfos);
 
     private static void Execute(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         if (syntaxInfos.IsEmpty)
@@ -25,7 +25,7 @@ public sealed class TypeModuleSyntaxGenerator : ISyntaxGenerator
             return;
         }
 
-        var module = syntaxInfos.GetModuleInfo(compilation.AssemblyName, out var defaultModule);
+        var module = syntaxInfos.GetModuleInfo(assemblyName, out var defaultModule);
 
         // the generator is disabled.
         if (module.Options == ModuleOptions.Disabled)

--- a/src/HotChocolate/Core/src/Types.Analyzers/Generators/TypesSyntaxGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Generators/TypesSyntaxGenerator.cs
@@ -11,7 +11,7 @@ public sealed class TypesSyntaxGenerator : ISyntaxGenerator
 {
     public void Generate(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         if (syntaxInfos.IsEmpty)
@@ -19,7 +19,7 @@ public sealed class TypesSyntaxGenerator : ISyntaxGenerator
             return;
         }
 
-        var module = syntaxInfos.GetModuleInfo(compilation.AssemblyName, out _);
+        var module = syntaxInfos.GetModuleInfo(assemblyName, out _);
 
         // the generator is disabled.
         if(module.Options == ModuleOptions.Disabled)

--- a/src/HotChocolate/Core/src/Types.Analyzers/GraphQLServerGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/GraphQLServerGenerator.cs
@@ -89,8 +89,6 @@ public class GraphQLServerGenerator : IIncrementalGenerator
         string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
-        var dictionary = new Dictionary<string, SyntaxInfo>();
-
         foreach (var syntaxInfo in syntaxInfos.AsSpan())
         {
             if (syntaxInfo.Diagnostics.Length > 0)

--- a/src/HotChocolate/Core/src/Types.Analyzers/GraphQLServerGenerator.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/GraphQLServerGenerator.cs
@@ -58,7 +58,10 @@ public class GraphQLServerGenerator : IIncrementalGenerator
                 .WithComparer(SyntaxInfoComparer.Default)
                 .Collect();
 
-        var valueProvider = context.CompilationProvider.Combine(syntaxInfos);
+        var assemblyNameProvider = context.CompilationProvider
+            .Select(static (c, _) => c.AssemblyName!);
+
+        var valueProvider = assemblyNameProvider.Combine(syntaxInfos);
 
         context.RegisterSourceOutput(
             valueProvider,
@@ -83,7 +86,7 @@ public class GraphQLServerGenerator : IIncrementalGenerator
 
     private static void Execute(
         SourceProductionContext context,
-        Compilation compilation,
+        string assemblyName,
         ImmutableArray<SyntaxInfo> syntaxInfos)
     {
         var dictionary = new Dictionary<string, SyntaxInfo>();
@@ -101,7 +104,7 @@ public class GraphQLServerGenerator : IIncrementalGenerator
 
         foreach (var generator in _generators.AsSpan())
         {
-            generator.Generate(context, compilation, syntaxInfos);
+            generator.Generate(context, assemblyName, syntaxInfos);
         }
     }
 }


### PR DESCRIPTION
Combining the CompilationProvider is an anti-pattern, create an IncrementalValueProvider for the assembly name instead.

See https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md where combining the CompilationProvider is given as a sample how to not do it.

> Consider the following (incorrect) combine where the basic inputs are combined, then used to generate some source:
> 
> public void Initialize(IncrementalGeneratorInitializationContext context)
> {
>     var compilation = context.CompilationProvider;
>     var texts = context.AdditionalTextsProvider;
> 
>     // Don't do this!
>     var combined = texts.Combine(compilation);
> 
>     context.RegisterSourceOutput(combined, static (spc, pair) =>
>     {
>         var assemblyName = pair.Right.AssemblyName;
>         // produce source ...
>     });