### PR TITLE
Updated code to prefer concrete values over `default`

### DIFF
--- a/src/HotChocolate/Core/src/Execution.Abstractions/Execution/IRequestExecutorProvider.cs
+++ b/src/HotChocolate/Core/src/Execution.Abstractions/Execution/IRequestExecutorProvider.cs
@@ -3,6 +3,6 @@ namespace HotChocolate.Execution;
 public interface IRequestExecutorProvider
 {
     public ValueTask<IRequestExecutor> GetExecutorAsync(
-        string? schemaName = default,
+        string? schemaName = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/HotChocolate/Core/src/Execution/Processing/Result/ResultBuilder.Pooling.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Result/ResultBuilder.Pooling.cs
@@ -4,8 +4,8 @@ namespace HotChocolate.Execution.Processing;
 
 internal sealed partial class ResultBuilder
 {
-    private RequestContext _context = default!;
-    private IExecutionDiagnosticEvents _diagnosticEvents = default!;
+    private RequestContext _context = null!;
+    private IExecutionDiagnosticEvents _diagnosticEvents = null!;
 
     public ResultBuilder(ResultPool resultPool)
     {

--- a/src/HotChocolate/Core/src/Features/PooledFeatureCollection.cs
+++ b/src/HotChocolate/Core/src/Features/PooledFeatureCollection.cs
@@ -136,7 +136,7 @@ public sealed class PooledFeatureCollection : IFeatureCollection
     /// <param name="defaults">
     /// The defaults for the feature collection.
     /// </param>
-    public void Initialize(IFeatureCollection? defaults = default)
+    public void Initialize(IFeatureCollection? defaults = null)
     {
         _defaults = defaults;
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Updated code to prefer concrete values over `default`.