### PR TITLE
[Fusion] Avoided accessing property that can throw in Deconstruct method

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Results/CompositionResult~1.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Results/CompositionResult~1.cs
@@ -85,7 +85,7 @@ public readonly record struct CompositionResult<TValue>
     {
         isSuccess = IsSuccess;
         isFailure = IsFailure;
-        value = Value;
+        value = _value;
         errors = Errors;
     }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Avoided accessing property that can throw in Deconstruct method.