### PR TITLE
[Fusion] Fix issue with conditions

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using HotChocolate.Execution.Processing;
 using HotChocolate.Fusion.Metadata;
+using HotChocolate.Fusion.Utilities;
 using HotChocolate.Language;
 using HotChocolate.Language.Visitors;
 using HotChocolate.Resolvers;
@@ -79,9 +80,11 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
             Array.Empty<DirectiveNode>(),
             rootSelectionSetNode);
 
-        return new RequestDocument(
-            new DocumentNode(new[] { operationDefinitionNode, }),
-            path);
+        var document = new DocumentNode([operationDefinitionNode]);
+        var rewriter = new SelectionRewriter();
+        document = rewriter.RewriteDocument(document, null);
+
+        return new RequestDocument(document, path);
     }
 
     private SelectionSetNode CreateRootLevelQuery(

--- a/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Planning/RequestFormatters/RequestDocumentFormatter.cs
@@ -258,7 +258,11 @@ internal abstract class RequestDocumentFormatter(FusionGraphConfiguration config
             ? new NameNode(selection.ResponseName)
             : null;
 
-        var hasDirectives = selection.SyntaxNodes.Any(node => node.Directives.Any());
+        // If the combined field node has directives, we need to print each
+        // field node part of the selection individually as to not end up
+        // in a situation where there are for example two `@skip` directives
+        // applied to the same node.
+        var hasDirectives = selection.SyntaxNode.Directives.Any();
 
         if (hasDirectives)
         {

--- a/src/HotChocolate/Fusion/src/Core/Utilities/SelectionRewriter.cs
+++ b/src/HotChocolate/Fusion/src/Core/Utilities/SelectionRewriter.cs
@@ -1,0 +1,169 @@
+using System.Collections.Immutable;
+using HotChocolate.Execution.Processing;
+using HotChocolate.Language;
+
+namespace HotChocolate.Fusion.Utilities;
+
+internal sealed class SelectionRewriter
+{
+    public DocumentNode RewriteDocument(DocumentNode document, string? operationName)
+    {
+        var operation = document.GetOperation(operationName);
+        var context = new Context();
+
+        RewriteFields(operation.SelectionSet, context);
+
+        var newSelectionSet = new SelectionSetNode(
+            null,
+            context.Selections.ToImmutable());
+
+        var newOperation = new OperationDefinitionNode(
+            null,
+            operation.Name,
+            operation.Operation,
+            operation.VariableDefinitions,
+            RewriteDirectives(operation.Directives),
+            newSelectionSet);
+
+        return new DocumentNode(ImmutableArray<IDefinitionNode>.Empty.Add(newOperation));
+    }
+
+    private void RewriteFields(SelectionSetNode selectionSet, Context context)
+    {
+        foreach (var selection in selectionSet.Selections)
+        {
+            switch (selection)
+            {
+                case FieldNode field:
+                    RewriteField(field, context);
+                    break;
+
+                case InlineFragmentNode inlineFragment:
+                    RewriteInlineFragment(inlineFragment, context);
+                    break;
+
+                case FragmentSpreadNode fragmentSpread:
+                    context.Selections.Add(fragmentSpread);
+                    break;
+            }
+        }
+    }
+
+    private void RewriteField(FieldNode fieldNode, Context context)
+    {
+        if (fieldNode.SelectionSet is null)
+        {
+            var node = fieldNode.WithLocation(null);
+
+            if (context.Visited.Add(node))
+            {
+                context.Selections.Add(node);
+            }
+        }
+        else
+        {
+            var fieldContext = new Context();
+
+            RewriteFields(fieldNode.SelectionSet, fieldContext);
+
+            var newSelectionSetNode = new SelectionSetNode(
+                null,
+                fieldContext.Selections.ToImmutable());
+
+            var newFieldNode = new FieldNode(
+                null,
+                fieldNode.Name,
+                fieldNode.Alias,
+                RewriteDirectives(fieldNode.Directives),
+                RewriteArguments(fieldNode.Arguments),
+                newSelectionSetNode);
+
+            if (context.Visited.Add(newFieldNode))
+            {
+                context.Selections.Add(newFieldNode);
+            }
+        }
+    }
+
+    private void RewriteInlineFragment(InlineFragmentNode inlineFragment, Context context)
+    {
+        if ((inlineFragment.TypeCondition is null ||
+                inlineFragment.TypeCondition.Name.Value.Equals(context.Type, StringComparison.Ordinal)) &&
+            inlineFragment.Directives.Count == 0)
+        {
+            RewriteFields(inlineFragment.SelectionSet, context);
+            return;
+        }
+
+        var inlineFragmentContext = new Context(inlineFragment.TypeCondition?.Name.Value);
+
+        RewriteFields(inlineFragment.SelectionSet, inlineFragmentContext);
+
+        var newSelectionSetNode = new SelectionSetNode(
+            null,
+            inlineFragmentContext.Selections.ToImmutable());
+
+        var newInlineFragment = new InlineFragmentNode(
+            null,
+            inlineFragment.TypeCondition,
+            RewriteDirectives(inlineFragment.Directives),
+            newSelectionSetNode);
+
+        context.Selections.Add(newInlineFragment);
+    }
+
+    private IReadOnlyList<DirectiveNode> RewriteDirectives(IReadOnlyList<DirectiveNode> directives)
+    {
+        if (directives.Count == 0)
+        {
+            return directives;
+        }
+
+        if (directives.Count == 1)
+        {
+            var directive = directives[0];
+            var newDirective = new DirectiveNode(directive.Name.Value, RewriteArguments(directive.Arguments));
+            return ImmutableArray<DirectiveNode>.Empty.Add(newDirective);
+        }
+
+        var buffer = new DirectiveNode[directives.Count];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            var directive = directives[i];
+            buffer[i] = new DirectiveNode(directive.Name.Value, RewriteArguments(directive.Arguments));
+        }
+
+        return ImmutableArray.Create(buffer);
+    }
+
+    private IReadOnlyList<ArgumentNode> RewriteArguments(IReadOnlyList<ArgumentNode> arguments)
+    {
+        if (arguments.Count == 0)
+        {
+            return arguments;
+        }
+
+        if (arguments.Count == 1)
+        {
+            return ImmutableArray<ArgumentNode>.Empty.Add(arguments[0].WithLocation(null));
+        }
+
+        var buffer = new ArgumentNode[arguments.Count];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = arguments[i].WithLocation(null);
+        }
+
+        return ImmutableArray.Create(buffer);
+    }
+
+    private class Context(string? typeName = null)
+    {
+        public string? Type => typeName;
+
+        public ImmutableArray<ISelectionNode>.Builder Selections { get; } =
+            ImmutableArray.CreateBuilder<ISelectionNode>();
+
+        public HashSet<ISelectionNode> Visited { get; } = new(SyntaxComparer.BySyntax);
+    }
+}

--- a/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/SkipTests.cs
@@ -2678,4 +2678,192 @@ public class SkipTests(ITestOutputHelper output)
         MatchMarkdownSnapshot(request, result);
     }
     #endregion
+
+    [Fact]
+    public async Task Same_TopLevel_Selection_Only_One_Skipped()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              price: Float!
+              brand: Brand
+            }
+
+            type Brand {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product @skip(if: $skip) {
+                             price
+                           }
+                           product {
+                             brand {
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = true })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Fact]
+    public async Task Same_TopLevel_Selection_Skipped_Twice()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              price: Float!
+              brand: Brand
+            }
+
+            type Brand {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product @skip(if: $skip) {
+                             price
+                           }
+                           product @skip(if: $skip) {
+                             brand {
+                               name
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = true })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Fact]
+    public async Task Same_Sub_Selection_Only_One_Skipped()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              price: Float!
+              brand: Brand
+            }
+
+            type Brand {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             brand @skip(if: $skip) {
+                               name
+                             }
+                             brand {
+                               id
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = true })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
+
+    [Fact]
+    public async Task Same_Sub_Selection_Skipped_Twice()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              product: Product
+            }
+
+            type Product {
+              id: ID!
+              price: Float!
+              brand: Brand
+            }
+
+            type Brand {
+              id: ID!
+              name: String!
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA]);
+        var executor = await subgraphs.GetExecutorAsync();
+        var request = OperationRequestBuilder.New()
+            .SetDocument("""
+                         query Test($skip: Boolean!) {
+                           product {
+                             brand @skip(if: $skip) {
+                               name
+                             }
+                             brand @skip(if: $skip) {
+                               id
+                             }
+                           }
+                         }
+                         """)
+            .SetVariableValues(new Dictionary<string, object?> { ["skip"] = true })
+            .Build();
+
+        // act
+        var result = await executor.ExecuteAsync(request);
+
+        // assert
+        MatchMarkdownSnapshot(request, result);
+    }
 }

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Only_One_Skipped.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Only_One_Skipped.md
@@ -1,0 +1,66 @@
+# Same_Sub_Selection_Only_One_Skipped
+
+## Result
+
+```json
+{
+  "data": {
+    "product": {
+      "brand": null
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    brand @skip(if: $skip) {
+      name
+    }
+    brand {
+      id
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+20B3F1E88D04B0D8A6C7C31B3FE4B6A21727E094
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { brand @skip(if: $skip) { name } brand { id } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Only_One_Skipped.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Only_One_Skipped.md
@@ -6,7 +6,9 @@
 {
   "data": {
     "product": {
-      "brand": null
+      "brand": {
+        "id": "1"
+      }
     }
   }
 }
@@ -30,7 +32,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-20B3F1E88D04B0D8A6C7C31B3FE4B6A21727E094
+464C363B5DA6DE9DECACBC57867F8467C5F6EBDC
 ```
 
 ## QueryPlan
@@ -45,7 +47,7 @@ query Test($skip: Boolean!) {
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } } }",
+        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } brand { name id } } }",
         "selectionSetId": 0,
         "forwardedVariables": [
           {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
@@ -4,25 +4,8 @@
 
 ```json
 {
-  "errors": [
-    {
-      "message": "Only one of each directive is allowed per location.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 3
-        }
-      ],
-      "path": [
-        "product"
-      ],
-      "extensions": {
-        "specifiedBy": "https://spec.graphql.org/October2021/#sec-Directives-Are-Unique-Per-Location"
-      }
-    }
-  ],
   "data": {
-    "product": null
+    "product": {}
   }
 }
 ```
@@ -45,7 +28,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-9BFCF93360016E8648F2E5FE8AB694B3CD50AC97
+73D677EC19A26DBBC1B3ADFFADEEC023B1B4388F
 ```
 
 ## QueryPlan
@@ -60,7 +43,7 @@ query Test($skip: Boolean!) {
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) @skip(if: $skip) { name id } } }",
+        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } brand @skip(if: $skip) { name id } } }",
         "selectionSetId": 0,
         "forwardedVariables": [
           {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
@@ -1,0 +1,81 @@
+# Same_Sub_Selection_Skipped_Twice
+
+## Result
+
+```json
+{
+  "errors": [
+    {
+      "message": "Only one of each directive is allowed per location.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "product"
+      ],
+      "extensions": {
+        "specifiedBy": "https://spec.graphql.org/October2021/#sec-Directives-Are-Unique-Per-Location"
+      }
+    }
+  ],
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product {
+    brand @skip(if: $skip) {
+      name
+    }
+    brand @skip(if: $skip) {
+      id
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+9BFCF93360016E8648F2E5FE8AB694B3CD50AC97
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product { brand @skip(if: $skip) { name } brand @skip(if: $skip) { id } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) @skip(if: $skip) { name id } } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_Sub_Selection_Skipped_Twice.md
@@ -28,7 +28,7 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-73D677EC19A26DBBC1B3ADFFADEEC023B1B4388F
+2626677079720B1BC51B536214BDB7B2C1F348C4
 ```
 
 ## QueryPlan
@@ -43,7 +43,7 @@ query Test($skip: Boolean!) {
       {
         "type": "Resolve",
         "subgraph": "Subgraph_1",
-        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } brand @skip(if: $skip) { name id } } }",
+        "document": "query Test_1($skip: Boolean!) { product { brand @skip(if: $skip) { name id } } }",
         "selectionSetId": 0,
         "forwardedVariables": [
           {

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Only_One_Skipped.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Only_One_Skipped.md
@@ -1,0 +1,64 @@
+# Same_TopLevel_Selection_Only_One_Skipped
+
+## Result
+
+```json
+{
+  "data": {
+    "product": null
+  }
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    price
+  }
+  product {
+    brand {
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+57D85C7B4A843EC7C561D336A7A367DFA4E0C337
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { price } product { brand { name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) { price brand { name } } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_Twice.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_Twice.md
@@ -1,0 +1,62 @@
+# Same_TopLevel_Selection_Skipped_Twice
+
+## Result
+
+```json
+{
+  "data": {}
+}
+```
+
+## Request
+
+```graphql
+query Test($skip: Boolean!) {
+  product @skip(if: $skip) {
+    price
+  }
+  product @skip(if: $skip) {
+    brand {
+      name
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+D6F2417F20DCBFB793319B5B51D05AA552AAF440
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { price } product @skip(if: $skip) { brand { name } } }",
+  "operation": "Test",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Resolve",
+        "subgraph": "Subgraph_1",
+        "document": "query Test_1($skip: Boolean!) { product @skip(if: $skip) @skip(if: $skip) { price brand { name } } }",
+        "selectionSetId": 0,
+        "forwardedVariables": [
+          {
+            "variable": "skip"
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_With_Entirely_Different_Skips.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_With_Entirely_Different_Skips.md
@@ -1,27 +1,21 @@
-# Same_TopLevel_Selection_Only_One_Skipped
+# Same_TopLevel_Selection_Skipped_With_Entirely_Different_Skips
 
 ## Result
 
 ```json
 {
-  "data": {
-    "product": {
-      "brand": {
-        "name": "string"
-      }
-    }
-  }
+  "data": {}
 }
 ```
 
 ## Request
 
 ```graphql
-query Test($skip: Boolean!) {
-  product @skip(if: $skip) {
+query Test($skip1: Boolean!, $skip2: Boolean!) {
+  product @skip(if: $skip1) {
     price
   }
-  product {
+  product @skip(if: $skip2) {
     brand {
       name
     }
@@ -32,14 +26,14 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-069A24AC99B558177CB5DCB4CE7E955A0281B31A
+4E267E255CE78944D042F593B46CF371F5ACDE78
 ```
 
 ## QueryPlan
 
 ```json
 {
-  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { price } product { brand { name } } }",
+  "document": "query Test($skip1: Boolean!, $skip2: Boolean!) { product @skip(if: $skip1) { price } product @skip(if: $skip2) { brand { name } } }",
   "operation": "Test",
   "rootNode": {
     "type": "Sequence",

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_With_Partially_Shared_Conditions.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/SkipTests.Same_TopLevel_Selection_Skipped_With_Partially_Shared_Conditions.md
@@ -1,4 +1,4 @@
-# Same_TopLevel_Selection_Skipped_Twice
+# Same_TopLevel_Selection_Skipped_With_Partially_Shared_Conditions
 
 ## Result
 
@@ -11,11 +11,11 @@
 ## Request
 
 ```graphql
-query Test($skip: Boolean!) {
+query Test($skip: Boolean!, $include: Boolean!) {
   product @skip(if: $skip) {
     price
   }
-  product @skip(if: $skip) {
+  product @include(if: $include) @skip(if: $skip) {
     brand {
       name
     }
@@ -26,14 +26,14 @@ query Test($skip: Boolean!) {
 ## QueryPlan Hash
 
 ```text
-55E292C2915D1077D46B29BB67F7D10ECB5292FF
+CD4B630431125928F20FCE53B019898FAF35C9BD
 ```
 
 ## QueryPlan
 
 ```json
 {
-  "document": "query Test($skip: Boolean!) { product @skip(if: $skip) { price } product @skip(if: $skip) { brand { name } } }",
+  "document": "query Test($skip: Boolean!, $include: Boolean!) { product @skip(if: $skip) { price } product @include(if: $include) @skip(if: $skip) { brand { name } } }",
   "operation": "Test",
   "rootNode": {
     "type": "Sequence",


### PR DESCRIPTION
With #8030 I introduced a regression, where you could end up with two `@skip` or `@include` on the same field (invalid), since the combined `Selection.SyntaxNode` contains the directives of all field nodes associated with the selection.

This PR adds a condition to only use the combined SyntaxNode, if there are no directives applied. I've also re-added the `SelectionRewriter` to compact them again.

While testing I found another (unrelated) issue to how conditions are handled on root selection and added a fix as well. The solution isn't very clean, but a clean solution would require a large rework, which I deemed not worth the effort, since Fusion v2 is already on the horizon...