### PR TITLE
refactor: :technologist: removed sealed from JsonType scalar

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Scalars/JsonType.cs
@@ -14,7 +14,7 @@ namespace HotChocolate.Types;
 ///
 /// The runtime representation of the JSON scalar is an <see cref="JsonElement"/>.
 /// </summary>
-public sealed class JsonType : ScalarType<JsonElement>
+public class JsonType : ScalarType<JsonElement>
 {
     /// <summary>
     /// Initializes a new instance of <see cref="JsonType"/>.


### PR DESCRIPTION
TL;DR: Remove `sealed` from `JsonType` scalar to allow developers extending it in their own scalars.

We use HC in our project and now want a Scalar that will basically output JSON, but we want to rename it as well as add documentation like a description and [`@specifiedBy`-directive](https://spec.graphql.org/draft/#sec--specifiedBy). Therefore it would be quite handy to just extend the `JsonType`. Furthermore I don't really see a benefit an sealing it 🤔 

