### PR TITLE
Added missing `Leave` method to `FieldSelectionMapSyntaxVisitor`

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Language/SyntaxVisitors/FieldSelectionMapSyntaxVisitor~1.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Language/SyntaxVisitors/FieldSelectionMapSyntaxVisitor~1.cs
@@ -120,6 +120,8 @@ internal class FieldSelectionMapSyntaxVisitor<TContext>(ISyntaxVisitorAction def
                 => Leave((NameNode)node, context),
             FieldSelectionMapSyntaxKind.Path
                 => Leave((PathNode)node, context),
+            FieldSelectionMapSyntaxKind.PathSegment
+                => Leave((PathSegmentNode)node, context),
             FieldSelectionMapSyntaxKind.SelectedListValue
                 => Leave((SelectedListValueNode)node, context),
             FieldSelectionMapSyntaxKind.SelectedObjectField
@@ -141,6 +143,11 @@ internal class FieldSelectionMapSyntaxVisitor<TContext>(ISyntaxVisitorAction def
 
     protected virtual ISyntaxVisitorAction Leave(
         PathNode node,
+        TContext context) =>
+        DefaultAction;
+
+    protected virtual ISyntaxVisitorAction Leave(
+        PathSegmentNode node,
         TContext context) =>
         DefaultAction;
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added missing `Leave` method to `FieldSelectionMapSyntaxVisitor`.