### PR TITLE
Fix invalid base64 ID parsing

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -275,7 +275,11 @@ public sealed class DefaultNodeIdSerializer(
             }
         }
 
-        Base64.DecodeFromUtf8InPlace(span, out var written);
+        var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);
+        if (operationStatus != OperationStatus.Done)
+        {
+            throw new NodeIdInvalidFormatException(formattedId);
+        }
         span = span.Slice(0, written);
 
         var delimiterIndex = FindDelimiterIndex(span);

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -176,7 +176,11 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
             }
         }
 
-        Base64.DecodeFromUtf8InPlace(span, out var written);
+        var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);
+        if (operationStatus != OperationStatus.Done)
+        {
+            throw new NodeIdInvalidFormatException(formattedId);
+        }
         span = span.Slice(0, written);
 
         var delimiterIndex = FindDelimiterIndex(span);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -519,6 +519,15 @@ public class DefaultNodeIdSerializerTests
     }
 
     [Fact]
+    public void Parse_Throws_NodeIdInvalidFormatException_On_InvalidBase64Input()
+    {
+        var serializer = CreateSerializer(new StringNodeIdValueSerializer());
+
+        Assert.Throws<NodeIdInvalidFormatException>(
+            () => serializer.Parse("Rm9vOkJhcg", typeof(string)));
+    }
+
+    [Fact]
     public void Ensure_Lookup_Works_With_HashCollision()
     {
         // arrange

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
@@ -441,6 +441,15 @@ public class OptimizedNodeIdSerializerTests
     }
 
     [Fact]
+    public void Parse_Throws_NodeIdInvalidFormatException_On_InvalidBase64Input()
+    {
+        var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
+
+        Assert.Throws<NodeIdInvalidFormatException>(
+            () => serializer.Parse("Rm9vOkJhcg", typeof(string)));
+    }
+
+    [Fact]
     public void Ensure_Lookup_Works_With_HashCollision()
     {
         // arrange


### PR DESCRIPTION
Adds checks for the Base64 string decoding, so it catches if it resulted in an error.

`Rm9vOkJhcg==` -> Valid. Value: `Foo:Bar`
`Rm9vOkJhcg` -> Invalid -> throws an exception.

Closes #8100 (in this specific format)
