### PR TITLE
Fixed calculation of totalPages in CreateRelativeForwardCursors method

### DIFF
--- a/src/GreenDonut/src/GreenDonut.Data/Extensions/GreenDonutPageExtensions.cs
+++ b/src/GreenDonut/src/GreenDonut.Data/Extensions/GreenDonutPageExtensions.cs
@@ -112,7 +112,7 @@ public static class GreenDonutPageExtensions
             return [];
         }
 
-        var totalPages = (page.TotalCount ?? 0) / (page.RequestedSize ?? 10);
+        var totalPages = Math.Ceiling((double)(page.TotalCount ?? 0) / (page.RequestedSize ?? 10));
 
         if (page.Index >= totalPages)
         {

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/RelativeCursorTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/RelativeCursorTests.cs
@@ -1222,6 +1222,23 @@ public class RelativeCursorTests(PostgreSqlResource resource)
         await Assert.ThrowsAsync<ArgumentException>(Error);
     }
 
+    [Fact]
+    public async Task RequestedSize_Not_Evenly_Divisible_By_TotalCount()
+    {
+        // Arrange
+        var connectionString = CreateConnectionString();
+        await SeedAsync(connectionString);
+        await using var context = new TestContext(connectionString);
+        var arguments = new PagingArguments(12) { EnableRelativeCursors = true };
+
+        // Act
+        var first = await context.Brands.OrderBy(t => t.Name).ThenBy(t => t.Id).ToPageAsync(arguments);
+
+        // Assert
+        Assert.Equal(20, first.TotalCount);
+        Assert.Single(first.CreateRelativeForwardCursors());
+    }
+
     private static async Task SeedAsync(string connectionString)
     {
         await using var context = new TestContext(connectionString);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed calculation of `totalPages` in `CreateRelativeForwardCursors` method.

Closes #8273