### PR TITLE
Updated CI workflow to only run Docker Hub login step for local branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,11 @@ jobs:
         timeout-minutes: 5
 
       - name: Log in to Docker Hub
+        # Run step only if branch is local (not from a fork).
+        if: >
+          github.event_name != 'pull_request' ||
+          (github.event_name == 'pull_request' &&
+           github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated CI workflow to only run Docker Hub login step for local branches.