### PR TITLE
Added tests for schema keyword retention when description is present

### DIFF
--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
@@ -717,6 +717,35 @@ public class SchemaSyntaxPrinterTests
     }
 
     [Fact]
+    public void Serialize_SchemaDefWithDescriptionAndOps_SchemaKeywordNotOmitted()
+    {
+        // arrange
+        var schema =
+            """
+            "Example schema"
+            schema {
+                query: Query
+                mutation: Mutation
+            }
+
+            type Query {
+                someField: String
+            }
+
+            type Mutation {
+                someMutation: String
+            }
+            """;
+        var document = Utf8GraphQLParser.Parse(schema);
+
+        // act
+        var result = document.ToString();
+
+        // assert
+        result.MatchInlineSnapshot(schema);
+    }
+
+    [Fact]
     public void Serialize_SchemaDefWithOpNoIndent_OutHasIndentation()
     {
         // arrange

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaFormatterTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaFormatterTests.cs
@@ -293,4 +293,34 @@ public class SchemaFormatterTests
             }
             """);
     }
+
+    [Fact]
+    public void Format_Schema_With_Description_Schema_Keyword_Not_Omitted()
+    {
+        // arrange
+        var sdl =
+            """
+            "Example schema"
+            schema {
+                query: Query
+                mutation: Mutation
+            }
+
+            type Query {
+                someField: String
+            }
+
+            type Mutation {
+                someMutation: String
+            }
+            """;
+
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // act
+        var formattedSdl = SchemaFormatter.FormatAsString(schema);
+
+        // assert
+        formattedSdl.MatchInlineSnapshot(sdl);
+    }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added tests for schema keyword retention when description is present.

---

See https://github.com/graphql/graphql-spec/pull/1167.