### PR TITLE
[Fusion] Excluded built-in source schema scalar types from being merged

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/FusionBuiltIns.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/FusionBuiltIns.cs
@@ -1,0 +1,15 @@
+using static HotChocolate.Fusion.WellKnownTypeNames;
+
+namespace HotChocolate.Fusion;
+
+internal static class FusionBuiltIns
+{
+    public static bool IsBuiltInSourceSchemaScalar(string typeName)
+    {
+        return typeName switch
+        {
+            FieldSelectionMap or FieldSelectionSet => true,
+            _ => false
+        };
+    }
+}

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -574,12 +574,19 @@ internal sealed class SourceSchemaMerger
     /// <seealso href="https://graphql.github.io/composite-schemas-spec/draft/#sec-Merge-Scalar-Types">
     /// Specification
     /// </seealso>
-    private MutableScalarTypeDefinition MergeScalarTypes(
+    private MutableScalarTypeDefinition? MergeScalarTypes(
         ImmutableArray<TypeInfo> typeGroup,
         MutableSchemaDefinition mergedSchema)
     {
         var firstScalar = typeGroup[0].Type;
         var typeName = firstScalar.Name;
+
+        // Built-in Fusion scalar types should not be merged.
+        if (FusionBuiltIns.IsBuiltInSourceSchemaScalar(typeName))
+        {
+            return null;
+        }
+
         var description = firstScalar.Description;
         var scalarType = GetOrCreateType<MutableScalarTypeDefinition>(mergedSchema, typeName);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
@@ -107,6 +107,17 @@ public sealed class SourceSchemaMergerScalarTests
                     @fusion__type(schema: A)
                     @fusion__type(schema: B)
                 """
+            },
+            // Built-in Fusion scalar types should not be merged (FieldSelectionSet/Map).
+            {
+                [
+                    """
+                    # Schema A
+                    directive @provides(fields: FieldSelectionSet!) on FIELD_DEFINITION
+                    directive @require(field: FieldSelectionMap!) on ARGUMENT_DEFINITION
+                    """
+                ],
+                ""
             }
         };
     }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Excluded built-in source schema scalar types from being merged.