### PR TITLE
Updated Roslynator (4.12.4 -> 4.13.1)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -142,8 +142,8 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'debug'">
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
-    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.4" />
-    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.12.4" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1" />
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.13.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated Roslynator (4.12.4 -> 4.13.1).