### PR TITLE
Fixed relative cursors to handle nullable types. 

### DIFF
--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/CursorKey.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/CursorKey.cs
@@ -1,5 +1,4 @@
 using System.Linq.Expressions;
-using System.Reflection;
 using GreenDonut.Data.Cursors.Serializers;
 
 namespace GreenDonut.Data.Cursors;
@@ -31,7 +30,12 @@ public sealed class CursorKey(
     /// <summary>
     /// Gets the compare method that is applicable to the key value.
     /// </summary>
-    public MethodInfo CompareMethod { get; } = serializer.GetCompareToMethod(expression.ReturnType);
+    public CursorKeyCompareMethod CompareMethod { get; } = serializer.GetCompareToMethod(expression.ReturnType);
+
+    /// <summary>
+    /// Gets a value indicating whether the key value is nullable.
+    /// </summary>
+    public bool IsNullable { get; } = serializer.IsNullable(expression.ReturnType);
 
     /// <summary>
     /// Gets a value defining the sort direction of this key in dataset.

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/CursorKeyCompareMethod.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/CursorKeyCompareMethod.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+
+namespace GreenDonut.Data.Cursors;
+
+/// <summary>
+/// Represents a method used to compare cursor keys.
+/// </summary>
+/// <param name="methodInfo">The <see cref="MethodInfo"/> for the comparison method.</param>
+/// <param name="type">The <see cref="Type"/> that the method belongs to.</param>
+public sealed class CursorKeyCompareMethod(
+    MethodInfo methodInfo,
+    Type type)
+{
+    /// <summary>
+    /// Gets the <see cref="MethodInfo"/> for the comparison method.
+    /// </summary>
+    public MethodInfo MethodInfo { get; } = methodInfo;
+
+    /// <summary>
+    /// Gets the <see cref="Type"/> that the method belongs to.
+    /// </summary>
+    public Type Type { get; } = type;
+}

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/BoolCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/BoolCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class BoolCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<bool>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<bool>();
 
     public bool IsSupported(Type type)
-        => type == typeof(bool);
+        => type == typeof(bool) || type == typeof(bool?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(bool?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/CompareToResolver.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/CompareToResolver.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using static System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
 
 namespace GreenDonut.Data.Cursors.Serializers;
@@ -8,9 +7,9 @@ internal static class CompareToResolver
 {
     private const string _compareTo = "CompareTo";
 
-    public static MethodInfo GetCompareToMethod<[DynamicallyAccessedMembers(PublicMethods)] T>()
+    public static CursorKeyCompareMethod GetCompareToMethod<[DynamicallyAccessedMembers(PublicMethods)] T>()
         => GetCompareToMethod(typeof(T));
 
-    private static MethodInfo GetCompareToMethod([DynamicallyAccessedMembers(PublicMethods)] Type type)
-        => type.GetMethod(_compareTo, [type])!;
+    private static CursorKeyCompareMethod GetCompareToMethod([DynamicallyAccessedMembers(PublicMethods)] Type type)
+        => new CursorKeyCompareMethod(type.GetMethod(_compareTo, [type])!, type);
 }

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateOnlyCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateOnlyCursorKeySerializer.cs
@@ -6,15 +6,18 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class DateOnlyCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo =
+    private static readonly CursorKeyCompareMethod _compareTo =
         CompareToResolver.GetCompareToMethod<DateOnly>();
 
     private const string _dateFormat = "yyyyMMdd";
 
     public bool IsSupported(Type type)
-        => type == typeof(DateOnly);
+        => type == typeof(DateOnly) || type == typeof(DateOnly?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(DateOnly?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateTimeCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateTimeCursorKeySerializer.cs
@@ -7,15 +7,18 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class DateTimeCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo =
+    private static readonly CursorKeyCompareMethod _compareTo =
         CompareToResolver.GetCompareToMethod<DateTime>();
 
     private const string _dateTimeFormat = "yyyyMMddHHmmssfffffff";
 
     public bool IsSupported(Type type)
-        => type == typeof(DateTime);
+        => type == typeof(DateTime) || type == typeof(DateTime?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(DateTime?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateTimeOffsetCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DateTimeOffsetCursorKeySerializer.cs
@@ -7,16 +7,19 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class DateTimeOffsetCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo =
+    private static readonly CursorKeyCompareMethod _compareTo =
         CompareToResolver.GetCompareToMethod<DateTimeOffset>();
 
     private const string _dateTimeFormat = "yyyyMMddHHmmssfffffff";
     private const string _offsetFormat = "hhmm";
 
     public bool IsSupported(Type type)
-        => type == typeof(DateTimeOffset);
+        => type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(DateTimeOffset?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DecimalCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DecimalCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class DecimalCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<decimal>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<decimal>();
 
     public bool IsSupported(Type type)
-        => type == typeof(decimal);
+        => type == typeof(decimal) || type == typeof(decimal?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(decimal?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DoubleCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/DoubleCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class DoubleCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<double>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<double>();
 
     public bool IsSupported(Type type)
-        => type == typeof(double);
+        => type == typeof(double) || type == typeof(double?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(double?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/FloatCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/FloatCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class FloatCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<float>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<float>();
 
     public bool IsSupported(Type type)
-        => type == typeof(float);
+        => type == typeof(float) || type == typeof(float?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(float?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/GuidCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/GuidCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class GuidCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<Guid>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<Guid>();
 
     public bool IsSupported(Type type)
-        => type == typeof(Guid);
+        => type == typeof(Guid) || type == typeof(Guid?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(Guid?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ICursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ICursorKeySerializer.cs
@@ -6,7 +6,9 @@ public interface ICursorKeySerializer
 {
     bool IsSupported(Type type);
 
-    MethodInfo GetCompareToMethod(Type type);
+    bool IsNullable(Type type);
+
+    CursorKeyCompareMethod GetCompareToMethod(Type type);
 
     object Parse(ReadOnlySpan<byte> formattedKey);
 

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/IntCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/IntCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class IntCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<int>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<int>();
 
     public bool IsSupported(Type type)
-        => type == typeof(int);
+        => type == typeof(int) || type == typeof(int?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(int?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/LongCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/LongCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class LongCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<long>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<long>();
 
     public bool IsSupported(Type type)
-        => type == typeof(long);
+        => type == typeof(long) || type == typeof(long?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(long?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ShortCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ShortCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class ShortCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<short>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<short>();
 
     public bool IsSupported(Type type)
-        => type == typeof(short);
+        => type == typeof(short) || type == typeof(short?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(short?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/StringCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/StringCursorKeySerializer.cs
@@ -6,12 +6,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 internal sealed class StringCursorKeySerializer : ICursorKeySerializer
 {
     private static readonly Encoding _encoding = Encoding.UTF8;
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<string>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<string>();
 
     public bool IsSupported(Type type)
         => type == typeof(string);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => false;
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/TimeOnlyCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/TimeOnlyCursorKeySerializer.cs
@@ -6,15 +6,18 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class TimeOnlyCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo =
+    private static readonly CursorKeyCompareMethod _compareTo =
         CompareToResolver.GetCompareToMethod<TimeOnly>();
 
     private const string _timeFormat = "HHmmssfffffff";
 
     public bool IsSupported(Type type)
-        => type == typeof(TimeOnly);
+        => type == typeof(TimeOnly) || type == typeof(TimeOnly?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(TimeOnly?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/UIntCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/UIntCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class UIntCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<uint>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<uint>();
 
     public bool IsSupported(Type type)
-        => type == typeof(uint);
+        => type == typeof(uint) || type == typeof(uint?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(uint?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ULongCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/ULongCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class ULongCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<ulong>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<ulong>();
 
     public bool IsSupported(Type type)
-        => type == typeof(ulong);
+        => type == typeof(ulong) || type == typeof(ulong?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(ulong?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/UShortCursorKeySerializer.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Cursors/Serializers/UShortCursorKeySerializer.cs
@@ -5,12 +5,15 @@ namespace GreenDonut.Data.Cursors.Serializers;
 
 internal sealed class UShortCursorKeySerializer : ICursorKeySerializer
 {
-    private static readonly MethodInfo _compareTo = CompareToResolver.GetCompareToMethod<ushort>();
+    private static readonly CursorKeyCompareMethod _compareTo = CompareToResolver.GetCompareToMethod<ushort>();
 
     public bool IsSupported(Type type)
-        => type == typeof(ushort);
+        => type == typeof(ushort) || type == typeof(ushort?);
 
-    public MethodInfo GetCompareToMethod(Type type)
+    public bool IsNullable(Type type)
+        => type == typeof(ushort?);
+
+    public CursorKeyCompareMethod GetCompareToMethod(Type type)
         => _compareTo;
 
     public object Parse(ReadOnlySpan<byte> formattedKey)

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/RelativeCursorTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/RelativeCursorTests.cs
@@ -63,9 +63,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_0='Brightex'
                 -- @__value_1='2'
                 -- @__p_2='3'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+                WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
                 ORDER BY b."Name", b."Id"
                 LIMIT @__p_2
                 ---------------
@@ -124,7 +124,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Brightex'
                 -- @__value_1='2'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -132,11 +132,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 1 AND (b0."Name" > @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" > @__value_1))
+                        WHERE b0."GroupId" = 1 AND b0."Name" >= @__value_0 AND (b0."Name" > @__value_0 OR b0."Id" > @__value_1)
                     ) AS b2
                     WHERE b2.row <= 3
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -197,9 +197,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='2'
                 -- @__p_3='3'
                 -- @__p_2='2'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+                WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
                 ORDER BY b."Name", b."Id"
                 LIMIT @__p_3 OFFSET @__p_2
                 ---------------
@@ -258,7 +258,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Brightex'
                 -- @__value_1='2'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -266,11 +266,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 1 AND (b0."Name" > @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" > @__value_1))
+                        WHERE b0."GroupId" = 1 AND b0."Name" >= @__value_0 AND (b0."Name" > @__value_0 OR b0."Id" > @__value_1)
                     ) AS b2
                     WHERE 2 < b2.row AND b2.row <= 5
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -335,11 +335,159 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='4'
                 -- @__p_3='3'
                 -- @__p_2='2'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+                WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
                 ORDER BY b."Name", b."Id"
                 LIMIT @__p_3 OFFSET @__p_2
+                ---------------
+
+                """);
+    }
+
+    [Fact]
+    public async Task Fetch_Fourth_Page_With_Offset_1_Order_By_DisplayName()
+    {
+        // Arrange
+
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+
+        await using var context = new TestContext(connectionString);
+        var arguments = new PagingArguments(2) { EnableRelativeCursors = true };
+        var first = await context.Brands.OrderBy(t => t.DisplayName).ThenBy(t => t.Id).ToPageAsync(arguments);
+        arguments = arguments with { After = first.CreateCursor(first.Last!, 0) };
+        var second = await context.Brands.OrderBy(t => t.DisplayName).ThenBy(t => t.Id).ToPageAsync(arguments);
+
+        // Act
+
+        using var capture = new CapturePagingQueryInterceptor();
+        arguments = arguments with { After = second.CreateCursor(second.Last!, 1) };
+        var fourth = await context.Brands.OrderBy(t => t.DisplayName).ThenBy(t => t.Id).ToPageAsync(arguments);
+
+        // Assert
+
+        /*
+        1. Aetherix
+        2. Brightex
+        3. Celestara
+        4. Dynamova     <- Cursor
+        5. Evolvance
+        6. Futurova
+        7. Glacient     <- Page 4 - Item 1
+        8. Hyperionix   <- Page 4 - Item 2
+        */
+
+        Snapshot.Create()
+            .Add(new { Page = fourth.Index, fourth.TotalCount, Items = fourth.Items.Select(t => t.Name).ToArray() })
+            .AddSql(capture)
+            .MatchInline(
+                """
+                ---------------
+                {
+                  "Page": 4,
+                  "TotalCount": 20,
+                  "Items": [
+                    "Glacient",
+                    "Hyperionix"
+                  ]
+                }
+                ---------------
+
+                SQL 0
+                ---------------
+                -- @__value_0='Dynamova'
+                -- @__value_1='4'
+                -- @__p_3='3'
+                -- @__p_2='2'
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
+                FROM "Brands" AS b
+                WHERE b."DisplayName" >= @__value_0 AND (b."DisplayName" > @__value_0 OR b."Id" > @__value_1)
+                ORDER BY b."DisplayName", b."Id"
+                LIMIT @__p_3 OFFSET @__p_2
+                ---------------
+
+                """);
+    }
+
+    [Fact]
+    public async Task Fetch_Second_Page_Order_By_FoundedDate()
+    {
+        // Arrange
+
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+
+        await using var context = new TestContext(connectionString);
+        var arguments = new PagingArguments(context.Brands.Count() / 2) { EnableRelativeCursors = true };
+        var first = await context.Brands.OrderBy(t => t.FoundedDate).ThenBy(t => t.Id).ToPageAsync(arguments);
+
+        // Act
+
+        using var capture = new CapturePagingQueryInterceptor();
+        arguments = arguments with { After = first.CreateCursor(first.Last!, 0) };
+        var second = await context.Brands.OrderBy(t => t.FoundedDate).ThenBy(t => t.Id).ToPageAsync(arguments);
+
+        // Assert
+
+        /*
+          
+        1. Dynamova     
+        2. Evolvance
+        3. Futurova
+        4. Glacient     
+        5. Hyperionix   
+        6. Innovexa    
+        7. Joventra     
+        8. Nebularis    
+        9. Omniflex    
+        10. Pulsarix    <- Cursor
+        11. Quantumis   <- Page 2 - Item 1
+        12. Radiantum   <- Page 2 - Item 2
+        13. Synerflux   <- Page 2 - Item 3
+        14. Vertexis    <- Page 2 - Item 4
+        15. Aetherix    <- Page 2 - Item 5
+        16. Brightex    <- Page 2 - Item 6
+        17. Celestara   <- Page 2 - Item 7
+        18. Kinetiq     <- Page 2 - Item 8
+        19. Luminara    <- Page 2 - Item 9
+        20. Momentumix  <- Page 2 - Item 10
+        */
+
+        Snapshot.Create()
+            .Add(new { Page = second.Index, second.TotalCount, Items = second.Items.Select(t => t.Name).ToArray() })
+            .AddSql(capture)
+            .MatchInline(
+                """
+                ---------------
+                {
+                  "Page": 2,
+                  "TotalCount": 20,
+                  "Items": [
+                    "Quantumis",
+                    "Radiantum",
+                    "Synerflux",
+                    "Vertexis",
+                    "Aetherix",
+                    "Brightex",
+                    "Celestara",
+                    "Kinetiq",
+                    "Luminara",
+                    "Momentumix"
+                  ]
+                }
+                ---------------
+
+                SQL 0
+                ---------------
+                -- @__value_0='01/10/2025' (DbType = Date)
+                -- @__value_1='16'
+                -- @__p_2='11'
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
+                FROM "Brands" AS b
+                WHERE b."FoundedDate" >= @__value_0 AND (b."FoundedDate" > @__value_0 OR b."Id" > @__value_1)
+                ORDER BY b."FoundedDate" IS NULL, b."FoundedDate", b."Id"
+                LIMIT @__p_2
                 ---------------
 
                 """);
@@ -400,7 +548,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Dynamova'
                 -- @__value_1='4'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -408,11 +556,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 1 AND (b0."Name" > @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" > @__value_1))
+                        WHERE b0."GroupId" = 1 AND b0."Name" >= @__value_0 AND (b0."Name" > @__value_0 OR b0."Id" > @__value_1)
                     ) AS b2
                     WHERE 2 < b2.row AND b2.row <= 5
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -475,9 +623,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='2'
                 -- @__p_3='3'
                 -- @__p_2='4'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+                WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
                 ORDER BY b."Name", b."Id"
                 LIMIT @__p_3 OFFSET @__p_2
                 ---------------
@@ -538,7 +686,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Brightex'
                 -- @__value_1='2'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -546,11 +694,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name", b0."Id") AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 1 AND (b0."Name" > @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" > @__value_1))
+                        WHERE b0."GroupId" = 1 AND b0."Name" >= @__value_0 AND (b0."Name" > @__value_0 OR b0."Id" > @__value_1)
                     ) AS b2
                     WHERE 4 < b2.row AND b2.row <= 7
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -616,9 +764,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_0='Synerflux'
                 -- @__value_1='19'
                 -- @__p_2='3'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+                WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
                 ORDER BY b."Name" DESC, b."Id" DESC
                 LIMIT @__p_2
                 ---------------
@@ -683,7 +831,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Synerflux'
                 -- @__value_1='19'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -691,11 +839,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 2 AND (b0."Name" < @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" < @__value_1))
+                        WHERE b0."GroupId" = 2 AND b0."Name" <= @__value_0 AND (b0."Name" < @__value_0 OR b0."Id" < @__value_1)
                     ) AS b2
                     WHERE b2.row <= 3
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -762,9 +910,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='19'
                 -- @__p_3='3'
                 -- @__p_2='2'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+                WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
                 ORDER BY b."Name" DESC, b."Id" DESC
                 LIMIT @__p_3 OFFSET @__p_2
                 ---------------
@@ -829,7 +977,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Synerflux'
                 -- @__value_1='19'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -837,11 +985,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 2 AND (b0."Name" < @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" < @__value_1))
+                        WHERE b0."GroupId" = 2 AND b0."Name" <= @__value_0 AND (b0."Name" < @__value_0 OR b0."Id" < @__value_1)
                     ) AS b2
                     WHERE 2 < b2.row AND b2.row <= 5
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -911,9 +1059,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='19'
                 -- @__p_3='3'
                 -- @__p_2='4'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+                WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
                 ORDER BY b."Name" DESC, b."Id" DESC
                 LIMIT @__p_3 OFFSET @__p_2
                 ---------------
@@ -981,7 +1129,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Synerflux'
                 -- @__value_1='19'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -989,11 +1137,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 2 AND (b0."Name" < @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" < @__value_1))
+                        WHERE b0."GroupId" = 2 AND b0."Name" <= @__value_0 AND (b0."Name" < @__value_0 OR b0."Id" < @__value_1)
                     ) AS b2
                     WHERE 4 < b2.row AND b2.row <= 7
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -1065,9 +1213,9 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 -- @__value_1='17'
                 -- @__p_3='3'
                 -- @__p_2='2'
-                SELECT b."Id", b."GroupId", b."Name"
+                SELECT b."Id", b."DisplayName", b."FoundedDate", b."GroupId", b."IsActive", b."Name"
                 FROM "Brands" AS b
-                WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+                WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
                 ORDER BY b."Name" DESC, b."Id" DESC
                 LIMIT @__p_3 OFFSET @__p_2
                 ---------------
@@ -1137,7 +1285,7 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                 ---------------
                 -- @__value_0='Quantumis'
                 -- @__value_1='17'
-                SELECT b1."GroupId", b3."Id", b3."GroupId", b3."Name"
+                SELECT b1."GroupId", b3."Id", b3."DisplayName", b3."FoundedDate", b3."GroupId", b3."IsActive", b3."Name"
                 FROM (
                     SELECT b."GroupId"
                     FROM "Brands" AS b
@@ -1145,11 +1293,11 @@ public class RelativeCursorTests(PostgreSqlResource resource)
                     GROUP BY b."GroupId"
                 ) AS b1
                 LEFT JOIN (
-                    SELECT b2."Id", b2."GroupId", b2."Name"
+                    SELECT b2."Id", b2."DisplayName", b2."FoundedDate", b2."GroupId", b2."IsActive", b2."Name"
                     FROM (
-                        SELECT b0."Id", b0."GroupId", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
+                        SELECT b0."Id", b0."DisplayName", b0."FoundedDate", b0."GroupId", b0."IsActive", b0."Name", ROW_NUMBER() OVER(PARTITION BY b0."GroupId" ORDER BY b0."Name" DESC, b0."Id" DESC) AS row
                         FROM "Brands" AS b0
-                        WHERE b0."GroupId" = 2 AND (b0."Name" < @__value_0 OR (b0."Name" = @__value_0 AND b0."Id" < @__value_1))
+                        WHERE b0."GroupId" = 2 AND b0."Name" <= @__value_0 AND (b0."Name" < @__value_0 OR b0."Id" < @__value_1)
                     ) AS b2
                     WHERE 2 < b2.row AND b2.row <= 5
                 ) AS b3 ON b1."GroupId" = b3."GroupId"
@@ -1222,6 +1370,33 @@ public class RelativeCursorTests(PostgreSqlResource resource)
         await Assert.ThrowsAsync<ArgumentException>(Error);
     }
 
+    [Fact]
+    public async Task Nullable_Fallback_Cursor()
+    {
+        // Arrange
+
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+
+        await using var context = new TestContext(connectionString);
+        var arguments = new PagingArguments(2) { EnableRelativeCursors = true };
+        var first = await context.Brands.OrderBy(t => t.FoundedDate).ToPageAsync(arguments);
+
+        // Act
+
+        arguments = arguments with { After = first.CreateCursor(first.Last!, 1) };
+
+        async Task Error()
+        {
+            await using var ctx = new TestContext(connectionString);
+            await ctx.Brands.OrderBy(t => t.FoundedDate).ToPageAsync(arguments);
+        }
+
+        // Assert
+
+        await Assert.ThrowsAsync<ArgumentException>(Error);
+    }
+
     private static async Task SeedAsync(string connectionString)
     {
         await using var context = new TestContext(connectionString);
@@ -1250,27 +1425,27 @@ public class RelativeCursorTests(PostgreSqlResource resource)
         20. Vertexis
         */
 
-        context.Brands.Add(new Brand { Name = "Aetherix", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Brightex", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Celestara", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Dynamova", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Evolvance", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Futurova", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Glacient", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Hyperionix", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Innovexa", GroupId = 1 });
-        context.Brands.Add(new Brand { Name = "Joventra", GroupId = 1 });
+        context.Brands.Add(new Brand { Name = "Aetherix", GroupId = 1, DisplayName = "Aetherix" });
+        context.Brands.Add(new Brand { Name = "Brightex", GroupId = 1, DisplayName = "Brightex", IsActive = false });
+        context.Brands.Add(new Brand { Name = "Celestara", GroupId = 1, DisplayName = "Celestara", IsActive = true });
+        context.Brands.Add(new Brand { Name = "Dynamova", GroupId = 1, DisplayName = "Dynamova", IsActive = true, FoundedDate = new DateOnly(2025, 1, 1) });
+        context.Brands.Add(new Brand { Name = "Evolvance", GroupId = 1, DisplayName = "Evolvance", IsActive = true, FoundedDate = new DateOnly(2025, 1, 2) });
+        context.Brands.Add(new Brand { Name = "Futurova", GroupId = 1, DisplayName = "Futurova", IsActive = true, FoundedDate = new DateOnly(2025, 1, 3) });
+        context.Brands.Add(new Brand { Name = "Glacient", GroupId = 1, DisplayName = "Glacient", IsActive = true, FoundedDate = new DateOnly(2025, 1, 4) });
+        context.Brands.Add(new Brand { Name = "Hyperionix", GroupId = 1, DisplayName = "Hyperionix", IsActive = true, FoundedDate = new DateOnly(2025, 1, 5) });
+        context.Brands.Add(new Brand { Name = "Innovexa", GroupId = 1, DisplayName = "Innovexa", IsActive = true, FoundedDate = new DateOnly(2025, 1, 6) });
+        context.Brands.Add(new Brand { Name = "Joventra", GroupId = 1, DisplayName = "Joventra", IsActive = true, FoundedDate = new DateOnly(2025, 1, 7) });
 
-        context.Brands.Add(new Brand { Name = "Kinetiq", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Luminara", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Momentumix", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Nebularis", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Omniflex", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Pulsarix", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Quantumis", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Radiantum", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Synerflux", GroupId = 2 });
-        context.Brands.Add(new Brand { Name = "Vertexis", GroupId = 2 });
+        context.Brands.Add(new Brand { Name = "Kinetiq", GroupId = 2, DisplayName = "Kinetiq" });
+        context.Brands.Add(new Brand { Name = "Luminara", GroupId = 2, DisplayName = "Luminara", IsActive = false });
+        context.Brands.Add(new Brand { Name = "Momentumix", GroupId = 2, DisplayName = "Momentumix", IsActive = true });
+        context.Brands.Add(new Brand { Name = "Nebularis", GroupId = 2, DisplayName = "Nebularis", IsActive = true, FoundedDate = new DateOnly(2025, 1, 8) });
+        context.Brands.Add(new Brand { Name = "Omniflex", GroupId = 2, DisplayName = "Omniflex", IsActive = true, FoundedDate = new DateOnly(2025, 1, 9) });
+        context.Brands.Add(new Brand { Name = "Pulsarix", GroupId = 2, DisplayName = "Pulsarix", IsActive = true, FoundedDate = new DateOnly(2025, 1, 10) });
+        context.Brands.Add(new Brand { Name = "Quantumis", GroupId = 2, DisplayName = "Quantumis", IsActive = true, FoundedDate = new DateOnly(2025, 1, 11) });
+        context.Brands.Add(new Brand { Name = "Radiantum", GroupId = 2, DisplayName = "Radiantum", IsActive = true, FoundedDate = new DateOnly(2025, 1, 12) });
+        context.Brands.Add(new Brand { Name = "Synerflux", GroupId = 2, DisplayName = "Synerflux", IsActive = true, FoundedDate = new DateOnly(2025, 1, 13) });
+        context.Brands.Add(new Brand { Name = "Vertexis", GroupId = 2, DisplayName = "Vertexis", IsActive = true, FoundedDate = new DateOnly(2025, 1, 14) });
 
         await context.SaveChangesAsync();
     }
@@ -1292,6 +1467,12 @@ public class RelativeCursorTests(PostgreSqlResource resource)
         public int Id { get; set; }
 
         [MaxLength(100)] public required string Name { get; set; }
+
+        public string? DisplayName { get; set; } = default!;
+
+        public bool? IsActive { get; set; }
+
+        public DateOnly? FoundedDate { get; set; }
     }
 }
 #endif

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_After_Id_13.md
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_After_Id_13.md
@@ -8,7 +8,7 @@
 -- @__p_2='6'
 SELECT b."Id", b."AlwaysNull", b."DisplayName", b."Name", b."BrandDetails_Country_Name"
 FROM "Brands" AS b
-WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
 ORDER BY b."Name", b."Id"
 LIMIT @__p_2
 ```
@@ -16,7 +16,7 @@ LIMIT @__p_2
 ## Expression 0
 
 ```text
-[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderBy(t => t.Name).ThenBy(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) > 0) OrElse ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) == 0) AndAlso (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) > 0)))).Take(6)
+[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderBy(t => t.Name).ThenBy(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) >= 0) AndAlso ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) > 0) OrElse (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) > 0)))).Take(6)
 ```
 
 ## Result 3

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_After_Id_13_NET8_0.md
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_After_Id_13_NET8_0.md
@@ -8,7 +8,7 @@
 -- @__p_2='6'
 SELECT b."Id", b."AlwaysNull", b."DisplayName", b."Name", b."BrandDetails_Country_Name"
 FROM "Brands" AS b
-WHERE b."Name" > @__value_0 OR (b."Name" = @__value_0 AND b."Id" > @__value_1)
+WHERE b."Name" >= @__value_0 AND (b."Name" > @__value_0 OR b."Id" > @__value_1)
 ORDER BY b."Name", b."Id"
 LIMIT @__p_2
 ```
@@ -16,7 +16,7 @@ LIMIT @__p_2
 ## Expression 0
 
 ```text
-[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderBy(t => t.Name).ThenBy(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) > 0) OrElse ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) == 0) AndAlso (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) > 0)))).Take(6)
+[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderBy(t => t.Name).ThenBy(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) >= 0) AndAlso ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) > 0) OrElse (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) > 0)))).Take(6)
 ```
 
 ## Result 3

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_Before_Id_96.md
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_Before_Id_96.md
@@ -8,7 +8,7 @@
 -- @__p_2='6'
 SELECT b."Id", b."AlwaysNull", b."DisplayName", b."Name", b."BrandDetails_Country_Name"
 FROM "Brands" AS b
-WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
 ORDER BY b."Name" DESC, b."Id" DESC
 LIMIT @__p_2
 ```
@@ -16,7 +16,7 @@ LIMIT @__p_2
 ## Expression 0
 
 ```text
-[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderByDescending(t => t.Name).ThenByDescending(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) < 0) OrElse ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) == 0) AndAlso (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) < 0)))).Take(6)
+[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderByDescending(t => t.Name).ThenByDescending(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) <= 0) AndAlso ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) < 0) OrElse (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) < 0)))).Take(6)
 ```
 
 ## Result 3

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_Before_Id_96_NET8_0.md
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/__snapshots__/IntegrationPagingHelperTests.Paging_First_5_Before_Id_96_NET8_0.md
@@ -8,7 +8,7 @@
 -- @__p_2='6'
 SELECT b."Id", b."AlwaysNull", b."DisplayName", b."Name", b."BrandDetails_Country_Name"
 FROM "Brands" AS b
-WHERE b."Name" < @__value_0 OR (b."Name" = @__value_0 AND b."Id" < @__value_1)
+WHERE b."Name" <= @__value_0 AND (b."Name" < @__value_0 OR b."Id" < @__value_1)
 ORDER BY b."Name" DESC, b."Id" DESC
 LIMIT @__p_2
 ```
@@ -16,7 +16,7 @@ LIMIT @__p_2
 ## Expression 0
 
 ```text
-[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderByDescending(t => t.Name).ThenByDescending(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) < 0) OrElse ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) == 0) AndAlso (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) < 0)))).Take(6)
+[Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression].OrderByDescending(t => t.Name).ThenByDescending(t => t.Id).Where(t => ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) <= 0) AndAlso ((t.Name.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.String]).value) < 0) OrElse (t.Id.CompareTo(value(GreenDonut.Data.Expressions.ExpressionHelpers+<>c__DisplayClass6_0`1[System.Int32]).value) < 0)))).Take(6)
 ```
 
 ## Result 3


### PR DESCRIPTION
The idea of how to implement relative cursors that can handle nullable types originated from [here](https://stackoverflow.com/questions/68971695/cursor-pagination-prev-next-with-null-values).

I've added the implementation. It works in the sense that all original tests still succeed, except for one. `Fetch_Second_Page_Order_By_FoundedDate` intentionally fails to highlight a flaw in the implementation. The algorithm expects NULL values to be smaller than any other value when ordering. However, this can be solved by adding an extra order condition for nullable keys, like:

```
OrderBy(t => t.FoundedDate == null).ThenBy(t => t.FoundedDate)
```

I'm planning to add this extra ORDER BY condition before any nullable cursor key, but that hasn't been implemented yet.


