### PR TITLE
[Fusion] Updated MergeUnionTypes to merge by union instead of intersection

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -629,9 +629,7 @@ internal sealed class SourceSchemaMerger
                 i => ((MutableUnionTypeDefinition)i.Type).Types.AsEnumerable(),
                 (i, t) => new UnionMemberInfo(t, (MutableUnionTypeDefinition)i.Type, i.Schema))
             .Where(i => !i.MemberType.HasInternalDirective())
-            .GroupBy(i => i.MemberType.Name)
-            // Intersection: Member type definition count matches union type definition count.
-            .Where(g => g.Count() == typeGroup.Length);
+            .GroupBy(i => i.MemberType.Name);
 
         foreach (var (memberName, memberGroup) in unionMemberGroupByName)
         {

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
@@ -69,8 +69,10 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                 union SearchResult
                     @fusion__type(schema: A)
                     @fusion__type(schema: B)
+                    @fusion__unionMember(schema: A, member: "Product")
                     @fusion__unionMember(schema: A, member: "Order")
-                    @fusion__unionMember(schema: B, member: "Order") = Order
+                    @fusion__unionMember(schema: B, member: "Order")
+                    @fusion__unionMember(schema: B, member: "User") = Product | Order | User
                 """
             },
             // If any of the unions is marked as @inaccessible, then the merged union is also marked
@@ -167,7 +169,7 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                     @fusion__type(schema: B) =
                 """
             },
-            // Union member type "User" internal in one of two schemas. No remaining member types.
+            // Union member type "User" internal in one of two schemas.
             {
                 [
                     """
@@ -192,7 +194,8 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
 
                 union SearchResult
                     @fusion__type(schema: A)
-                    @fusion__type(schema: B) =
+                    @fusion__type(schema: B)
+                    @fusion__unionMember(schema: A, member: "User") = User
                 """
             },
             // Union member type "Order" internal in one of two schemas, "Product" visible in both.
@@ -232,7 +235,8 @@ public sealed class SourceSchemaMergerUnionTests : CompositionTestBase
                     @fusion__type(schema: A)
                     @fusion__type(schema: B)
                     @fusion__unionMember(schema: A, member: "Product")
-                    @fusion__unionMember(schema: B, member: "Product") = Product
+                    @fusion__unionMember(schema: B, member: "Product")
+                    @fusion__unionMember(schema: A, member: "Order") = Product | Order
                 """
             },
             // @lookup


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Updated MergeUnionTypes to merge by union instead of intersection.