### PR TITLE
Skipped flaky test in Apollo WebSocketProtocolTests

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/Apollo/WebSocketProtocolTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/Apollo/WebSocketProtocolTests.cs
@@ -520,7 +520,8 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory)
             Assert.Equal(CloseReasons.InvalidMessage, (int)webSocket.CloseStatus!.Value);
         });
 
-    [Fact]
+    // TODO : FIX Flaky Test
+    [Fact(Skip = "Flaky")]
     public Task Send_Start_ReceiveDataOnMutation_StripNull() =>
         TryTest(
             async ct =>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Skipped flaky test in Apollo `WebSocketProtocolTests`.