### PR TITLE
[Fusion] Replaced filtering with assertion in `MergeArgumentDefinitions`

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -151,8 +151,7 @@ internal sealed class SourceSchemaMerger
         ImmutableArray<FieldArgumentInfo> argumentGroup,
         MutableSchemaDefinition mergedSchema)
     {
-        // Remove all arguments marked with @require.
-        argumentGroup = [.. argumentGroup.Where(i => !i.Argument.HasRequireDirective())];
+        Assert(!argumentGroup.Any(i => i.Argument.HasRequireDirective()));
 
         var mergedArgument = argumentGroup.Select(i => i.Argument).FirstOrDefault();
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Replaced filtering with assertion in `MergeArgumentDefinitions`.