### PR TITLE
[Fusion] Parsed `@require(field:)` as FieldSelectionMap

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Events/SchemaEvents.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Events/SchemaEvents.cs
@@ -123,15 +123,6 @@ internal record RequireFieldInvalidTypeEvent(
     MutableComplexTypeDefinition Type,
     MutableSchemaDefinition Schema) : IEvent;
 
-internal record RequireFieldNodeEvent(
-    FieldNode FieldNode,
-    ImmutableArray<string> FieldNamePath,
-    Directive RequireDirective,
-    MutableInputFieldDefinition Argument,
-    MutableOutputFieldDefinition Field,
-    MutableComplexTypeDefinition Type,
-    MutableSchemaDefinition Schema) : IEvent;
-
 internal record SchemaEvent(MutableSchemaDefinition Schema) : IEvent;
 
 internal record TypeEvent(


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Parsed `@require(field:)` as `FieldSelectionMap`.