### PR TITLE
[Fusion] Added support for shorthand `SelectedObjectField` in validator

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Validators/FieldSelectionMapValidator.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Validators/FieldSelectionMapValidator.cs
@@ -286,6 +286,23 @@ public sealed class FieldSelectionMapValidator(MutableSchemaDefinition schema)
             context.InputTypes.Push(currentInputType);
         }
 
+        if (node.SelectedValue is null
+            && context.OutputTypes.Peek() is MutableComplexTypeDefinition complexType)
+        {
+            if (!complexType.Fields.TryGetField(node.Name.Value, out var field))
+            {
+                context.Errors.Add(
+                    string.Format(
+                        FieldSelectionMapValidator_FieldDoesNotExistOnType,
+                        node.Name,
+                        complexType.Name));
+
+                return Skip;
+            }
+
+            context.SelectedFields.Add(field);
+        }
+
         return Continue;
     }
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Utilities.Tests/Validators/FieldSelectionMapValidatorTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Utilities.Tests/Validators/FieldSelectionMapValidatorTests.cs
@@ -268,6 +268,7 @@ public sealed class FieldSelectionMapValidatorTests
             { "FindMediaInput", "Media", "{ bookId: <Book>.id } | { movieId: <Movie>.id }" },
             { "Nested", "Media", "{ nested: { bookId: <Book>.id } | { movieId: <Movie>.id } }" },
             // Other tests.
+            { "String", "Book", "{ id title }" },
             { "ID", "Query", "mediaById<Book>.author.id | mediaById<Movie>.id" },
             { "ID", "Media", "{ bookId: <Book>.author.id } | { movieId: <Movie>.id }" }
         };
@@ -319,6 +320,15 @@ public sealed class FieldSelectionMapValidatorTests
             // TODO: 6.3.6 Selected Object Field Uniqueness examples.
             // Blocked by https://github.com/graphql/composite-schemas-spec/issues/171.
             // Additional tests.
+            {
+                "String",
+                "Book",
+                "{ id unknownField1 unknownField2 }",
+                [
+                    "The field 'unknownField1' does not exist on the type 'Book'.",
+                    "The field 'unknownField2' does not exist on the type 'Book'."
+                ]
+            },
             {
                 "ID",
                 "Media",


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Added support for shorthand `SelectedObjectField` in validator.