### PR TITLE
[Fusion] Avoid writing log entries as GraphQL comments when unnecessary

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/Commands/ComposeCommand.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/Commands/ComposeCommand.cs
@@ -3,8 +3,6 @@ using System.CommandLine;
 using System.CommandLine.IO;
 using System.Text;
 using HotChocolate.Fusion.Logging;
-using HotChocolate.Fusion.Results;
-using HotChocolate.Types.Mutable;
 using static HotChocolate.Fusion.Properties.CommandLineResources;
 
 namespace HotChocolate.Fusion.Commands;
@@ -97,7 +95,10 @@ internal sealed class ComposeCommand : Command
 
         var result = schemaComposer.Compose();
 
-        WriteCompositionLog(compositionLog, console, result);
+        WriteCompositionLog(
+            compositionLog,
+            writer: result.IsSuccess ? console.Out : console.Error,
+            writeAsGraphQLComments: result.IsSuccess && compositeSchemaFile is null);
 
         if (result.IsFailure)
         {
@@ -138,11 +139,10 @@ internal sealed class ComposeCommand : Command
 
     private static void WriteCompositionLog(
         CompositionLog compositionLog,
-        IConsole console,
-        CompositionResult<MutableSchemaDefinition> result)
+        IStandardStreamWriter writer,
+        bool writeAsGraphQLComments)
     {
         Console.OutputEncoding = Encoding.UTF8;
-        var writer = result.IsSuccess ? console.Out : console.Error;
 
         foreach (var entry in compositionLog)
         {
@@ -164,8 +164,7 @@ internal sealed class ComposeCommand : Command
 
             var message = $"{emoji} [{abbreviatedSeverity}] {entry.Message} ({entry.Code})";
 
-            // When the composition is successful, write log entries as GraphQL comments.
-            if (result.IsSuccess)
+            if (writeAsGraphQLComments)
             {
                 message = $"# {message}";
             }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Avoid writing log entries as GraphQL comments when unnecessary.