### PR TITLE
[Fusion] Added missing summaries to FieldSelectionMap node classes

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Language/Nodes/SelectedValueEntryNode.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Language/Nodes/SelectedValueEntryNode.cs
@@ -1,7 +1,33 @@
 namespace HotChocolate.Fusion.Language;
 
 /// <summary>
-/// TODO: Add summary.
+/// Each <c>SelectedValueEntry</c> may take one of the following forms:
+///
+/// <list type="bullet">
+///     <item>
+///         <description>
+///         A <c>Path</c> (when not immediately followed by a dot) that is designed to point to a
+///         single value, although it may reference multiple fields depending on its return type.
+///         </description>
+///     </item>
+///     <item>
+///         <description>
+///         A <c>Path</c> immediately followed by a dot and a <c>SelectedObjectValue</c> to denote
+///         a nested object selection.
+///         </description>
+///     </item>
+///     <item>
+///         <description>
+///         A <c>Path</c> immediately followed by a <c>SelectedListValue</c> to denote selection
+///         from a list.
+///         </description>
+///     </item>
+///     <item>
+///         <description>
+///         A standalone <c>SelectedObjectValue</c>.
+///         </description>
+///     </item>
+/// </list>
 /// </summary>
 public sealed class SelectedValueEntryNode(
     Location? location = null,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Language/Nodes/SelectedValueNode.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Language/Nodes/SelectedValueNode.cs
@@ -1,7 +1,8 @@
 namespace HotChocolate.Fusion.Language;
 
 /// <summary>
-/// TODO: Add summary.
+/// A <c>SelectedValue</c> consists of one or more <c>SelectedValueEntry</c> components, which may
+/// be joined by a pipe (<c>|</c>) operator to indicate alternative selections based on type.
 /// </summary>
 public sealed class SelectedValueNode(
     SelectedValueEntryNode selectedValueEntry,


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Added missing summaries to `FieldSelectionMap` node classes.