### PR TITLE
[Core] Added empty cursor string validation

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/IndexCursor.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/IndexCursor.cs
@@ -18,6 +18,12 @@ internal static class IndexCursor
 
     public static unsafe bool TryParse(string cursor, out int index)
     {
+        if (string.IsNullOrWhiteSpace(cursor))
+        {
+            index = -1;
+            return false;
+        }
+
         fixed (char* cPtr = cursor)
         {
             var count = _utf8.GetByteCount(cPtr, cursor.Length);

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
@@ -983,6 +983,30 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task Invalid_EmptyString_After_Index_Cursor()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<QueryType>()
+            .Services.BuildServiceProvider()
+            .GetRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              letters(first: 2 after: "") {
+                  edges {
+                      cursor
+                  }
+              }
+            }
+            """
+        );
+
+        result.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task Invalid_Before_Index_Cursor()
     {
         var executor =
@@ -997,6 +1021,31 @@ public class IntegrationTests
             """
             {
               letters(first: 2 before: "INVALID") {
+                  edges {
+                      cursor
+                  }
+              }
+            }
+            """);
+
+        result.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Invalid_EmptyString_Before_Index_Cursor()
+    {
+        var executor =
+            await new ServiceCollection()
+                .AddGraphQL()
+                .AddQueryType<QueryType>()
+                .Services
+                .BuildServiceProvider()
+                .GetRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              letters(first: 2 before: "") {
                   edges {
                       cursor
                   }

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.Invalid_EmptyString_After_Index_Cursor.snap
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.Invalid_EmptyString_After_Index_Cursor.snap
@@ -1,0 +1,24 @@
+{
+  "errors": [
+    {
+      "message": "The cursor specified in `after` has an invalid format.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "letters"
+      ],
+      "extensions": {
+        "argument": "after",
+        "cursor": "",
+        "code": "HC0078"
+      }
+    }
+  ],
+  "data": {
+    "letters": null
+  }
+}

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.Invalid_EmptyString_Before_Index_Cursor.snap
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/__snapshots__/IntegrationTests.Invalid_EmptyString_Before_Index_Cursor.snap
@@ -1,0 +1,24 @@
+{
+  "errors": [
+    {
+      "message": "The cursor specified in `before` has an invalid format.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "letters"
+      ],
+      "extensions": {
+        "argument": "before",
+        "cursor": "",
+        "code": "HC0078"
+      }
+    }
+  ],
+  "data": {
+    "letters": null
+  }
+}


### PR DESCRIPTION
# Current state

When user specifies an empty string as either _after_ of _before_ in cursor pagination, the code throws  ArgumentNullException when trying to parse it.

# Implementation

Added simple check in IndexCursor to gracefully fail the parsing when cursor is an empty string causing the correct error code to be returned instead of Unexpected execution error.
