### PR TITLE
[Fusion] Add SubgraphRequestError diagnostic event

### DIFF
--- a/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/AggregateFusionDiagnosticEvents.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/AggregateFusionDiagnosticEvents.cs
@@ -41,6 +41,14 @@ internal sealed class AggregateFusionDiagnosticEvents(IFusionDiagnosticEventList
         }
     }
 
+    public void SubgraphRequestError(string subgraphName, Exception exception)
+    {
+        for (var i = 0; i < listeners.Length; i++)
+        {
+            listeners[i].SubgraphRequestError(subgraphName, exception);
+        }
+    }
+
     private sealed class AggregateActivityScope(IDisposable[] scopes) : IDisposable
     {
         private bool _disposed;

--- a/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/FusionDiagnosticEventListener.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/FusionDiagnosticEventListener.cs
@@ -34,6 +34,11 @@ public class FusionDiagnosticEventListener : IFusionDiagnosticEventListener
     {
     }
 
+    /// <inheritdoc />
+    public virtual void SubgraphRequestError(string subgraphName, Exception exception)
+    {
+    }
+
     private sealed class EmptyActivityScope : IDisposable
     {
         public void Dispose()

--- a/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/IFusionDiagnosticEvents.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/IFusionDiagnosticEvents.cs
@@ -39,4 +39,15 @@ public interface IFusionDiagnosticEvents
     /// The exception that occurred while executing a ResolveByKeyBatch QueryPlan node.
     /// </param>
     void ResolveByKeyBatchError(Exception exception);
+
+    /// <summary>
+    /// Called when an exception occurred during the request to a subgraph service.
+    /// </summary>
+    /// <param name="subgraphName">
+    /// The name of the subgraph the request was sent to.
+    /// </param>
+    /// <param name="exception">
+    /// The exception that occurred during the request to a subgraph service.
+    /// </param>
+    void SubgraphRequestError(string subgraphName, Exception exception);
 }

--- a/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/NoopFusionDiagnosticEvents.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Diagnostic/NoopFusionDiagnosticEvents.cs
@@ -19,6 +19,10 @@ internal sealed class NoopFusionDiagnosticEvents : IFusionDiagnosticEvents, IDis
     {
     }
 
+    public void SubgraphRequestError(string subgraphName, Exception exception)
+    {
+    }
+
     public void Dispose()
     {
     }

--- a/src/HotChocolate/Fusion/src/Core/Execution/Nodes/Resolve.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Nodes/Resolve.cs
@@ -150,6 +150,10 @@ internal sealed class Resolve(int id, Config config) : ResolverNodeBase(id, conf
 
             if (response.TransportException is not null)
             {
+                context.DiagnosticEvents.SubgraphRequestError(
+                    subgraphName,
+                    response.TransportException);
+
                 CreateTransportErrors(
                     response.TransportException,
                     context.Result,

--- a/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveByKeyBatch.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveByKeyBatch.cs
@@ -153,6 +153,8 @@ internal sealed class ResolveByKeyBatch : ResolverNodeBase
 
         if (response.TransportException is not null)
         {
+            context.DiagnosticEvents.SubgraphRequestError(subgraphName, response.TransportException);
+
             foreach (var state in batchExecutionState)
             {
                 CreateTransportErrors(

--- a/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveNode.cs
+++ b/src/HotChocolate/Fusion/src/Core/Execution/Nodes/ResolveNode.cs
@@ -69,9 +69,9 @@ internal sealed class ResolveNode(int id, Selection selection) : QueryPlanNode(i
         {
             typeName = context.ParseTypeNameFromId(formattedId.Value);
         }
-        catch (IdSerializationException ex)
+        catch (Exception exception)
         {
-            context.Result.AddError(InvalidNodeFormat(_selection, ex), _selection);
+            context.Result.AddError(InvalidNodeFormat(_selection, exception), _selection);
             return;
         }
 


### PR DESCRIPTION
- Adds a new `SubgraphRequestError` diagnostic event, so HTTP request failures to subgraphs can be logged separately
- Catch all exceptions when parsing typename from Id in `ResolveNode` query plan node
  - While examining our logs I noticed some `IndexOutOfRangeException`s that were wrongly thrown and counted as query plan errors