### PR TITLE
[Fusion] Refactored `RequireInvalidFieldsRule` (no source schema access)

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/CompositionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/CompositionContext.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging.Contracts;
 using HotChocolate.Types.Mutable;
@@ -13,12 +12,6 @@ internal sealed class CompositionContext(
     /// Gets the schema definitions.
     /// </summary>
     public ImmutableSortedSet<MutableSchemaDefinition> SchemaDefinitions { get; } = schemaDefinitions;
-
-    /// <summary>
-    /// Gets a dictionary of schema definitions by name.
-    /// </summary>
-    public FrozenDictionary<string, MutableSchemaDefinition> SchemaDefinitionsByName { get; }
-        = schemaDefinitions.ToFrozenDictionary(s => s.Name);
 
     /// <summary>
     /// Gets the composition log.

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/RequireInvalidFieldsRule.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/PostMergeValidationRules/RequireInvalidFieldsRule.cs
@@ -4,11 +4,10 @@ using HotChocolate.Fusion.Extensions;
 using HotChocolate.Fusion.Language;
 using HotChocolate.Fusion.Validators;
 using HotChocolate.Language;
-using HotChocolate.Types;
-using HotChocolate.Types.Mutable;
 using static HotChocolate.Fusion.Logging.LogEntryHelper;
 using static HotChocolate.Fusion.WellKnownArgumentNames;
 using static HotChocolate.Fusion.WellKnownDirectiveNames;
+using static HotChocolate.Language.Utf8GraphQLParser.Syntax;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
 
@@ -40,15 +39,9 @@ internal sealed class RequireInvalidFieldsRule : IEventHandler<OutputFieldEvent>
         foreach (var fusionRequiresDirective in fusionRequiresDirectives)
         {
             var sourceSchemaName = (string)fusionRequiresDirective.Arguments[Schema].Value!;
-            var sourceSchema = context.SchemaDefinitionsByName[sourceSchemaName];
-
-            if (!(sourceSchema.Types.TryGetType(type.Name, out var sourceType)
-                && sourceType is MutableComplexTypeDefinition sourceComplexType))
-            {
-                return;
-            }
-
-            var arguments = sourceComplexType.Fields[field.Name].Arguments;
+            var fieldArgumentValue = (string)fusionRequiresDirective.Arguments[Field].Value!;
+            var fieldDefinition = ParseFieldDefinition(fieldArgumentValue);
+            var arguments = fieldDefinition.Arguments;
             var map = (ListValueNode)fusionRequiresDirective.Arguments[Map];
 
             for (var i = 0; i < arguments.Count; i++)
@@ -62,8 +55,8 @@ internal sealed class RequireInvalidFieldsRule : IEventHandler<OutputFieldEvent>
 
                 var fieldSelectionMapParser = new FieldSelectionMapParser(selectionMap);
                 var fieldSelectionMap = fieldSelectionMapParser.Parse();
-                var argument = arguments.AsEnumerable().ElementAt(i);
-                var inputType = schema.Types[argument.Type.AsTypeDefinition().Name];
+                var argument = arguments[i];
+                var inputType = schema.Types[argument.Type.NamedType().Name.Value];
                 var errors = validator.Validate(fieldSelectionMap, inputType, type);
 
                 if (errors.Any())
@@ -71,7 +64,7 @@ internal sealed class RequireInvalidFieldsRule : IEventHandler<OutputFieldEvent>
                     context.Log.Write(
                         RequireInvalidFields(
                             fusionRequiresDirective,
-                            argument.Name,
+                            argument.Name.Value,
                             field.Name,
                             type.Name,
                             sourceSchemaName,


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Refactored `RequireInvalidFieldsRule` (no source schema access).