### PR TITLE
Fix ignored invalid field when enum is present

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/VariableCoercionHelper.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/VariableCoercionHelper.cs
@@ -173,6 +173,7 @@ internal sealed class VariableCoercionHelper
             {
                 // if we do not find a field on the type we also skip this error and let
                 // the deserialization produce a proper error on this.
+                fields?.Add(current);
                 continue;
             }
 

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/VariableCoercionIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/VariableCoercionIntegrationTests.cs
@@ -151,13 +151,15 @@ public class VariableCoercionIntegrationTests
     }
 
     [Fact]
-    public async Task Invalid_Enum_Value_Provided()
+    public async Task Invalid_Field_Provided_When_Enum_Is_Present()
     {
         var executor = await CreateSchemaAsync();
 
         var user = new ObjectValueNode(
             new ObjectFieldNode("name", "Oliver"),
-            new ObjectFieldNode("gender", "FOO"));
+            new ObjectFieldNode("surname", "Smith"),
+            new ObjectFieldNode("gender", "MALE"),
+            new ObjectFieldNode("foo", "bar"));
 
         var request =
             OperationRequestBuilder
@@ -170,15 +172,13 @@ public class VariableCoercionIntegrationTests
     }
 
     [Fact]
-    public async Task Invalid_Field_Provided_When_Enum_Is_Present()
+    public async Task Invalid_Enum_Value_Provided()
     {
         var executor = await CreateSchemaAsync();
 
         var user = new ObjectValueNode(
             new ObjectFieldNode("name", "Oliver"),
-            new ObjectFieldNode("surname", "Smith"),
-            new ObjectFieldNode("gender", "MALE"),
-            new ObjectFieldNode("foo", "bar"));
+            new ObjectFieldNode("gender", "FOO"));
 
         var request =
             OperationRequestBuilder

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/VariableCoercionIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/VariableCoercionIntegrationTests.cs
@@ -14,7 +14,8 @@ public class VariableCoercionIntegrationTests
 
         var user = new ObjectValueNode(
             new ObjectFieldNode("name", "Oliver"),
-            new ObjectFieldNode("surname", "Smith"));
+            new ObjectFieldNode("surname", "Smith"),
+            new ObjectFieldNode("gender", "MALE"));
 
         var request =
             OperationRequestBuilder
@@ -51,7 +52,8 @@ public class VariableCoercionIntegrationTests
 
         var user = new ObjectValueNode(
             new ObjectFieldNode("name", NullValueNode.Default),
-            new ObjectFieldNode("surname", "Smith"));
+            new ObjectFieldNode("surname", "Smith"),
+            new ObjectFieldNode("gender", "MALE"));
 
         var request =
             OperationRequestBuilder
@@ -69,7 +71,8 @@ public class VariableCoercionIntegrationTests
         var executor = await CreateSchemaAsync();
 
         var user = new ObjectValueNode(
-            new ObjectFieldNode("surname", "Smith"));
+            new ObjectFieldNode("surname", "Smith"),
+            new ObjectFieldNode("gender", "MALE"));
 
         var request =
             OperationRequestBuilder
@@ -147,6 +150,46 @@ public class VariableCoercionIntegrationTests
         await executor.ExecuteAsync(request).MatchSnapshotAsync();
     }
 
+    [Fact]
+    public async Task Invalid_Enum_Value_Provided()
+    {
+        var executor = await CreateSchemaAsync();
+
+        var user = new ObjectValueNode(
+            new ObjectFieldNode("name", "Oliver"),
+            new ObjectFieldNode("gender", "FOO"));
+
+        var request =
+            OperationRequestBuilder
+                .New()
+                .SetDocument("mutation($user: UserInput!) { addUser(user: $user) }")
+                .SetVariableValues(new Dictionary<string, object?> { {"user", user }, })
+                .Build();
+
+        await executor.ExecuteAsync(request).MatchSnapshotAsync();
+    }
+
+    [Fact]
+    public async Task Invalid_Field_Provided_When_Enum_Is_Present()
+    {
+        var executor = await CreateSchemaAsync();
+
+        var user = new ObjectValueNode(
+            new ObjectFieldNode("name", "Oliver"),
+            new ObjectFieldNode("surname", "Smith"),
+            new ObjectFieldNode("gender", "MALE"),
+            new ObjectFieldNode("foo", "bar"));
+
+        var request =
+            OperationRequestBuilder
+                .New()
+                .SetDocument("mutation($user: UserInput!) { addUser(user: $user) }")
+                .SetVariableValues(new Dictionary<string, object?> { {"user", user }, })
+                .Build();
+
+        await executor.ExecuteAsync(request).MatchSnapshotAsync();
+    }
+
     private static async Task<IRequestExecutor> CreateSchemaAsync()
     {
         return await new ServiceCollection()
@@ -160,7 +203,7 @@ public class VariableCoercionIntegrationTests
     {
         public string AddUser(User user)
         {
-            return user.Name + " " + user.Surname + " was added!";
+            return $"{user.Name} {user.Surname} ({user.Gender}) was added!";
         }
     }
 
@@ -181,7 +224,11 @@ public class VariableCoercionIntegrationTests
         public string Name { get; set; } = name;
 
         public string? Surname { get; set; }
+
+        public GenderEnum? Gender { get; set; }
     }
+
+    public enum GenderEnum { Male, Female }
 
     public class UserInputType : InputObjectType<User>
     {

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Invalid_Enum_Value_Provided.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Invalid_Enum_Value_Provided.snap
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "message": "GenderEnum cannot parse the given literal of type `EnumValueNode`.",
+      "path": [
+        "user",
+        "gender"
+      ],
+      "extensions": {
+        "fieldCoordinate": "UserInput.gender",
+        "fieldType": "GenderEnum"
+      }
+    }
+  ]
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Invalid_Field_Provided_When_Enum_Is_Present.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Invalid_Field_Provided_When_Enum_Is_Present.snap
@@ -1,0 +1,13 @@
+{
+  "errors": [
+    {
+      "message": "The field `foo` does not exist on the type `UserInput`.",
+      "path": [
+        "user"
+      ],
+      "extensions": {
+        "type": "UserInput"
+      }
+    }
+  ]
+}

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_And_NonNullables_Are_Set.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_And_NonNullables_Are_Set.snap
@@ -1,5 +1,5 @@
-﻿{
+{
   "data": {
-    "addUser": "Oliver Smith was added!"
+    "addUser": "Oliver Smith (Male) was added!"
   }
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_Are_Not_Set_NonNullables_Are_Set.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_Are_Not_Set_NonNullables_Are_Set.snap
@@ -1,5 +1,5 @@
-﻿{
+{
   "data": {
-    "addUser": "Oliver  was added!"
+    "addUser": "Oliver  () was added!"
   }
 }

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_Are_Set_And_NonNullables_Are_Set_To_Null.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/Components/__snapshots__/VariableCoercionIntegrationTests.Nullables_Are_Set_And_NonNullables_Are_Set_To_Null.snap
@@ -1,4 +1,4 @@
-﻿{
+{
   "errors": [
     {
       "message": "Cannot accept null for non-nullable input.",


### PR DESCRIPTION
Fixes "Invalid fields in variable ignored when an enum is present"

- Extends `User`  in `VariableCoercionIntegrationTests` with an enum field and updates related fields.
- Adds an integration test to cover the case: `Invalid_Field_Provided_When_Enum_Is_Present`
- Adds an integration test to cover invalid enum value: `Invalid_Enum_Value_Provided`

Closes #8025
