### PR TITLE
Disabled naming style warnings in WellKnownTypes class

### DIFF
--- a/src/HotChocolate/Core/src/Types.Shared/WellKnownTypes.cs
+++ b/src/HotChocolate/Core/src/Types.Shared/WellKnownTypes.cs
@@ -5,6 +5,7 @@ namespace HotChocolate.Utilities.Introspection;
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 internal static class WellKnownTypes
 {
+#pragma warning disable IDE1006 // Naming Styles
     public const string __Directive = "__Directive";
     public const string __DirectiveLocation = "__DirectiveLocation";
     public const string __EnumValue = "__EnumValue";
@@ -13,6 +14,7 @@ internal static class WellKnownTypes
     public const string __Schema = "__Schema";
     public const string __Type = "__Type";
     public const string __TypeKind = "__TypeKind";
+#pragma warning restore IDE1006 // Naming Styles
     public const string String = "String";
     public const string Boolean = "Boolean";
     public const string Float = "Float";


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Disabled naming style warnings in WellKnownTypes class.