### PR TITLE
[Fusion] Removed unreferenced types from the merged schema

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Options/SourceSchemaMergerOptions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Options/SourceSchemaMergerOptions.cs
@@ -2,5 +2,7 @@ namespace HotChocolate.Fusion.Options;
 
 internal sealed class SourceSchemaMergerOptions
 {
+    public bool RemoveUnreferencedTypes { get; init; } = true;
+
     public bool AddFusionDefinitions { get; init; } = true;
 }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/SourceSchemaMerger.cs
@@ -67,6 +67,11 @@ internal sealed class SourceSchemaMerger
 
         SetOperationTypes(mergedSchema);
 
+        if (_options.RemoveUnreferencedTypes)
+        {
+            mergedSchema.RemoveUnreferencedTypes();
+        }
+
         // Add lookup directives.
         foreach (var schema in _schemas)
         {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Extensions/MutableSchemaDefinitionExtensions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Utilities/Extensions/MutableSchemaDefinitionExtensions.cs
@@ -1,0 +1,122 @@
+using HotChocolate.Types;
+using HotChocolate.Types.Mutable;
+
+namespace HotChocolate.Fusion.Extensions;
+
+public static class MutableSchemaDefinitionExtensions
+{
+    public static void RemoveUnreferencedTypes(this MutableSchemaDefinition schema)
+    {
+        var touchedTypes = new HashSet<ITypeDefinition>();
+        var backlog = new Stack<ITypeDefinition>();
+
+        if (schema.QueryType is not null)
+        {
+            backlog.Push(schema.QueryType);
+        }
+
+        if (schema.MutationType is not null)
+        {
+            backlog.Push(schema.MutationType);
+        }
+
+        if (schema.SubscriptionType is not null)
+        {
+            backlog.Push(schema.SubscriptionType);
+        }
+
+        while (backlog.TryPop(out var type))
+        {
+            if (!touchedTypes.Add(type)
+                || type.Kind == TypeKind.Scalar
+                || type.Kind == TypeKind.Enum)
+            {
+                continue;
+            }
+
+            switch (type)
+            {
+                case IComplexTypeDefinition complexType:
+                    InspectComplexType(schema, complexType, backlog);
+                    break;
+
+                case IInputObjectTypeDefinition inputObjectType:
+                    InspectInputObjectType(inputObjectType, backlog);
+                    break;
+
+                case IUnionTypeDefinition unionType:
+                    InspectUnionType(unionType, backlog);
+                    break;
+            }
+        }
+
+        var typesToRemove = new HashSet<ITypeDefinition>();
+        foreach (var type in schema.Types)
+        {
+            if (touchedTypes.Contains(type))
+            {
+                continue;
+            }
+
+            typesToRemove.Add(type);
+        }
+
+        if (typesToRemove.Count > 0)
+        {
+            foreach (var type in typesToRemove)
+            {
+                schema.Types.Remove(type);
+            }
+        }
+    }
+
+    private static void InspectComplexType(
+        ISchemaDefinition schema,
+        IComplexTypeDefinition complexType,
+        Stack<ITypeDefinition> backlog)
+    {
+        foreach (var @interface in complexType.Implements)
+        {
+            backlog.Push(@interface);
+        }
+
+        foreach (var field in complexType.Fields)
+        {
+            var returnType = field.Type.AsTypeDefinition();
+            backlog.Push(returnType);
+
+            if (returnType is IInterfaceTypeDefinition or IUnionTypeDefinition)
+            {
+                foreach (var possibleType in schema.GetPossibleTypes(returnType))
+                {
+                    backlog.Push(possibleType);
+                }
+            }
+
+            foreach (var argument in field.Arguments)
+            {
+                backlog.Push(argument.Type.AsTypeDefinition());
+            }
+        }
+    }
+
+    private static void InspectInputObjectType(
+        IInputObjectTypeDefinition inputObjectType,
+        Stack<ITypeDefinition> backlog)
+    {
+        foreach (var field in inputObjectType.Fields)
+        {
+            backlog.Push(field.Type.AsTypeDefinition());
+        }
+    }
+
+    private static void InspectUnionType(
+        IUnionTypeDefinition unionType,
+        Stack<ITypeDefinition> backlog)
+    {
+        foreach (var member in unionType.Types)
+        {
+            backlog.Push(member);
+        }
+    }
+}

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedEnumTypeRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedEnumTypeRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EmptyMergedEnumTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EmptyMergedEnumTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedInputObjectTypeRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedInputObjectTypeRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EmptyMergedInputObjectTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EmptyMergedInputObjectTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedInterfaceTypeRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedInterfaceTypeRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EmptyMergedInterfaceTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EmptyMergedInterfaceTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedObjectTypeRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedObjectTypeRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EmptyMergedObjectTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EmptyMergedObjectTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedUnionTypeRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EmptyMergedUnionTypeRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EmptyMergedUnionTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EmptyMergedUnionTypeRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EnumTypeDefaultValueInaccessibleRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/EnumTypeDefaultValueInaccessibleRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class EnumTypeDefaultValueInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class EnumTypeDefaultValueInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/ImplementedByInaccessibleRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/ImplementedByInaccessibleRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class ImplementedByInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class ImplementedByInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/InterfaceFieldNoImplementationRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/InterfaceFieldNoImplementationRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class InterfaceFieldNoImplementationRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class InterfaceFieldNoImplementationRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/IsInvalidFieldRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/IsInvalidFieldRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class IsInvalidFieldRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class IsInvalidFieldRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/NoQueriesRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/NoQueriesRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class NoQueriesRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class NoQueriesRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/NonNullInputFieldIsInaccessibleRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/NonNullInputFieldIsInaccessibleRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class NonNullInputFieldIsInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class NonNullInputFieldIsInaccessibleRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/RequireInvalidFieldsRuleTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/PostMergeValidationRules/RequireInvalidFieldsRuleTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using HotChocolate.Fusion.Logging;
+using HotChocolate.Fusion.Options;
 using static HotChocolate.Fusion.CompositionTestHelper;
 
 namespace HotChocolate.Fusion.PostMergeValidationRules;
@@ -16,7 +17,9 @@ public sealed class RequireInvalidFieldsRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 
@@ -34,7 +37,9 @@ public sealed class RequireInvalidFieldsRuleTests
     {
         // arrange
         var schemas = CreateSchemaDefinitions(sdl);
-        var merger = new SourceSchemaMerger(schemas);
+        var merger = new SourceSchemaMerger(
+            schemas,
+            new SourceSchemaMergerOptions { RemoveUnreferencedTypes = false });
         var mergeResult = merger.Merge();
         var validator = new PostMergeValidator(mergeResult.Value, s_rules, schemas, _log);
 

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Argument.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Argument.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerArgumentTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Enum.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Enum.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerEnumTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.EnumValue.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.EnumValue.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerEnumValueTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputField.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputField.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerInputFieldTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputObject.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.InputObject.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerInputObjectTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Interface.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Interface.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerInterfaceTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Object.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Object.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerObjectTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.OutputField.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.OutputField.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerOutputFieldTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Scalar.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerScalarTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Composition.Tests/SourceSchemaMerger.Union.Tests.cs
@@ -13,7 +13,11 @@ public sealed class SourceSchemaMergerUnionTests
         // arrange
         var merger = new SourceSchemaMerger(
             CreateSchemaDefinitions(sdl),
-            new SourceSchemaMergerOptions { AddFusionDefinitions = false });
+            new SourceSchemaMergerOptions
+            {
+                RemoveUnreferencedTypes = false,
+                AddFusionDefinitions = false
+            });
 
         // act
         var result = merger.Merge();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- [Fusion] Removed unreferenced types from the merged schema.