### PR TITLE
Updated node ID serializers to ensure correct padding while parsing

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/DefaultNodeIdSerializer.cs
@@ -204,6 +204,25 @@ public sealed class DefaultNodeIdSerializer(
             }
         }
 
+        // Ensure correct padding.
+        var firstPaddingIndex = span.IndexOf((byte)'=');
+        var nonPaddedLength = firstPaddingIndex == -1 ? span.Length : firstPaddingIndex;
+        var actualPadding = firstPaddingIndex == -1 ? 0 : span.Length - firstPaddingIndex;
+        var expectedPadding = (4 - nonPaddedLength % 4) % 4;
+
+        if (actualPadding != expectedPadding)
+        {
+            Span<byte> correctedSpan = stackalloc byte[nonPaddedLength + expectedPadding];
+            span[..nonPaddedLength].CopyTo(correctedSpan);
+
+            for (var i = nonPaddedLength; i < correctedSpan.Length; i++)
+            {
+                correctedSpan[i] = (byte)'=';
+            }
+
+            span = correctedSpan;
+        }
+
         var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);
         if (operationStatus != OperationStatus.Done)
         {
@@ -278,6 +297,25 @@ public sealed class DefaultNodeIdSerializer(
                     span[i] = (byte)'/';
                 }
             }
+        }
+
+        // Ensure correct padding.
+        var firstPaddingIndex = span.IndexOf((byte)'=');
+        var nonPaddedLength = firstPaddingIndex == -1 ? span.Length : firstPaddingIndex;
+        var actualPadding = firstPaddingIndex == -1 ? 0 : span.Length - firstPaddingIndex;
+        var expectedPadding = (4 - nonPaddedLength % 4) % 4;
+
+        if (actualPadding != expectedPadding)
+        {
+            Span<byte> correctedSpan = stackalloc byte[nonPaddedLength + expectedPadding];
+            span[..nonPaddedLength].CopyTo(correctedSpan);
+
+            for (var i = nonPaddedLength; i < correctedSpan.Length; i++)
+            {
+                correctedSpan[i] = (byte)'=';
+            }
+
+            span = correctedSpan;
         }
 
         var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);

--- a/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Relay/Serialization/OptimizedNodeIdSerializer.cs
@@ -106,6 +106,25 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
             }
         }
 
+        // Ensure correct padding.
+        var firstPaddingIndex = span.IndexOf((byte)'=');
+        var nonPaddedLength = firstPaddingIndex == -1 ? span.Length : firstPaddingIndex;
+        var actualPadding = firstPaddingIndex == -1 ? 0 : span.Length - firstPaddingIndex;
+        var expectedPadding = (4 - nonPaddedLength % 4) % 4;
+
+        if (actualPadding != expectedPadding)
+        {
+            Span<byte> correctedSpan = stackalloc byte[nonPaddedLength + expectedPadding];
+            span[..nonPaddedLength].CopyTo(correctedSpan);
+
+            for (var i = nonPaddedLength; i < correctedSpan.Length; i++)
+            {
+                correctedSpan[i] = (byte)'=';
+            }
+
+            span = correctedSpan;
+        }
+
         var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);
         if (operationStatus != OperationStatus.Done)
         {
@@ -179,6 +198,25 @@ internal sealed class OptimizedNodeIdSerializer : INodeIdSerializer
                     span[i] = (byte)'/';
                 }
             }
+        }
+
+        // Ensure correct padding.
+        var firstPaddingIndex = span.IndexOf((byte)'=');
+        var nonPaddedLength = firstPaddingIndex == -1 ? span.Length : firstPaddingIndex;
+        var actualPadding = firstPaddingIndex == -1 ? 0 : span.Length - firstPaddingIndex;
+        var expectedPadding = (4 - nonPaddedLength % 4) % 4;
+
+        if (actualPadding != expectedPadding)
+        {
+            Span<byte> correctedSpan = stackalloc byte[nonPaddedLength + expectedPadding];
+            span[..nonPaddedLength].CopyTo(correctedSpan);
+
+            for (var i = nonPaddedLength; i < correctedSpan.Length; i++)
+            {
+                correctedSpan[i] = (byte)'=';
+            }
+
+            span = correctedSpan;
         }
 
         var operationStatus = Base64.DecodeFromUtf8InPlace(span, out var written);

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/DefaultNodeIdSerializerTests.cs
@@ -524,7 +524,7 @@ public class DefaultNodeIdSerializerTests
         var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         Assert.Throws<NodeIdInvalidFormatException>(
-            () => serializer.Parse("Rm9vOkJhcg", typeof(string)));
+            () => serializer.Parse("!", typeof(string)));
     }
 
     [Fact]
@@ -535,7 +535,27 @@ public class DefaultNodeIdSerializerTests
         var serializer = CreateSerializer(new StringNodeIdValueSerializer());
 
         Assert.Throws<NodeIdInvalidFormatException>(
-            () => serializer.Parse("Rm9vOkJhcg", lookup.Object));
+            () => serializer.Parse("!", lookup.Object));
+    }
+
+    [Theory]
+    [InlineData("RW50aXR5OjE")]      // No padding (length: 11).
+    [InlineData("RW50aXR5OjE=")]     // Correct padding (length: 12).
+    [InlineData("RW50aXR5OjE==")]    // Excess padding (length: 13).
+    [InlineData("RW50aXR5OjE===")]   // Excess padding (length: 14).
+    [InlineData("RW50aXR5OjE====")]  // Excess padding (length: 15).
+    [InlineData("RW50aXR5OjE=====")] // Excess padding (length: 16).
+    public void Parse_Ensures_Correct_Padding(string id)
+    {
+        var lookup = new Mock<INodeIdRuntimeTypeLookup>();
+        lookup.Setup(t => t.GetNodeIdRuntimeType("Entity")).Returns(typeof(int));
+        var serializer = CreateSerializer(new Int32NodeIdValueSerializer());
+
+        void Act1() => serializer.Parse(id, typeof(int));
+        void Act2() => serializer.Parse(id, lookup.Object);
+
+        Assert.Null(Record.Exception(Act1));
+        Assert.Null(Record.Exception(Act2));
     }
 
     [Fact]

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Relay/OptimizedNodeIdSerializerTests.cs
@@ -446,7 +446,7 @@ public class OptimizedNodeIdSerializerTests
         var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
 
         Assert.Throws<NodeIdInvalidFormatException>(
-            () => serializer.Parse("Rm9vOkJhcg", typeof(string)));
+            () => serializer.Parse("!", typeof(string)));
     }
 
     [Fact]
@@ -458,7 +458,27 @@ public class OptimizedNodeIdSerializerTests
         var serializer = CreateSerializer("Foo", new StringNodeIdValueSerializer());
 
         Assert.Throws<NodeIdInvalidFormatException>(
-            () => serializer.Parse("Rm9vOkJhcg", lookup.Object));
+            () => serializer.Parse("!", lookup.Object));
+    }
+
+    [Theory]
+    [InlineData("RW50aXR5OjE")]      // No padding (length: 11).
+    [InlineData("RW50aXR5OjE=")]     // Correct padding (length: 12).
+    [InlineData("RW50aXR5OjE==")]    // Excess padding (length: 13).
+    [InlineData("RW50aXR5OjE===")]   // Excess padding (length: 14).
+    [InlineData("RW50aXR5OjE====")]  // Excess padding (length: 15).
+    [InlineData("RW50aXR5OjE=====")] // Excess padding (length: 16).
+    public void Parse_Ensures_Correct_Padding(string id)
+    {
+        var lookup = new Mock<INodeIdRuntimeTypeLookup>();
+        lookup.Setup(t => t.GetNodeIdRuntimeType(default)).Returns(default(Type));
+        var serializer = CreateSerializer("Entity", new Int32NodeIdValueSerializer());
+
+        void Act1() => serializer.Parse(id, typeof(int));
+        void Act2() => serializer.Parse(id, lookup.Object);
+
+        Assert.Null(Record.Exception(Act1));
+        Assert.Null(Record.Exception(Act2));
     }
 
     [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated `OptimizedNodeIdSerializer.Parse` to ensure correct padding.