### PR TITLE
Fix an exception occurring when id is null

### DIFF
--- a/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageParser.cs
+++ b/src/StrawberryShake/Client/src/Transport.WebSockets/Protocols/GraphQLWebSocket/GraphQLWebSocketMessageParser.cs
@@ -110,7 +110,11 @@ internal ref struct GraphQLWebSocketMessageParser
             case _i:
                 if (fieldName.SequenceEqual(Id))
                 {
-                    Expect(JsonTokenType.String);
+                    if (_reader.TokenType != JsonTokenType.Null)
+                    {
+                        Expect(JsonTokenType.String);
+                    }
+
                     message.Id = _reader.GetString();
                 }
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

My GraphQL server is built using `GraphQL.AspNet`.
When using the `StrawberryShake` client with subscriptions, it does not work.
After debugging, I found that the server receives the following value, and an exception occurs when id is null:
```json
{"id":null,"type":"connection_ack"}
```

Please check if it is correct to validate whether the `id` value is null.

Closes #bugnumber (in this specific format)
