### PR TITLE
Fix flaky executor tests

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/EvictSchemaTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/EvictSchemaTests.cs
@@ -10,7 +10,8 @@ public class EvictSchemaTests(TestServerFactory serverFactory) : ServerTestBase(
     public async Task Evict_Default_Schema()
     {
         // arrange
-        var newExecutorCreatedResetEvent = new AutoResetEvent(false);
+        var newExecutorCreatedResetEvent = new ManualResetEventSlim(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var server = CreateStarWarsServer();
 
         var time1 = await server.GetAsync(
@@ -28,7 +29,7 @@ public class EvictSchemaTests(TestServerFactory serverFactory) : ServerTestBase(
         // act
         await server.GetAsync(
             new ClientQueryRequest { Query = "{ evict }", });
-        newExecutorCreatedResetEvent.WaitOne(5000);
+        newExecutorCreatedResetEvent.Wait(cts.Token);
 
         // assert
         var time2 = await server.GetAsync(
@@ -40,7 +41,8 @@ public class EvictSchemaTests(TestServerFactory serverFactory) : ServerTestBase(
     public async Task Evict_Named_Schema()
     {
         // arrange
-        var newExecutorCreatedResetEvent = new AutoResetEvent(false);
+        var newExecutorCreatedResetEvent = new ManualResetEventSlim(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var server = CreateStarWarsServer();
 
         var time1 = await server.GetAsync(
@@ -60,7 +62,7 @@ public class EvictSchemaTests(TestServerFactory serverFactory) : ServerTestBase(
         await server.GetAsync(
             new ClientQueryRequest { Query = "{ evict }", },
             "/evict");
-        newExecutorCreatedResetEvent.WaitOne(5000);
+        newExecutorCreatedResetEvent.Wait(cts.Token);
 
         // assert
         var time2 = await server.GetAsync(

--- a/src/HotChocolate/Core/test/Execution.Tests/AutoUpdateRequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/AutoUpdateRequestExecutorProxyTests.cs
@@ -33,7 +33,8 @@ public class AutoUpdateRequestExecutorProxyTests
     public async Task Ensure_Executor_Is_Correctly_Swapped_When_Evicted()
     {
         // arrange
-        var executorUpdatedResetEvent = new AutoResetEvent(false);
+        var executorUpdatedResetEvent = new ManualResetEventSlim(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var resolver =
             new ServiceCollection()
                 .AddGraphQL()
@@ -58,7 +59,7 @@ public class AutoUpdateRequestExecutorProxyTests
         // act
         var a = proxy.InnerExecutor;
         resolver.EvictRequestExecutor();
-        executorUpdatedResetEvent.WaitOne(1000);
+        executorUpdatedResetEvent.Wait(cts.Token);
 
         var b = proxy.InnerExecutor;
 

--- a/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/RequestExecutorProxyTests.cs
@@ -31,7 +31,8 @@ public class RequestExecutorProxyTests
     public async Task Ensure_Executor_Is_Correctly_Swapped_When_Evicted()
     {
         // arrange
-        var executorUpdatedResetEvent = new AutoResetEvent(false);
+        var executorUpdatedResetEvent = new ManualResetEventSlim(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var resolver =
             new ServiceCollection()
                 .AddGraphQL()
@@ -54,7 +55,7 @@ public class RequestExecutorProxyTests
         // act
         var a = await proxy.GetRequestExecutorAsync(CancellationToken.None);
         resolver.EvictRequestExecutor();
-        executorUpdatedResetEvent.WaitOne(1000);
+        executorUpdatedResetEvent.Wait(cts.Token);
         var b = await proxy.GetRequestExecutorAsync(CancellationToken.None);
 
         // assert


### PR DESCRIPTION
- Increased reset event timeout to 5s
- Switched to `ManualResetEventSlim` and CancellationTokens so an elapsed timeout will trigger a proper `OperationCanceledException`