### PR TITLE
[Fusion] Removed "extend" keyword from test theory data

### DIFF
--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/QueryRootTypeInaccessibleRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaValidationRules/QueryRootTypeInaccessibleRuleTests.cs
@@ -52,7 +52,7 @@ public sealed class QueryRootTypeInaccessibleRuleTests : CompositionTestBase
             {
                 [
                     """
-                    extend schema {
+                    schema {
                         query: Query
                     }
 
@@ -80,7 +80,7 @@ public sealed class QueryRootTypeInaccessibleRuleTests : CompositionTestBase
             {
                 [
                     """
-                    extend schema {
+                    schema {
                         query: Query
                     }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Removed "extend" keyword from test theory data.