### PR TITLE
Avoided setting an implicit name for enum values with an explicit name

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumTypeDescriptor.cs
@@ -72,12 +72,16 @@ public class EnumTypeDescriptor
         {
             foreach (var value in Context.TypeInspector.GetEnumValues(typeDefinition.RuntimeType))
             {
+                if (values.ContainsKey(value))
+                {
+                    continue;
+                }
+
                 var valueDefinition =
                     EnumValueDescriptor.New(Context, value)
                         .CreateDefinition();
 
-                if (valueDefinition.RuntimeValue is not null &&
-                    !values.ContainsKey(valueDefinition.RuntimeValue))
+                if (valueDefinition.RuntimeValue is not null)
                 {
                     values.Add(valueDefinition.RuntimeValue, valueDefinition);
                 }

--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumValueDescriptor.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/EnumValueDescriptor.cs
@@ -16,7 +16,6 @@ public class EnumValueDescriptor
             throw new ArgumentNullException(nameof(runtimeValue));
         }
 
-        Definition.Name = context.Naming.GetEnumValueName(runtimeValue);
         Definition.RuntimeValue = runtimeValue;
         Definition.Description = context.Naming.GetEnumValueDescription(runtimeValue);
         Definition.Member = context.TypeInspector.GetEnumValueMember(runtimeValue);
@@ -51,6 +50,11 @@ public class EnumValueDescriptor
             {
                 Ignore();
             }
+        }
+
+        if (string.IsNullOrEmpty(definition.Name))
+        {
+            Definition.Name = Context.Naming.GetEnumValueName(Definition.RuntimeValue!);
         }
 
         base.OnCreateDefinition(definition);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/EnumTypeTests.cs
@@ -293,6 +293,46 @@ public class EnumTypeTests : TypeTestBase
     }
 
     [Fact]
+    public void EnumValue_ImplicitInvalidName_SchemaException()
+    {
+        // arrange
+        // act
+        static void Action() =>
+            SchemaBuilder.New()
+                .AddQueryType<Bar>()
+                .AddType(new EnumType<UnitsEnum>())
+                .ModifyOptions(o => o.StrictValidation = false)
+                .Create();
+
+        // assert
+        Assert.Throws<SchemaException>(Action)
+            .Errors.Single().Message.MatchInlineSnapshot(
+                """
+                `SÆT` is not a valid GraphQL name.
+                https://spec.graphql.org/October2021/#sec-Names
+                 (Parameter 'value')
+                """);
+    }
+
+    [Fact]
+    public void EnumValue_ExplicitName()
+    {
+        // arrange
+        // act
+        var schema = SchemaBuilder.New()
+            .AddQueryType<Bar>()
+            .AddType(new EnumType<UnitsEnum>(d => d.Value(UnitsEnum.SÆT).Name("SAT")))
+            .ModifyOptions(o => o.StrictValidation = false)
+            .Create();
+
+        var enumType = schema.Types.OfType<EnumType>().Last();
+
+        // assert
+        Assert.Equal("SAT", enumType.Values[0].Name);
+        Assert.Equal("ANOTHER_VALUE", enumType.Values[1].Name);
+    }
+
+    [Fact]
     public void EnumValueT_ValueIsNull_SchemaException()
     {
         // arrange
@@ -702,6 +742,14 @@ public class EnumTypeTests : TypeTestBase
         Info,
         Warning,
         Critical
+    }
+
+    private enum UnitsEnum
+    {
+        // ReSharper disable once InconsistentNaming
+        SÆT,
+        // ReSharper disable once UnusedMember.Local
+        AnotherValue
     }
 
     public class QueryWithEnum


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Avoided setting an implicit name for enum values with an explicit name.

Closes #7433
Closes #7754