### PR TITLE
Used global using everywhere for Xunit

### DIFF
--- a/src/CookieCrumble/test/CookieCrumble.Tests/CookieCrumble.Tests.csproj
+++ b/src/CookieCrumble/test/CookieCrumble.Tests/CookieCrumble.Tests.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\..\src\CookieCrumble.Xunit\CookieCrumble.Xunit.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
 </Project>

--- a/src/CookieCrumble/test/CookieCrumble.Tests/Usings.cs
+++ b/src/CookieCrumble/test/CookieCrumble.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.Tests/Internal/ExpressionHasherTests.cs
@@ -1,5 +1,4 @@
 using System.Linq.Expressions;
-using Xunit;
 
 namespace GreenDonut.Data.Internal;
 

--- a/src/HotChocolate/Caching/test/Caching.Memory.Tests/CacheTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Memory.Tests/CacheTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Caching.Memory;
 
 public class CacheTests

--- a/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using Xunit;
 
 namespace HotChocolate.Caching.Tests;
 

--- a/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTypeTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/CacheControlDirectiveTypeTests.cs
@@ -1,6 +1,5 @@
 using HotChocolate.Language;
 using HotChocolate.Types;
-using Xunit;
 
 namespace HotChocolate.Caching.Tests;
 

--- a/src/HotChocolate/Caching/test/Caching.Tests/CacheControlTypeInterceptorTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/CacheControlTypeInterceptorTests.cs
@@ -3,7 +3,6 @@ using HotChocolate.Execution;
 using HotChocolate.Tests;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace HotChocolate.Caching.Tests;
 

--- a/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/HttpCachingTests.cs
@@ -2,7 +2,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace HotChocolate.Caching.Http.Tests;
 

--- a/src/HotChocolate/Caching/test/Caching.Tests/SchemaTests.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/SchemaTests.cs
@@ -1,7 +1,6 @@
 using HotChocolate.Execution;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace HotChocolate.Caching.Tests;
 

--- a/src/HotChocolate/Caching/test/Caching.Tests/ServerTestBase.cs
+++ b/src/HotChocolate/Caching/test/Caching.Tests/ServerTestBase.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace HotChocolate.Caching.Http.Tests;
 

--- a/src/HotChocolate/Caching/test/Directory.Build.props
+++ b/src/HotChocolate/Caching/test/Directory.Build.props
@@ -10,6 +10,7 @@
     <Using Include="CookieCrumble" />
     <Using Include="CookieCrumble.HotChocolate" />
     <Using Include="CookieCrumble.Xunit" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Execution/FetchResultTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Execution/FetchResultTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using HotChocolate.Fusion.Execution;
 using HotChocolate.Fusion.Types;
-using Xunit;
 
 namespace HotChocolate.Fusion.Execution;
 

--- a/src/HotChocolate/Language/test/Directory.Build.props
+++ b/src/HotChocolate/Language/test/Directory.Build.props
@@ -10,6 +10,7 @@
     <Using Include="CookieCrumble" />
     <Using Include="CookieCrumble.HotChocolate" />
     <Using Include="CookieCrumble.Xunit" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ArgumentNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ArgumentNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public sealed class ArgumentNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/BooleanValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/BooleanValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class BooleanValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class DirectiveDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DirectiveNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class DirectiveNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DocumentNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/DocumentNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class DocumentNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class EnumTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class EnumTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumValueDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumValueDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class EnumValueDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/EnumValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class EnumValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FieldDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FieldDefinitionNodeTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using static HotChocolate.Language.Utf8GraphQLParser.Syntax;
 
 namespace HotChocolate.Language.SyntaxTree;

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FieldNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FieldNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class FieldNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FloatValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FloatValueNodeTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language.SyntaxTree;
 

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class FragmentDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class FragmentSpreadNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InlineFragmentNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InlineFragmentNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InlineFragmentNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputObjectTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputObjectTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InputObjectTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputObjectTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputObjectTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InputObjectTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputValueDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InputValueDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InputValueDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/IntValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/IntValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class IntValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InterfaceTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InterfaceTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InterfaceTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InterfaceTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/InterfaceTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class InterfaceTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ListTypeNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ListTypeNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ListTypeNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ListValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ListValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ListValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NamedTypeNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NamedTypeNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class NamedTypeNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NonNullTypeNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NonNullTypeNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class NonNullTypeNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NullValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/NullValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class NullValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectFieldNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectFieldNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ObjectFieldNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ObjectTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ObjectTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ObjectValueNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ObjectValueNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/OperationDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/OperationDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class OperationDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/OperationTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/OperationTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class OperationTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ScalarTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ScalarTypeDefinitionNodeTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using static HotChocolate.Language.SyntaxTree.TestLocations;
 
 namespace HotChocolate.Language.SyntaxTree;

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ScalarTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/ScalarTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class ScalarTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaCoordinateNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaCoordinateNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class SchemaCoordinateNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaCoordinateTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaCoordinateTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class SchemaCoordinateTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class SchemaDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SchemaExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class SchemaExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SelectionSetNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/SelectionSetNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class SelectionSetNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/StringValueNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/StringValueNodeTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 using static HotChocolate.Language.SyntaxComparison;
 
 namespace HotChocolate.Language.SyntaxTree;

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Syntax.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Syntax.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public static class SyntaxEqualityComparerTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/UnionTypeDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/UnionTypeDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class UnionTypeDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/UnionTypeExtensionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/UnionTypeExtensionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class UnionTypeExtensionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/QuerySyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/QuerySyntaxPrinterTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree.Utilities;
 
 public class QuerySyntaxPrinterTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/Utilities/SchemaSyntaxPrinterTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree.Utilities;
 
 public class SchemaSyntaxPrinterTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableDefinitionNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class VariableDefinitionNodeTests

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/VariableNodeTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.SyntaxTree;
 
 public class VariableNodeTests

--- a/src/HotChocolate/Language/test/Language.Tests/GraphQLConstantsTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/GraphQLConstantsTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language;
 
 public class GraphQLConstantsTests

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/BlockStringHelperTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/BlockStringHelperTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/BlockStringTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/BlockStringTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/CommentTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/CommentTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/DirectiveParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ErrorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ErrorTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language;
 
 public class ErrorTests

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLParserSyntaxTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLParserSyntaxTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/GraphQLRequestParserTests.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 using Newtonsoft.Json;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/InterfaceTypeParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/InterfaceTypeParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/KitchenSinkParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/KitchenSinkParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 using static CookieCrumble.Formatters.SnapshotValueFormatters;
 
 namespace HotChocolate.Language;

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/NameTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/NameTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/NumberTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/NumberTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ParseUtf8SurrogatePairTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ParseUtf8SurrogatePairTests.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Newtonsoft.Json;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/PunctuatorTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/PunctuatorTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 using static CookieCrumble.Formatters.SnapshotValueFormatters;
 
 namespace HotChocolate.Language;

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/SchemaCoordinateParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/SchemaCoordinateParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/SchemaParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/SchemaParserTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/StringTokenReaderTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/StringTokenReaderTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/SyntaxParserHelperTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/SyntaxParserHelperTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8HelperTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8HelperTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ValueParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ValueParserTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language;
 
 public class ValueParserTests

--- a/src/HotChocolate/Language/test/Language.Tests/TypeNodeExtensionsTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/TypeNodeExtensionsTests.cs
@@ -1,5 +1,4 @@
 using HotChocolate.Language.Utilities;
-using Xunit;
 
 namespace HotChocolate.Language;
 

--- a/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language.Utilities;
 
 public class SyntaxPrinterTests

--- a/src/HotChocolate/Language/test/Language.Tests/ValueNodeExtensionsTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/ValueNodeExtensionsTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Language;
 
 public static class ValueNodeExtensionsTests

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/DefaultSyntaxNavigatorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/DefaultSyntaxNavigatorTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using static HotChocolate.Language.Utf8GraphQLParser.Syntax;
 
 namespace HotChocolate.Language.Visitors;

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SchemaCoordinateVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SchemaCoordinateVisitorTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using HotChocolate.Language.Visitors;
 
 namespace HotChocolate.Language;

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
@@ -1,5 +1,4 @@
 using HotChocolate.Language.Utilities;
-using Xunit;
 using static HotChocolate.Language.Utf8GraphQLParser;
 
 namespace HotChocolate.Language.Visitors;

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using static HotChocolate.Language.Utf8GraphQLParser;
 using static HotChocolate.Language.Visitors.SyntaxVisitor;
 

--- a/src/HotChocolate/Language/test/Language.Web.Tests/Usings.cs
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/src/HotChocolate/Utilities/test/Directory.Build.props
+++ b/src/HotChocolate/Utilities/test/Directory.Build.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Using Include="CookieCrumble" />
     <Using Include="CookieCrumble.Xunit" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionClientTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using Xunit;
 using HotChocolate.AspNetCore.Tests.Utilities;
 
 // ReSharper disable AccessToDisposedClosure

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionFormatterTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionFormatterTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Xunit;
 using static HotChocolate.Utilities.Introspection.IntrospectionClient;
 
 namespace HotChocolate.Utilities.Introspection;

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/IntrospectionQueryBuilderTests.cs
@@ -1,5 +1,4 @@
 using HotChocolate.Language.Utilities;
-using Xunit;
 
 namespace HotChocolate.Utilities.Introspection;
 

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/ActivatorHelperTests.txt
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/ActivatorHelperTests.txt
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using Snapshooter.Xunit;
-using Xunit;
 
 namespace HotChocolate.Utilities;
 

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/CombinedServiceProviderTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/CombinedServiceProviderTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace HotChocolate.Utilities;
 

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/MiddlewareCompilerTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/MiddlewareCompilerTests.cs
@@ -1,5 +1,4 @@
 using System.Linq.Expressions;
-using Xunit;
 
 namespace HotChocolate.Utilities;
 

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/PooledArrayWriterTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/PooledArrayWriterTests.cs
@@ -1,5 +1,4 @@
 using HotChocolate.Buffers;
-using Xunit;
 
 namespace HotChocolate.Utilities;
 

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/AsyncEnumerableStreamAdapterTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/AsyncEnumerableStreamAdapterTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Utilities.StreamAdapters;
 
 public class AsyncEnumerableStreamAdapterTests

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/EnumerableStreamAdapterTests.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/EnumerableStreamAdapterTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Utilities.StreamAdapters;
 
 public class EnumerableStreamAdapterTests

--- a/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/QueryableStreamAdapter.cs
+++ b/src/HotChocolate/Utilities/test/Utilities.Tests/StreamAdapters/QueryableStreamAdapter.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace HotChocolate.Utilities.StreamAdapters;
 
 public class QueryableStreamAdapterTests

--- a/src/StrawberryShake/Client/test/Core.Tests/Integration/IntegrationTests.cs
+++ b/src/StrawberryShake/Client/test/Core.Tests/Integration/IntegrationTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using ChilliCream.Testing;
 using StrawberryShake.Integration.Mappers;
 using StrawberryShake.Serialization;
-using Xunit;
 
 namespace StrawberryShake.Integration
 {

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetHeroWithFragmentIncludeAndSkipDirectiveTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetHeroWithFragmentIncludeAndSkipDirectiveTest.cs
@@ -6,7 +6,6 @@ using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using StrawberryShake.Transport.WebSockets;
-using Xunit;
 
 namespace StrawberryShake.CodeGeneration.CSharp.Integration.StarWarsGetHeroWithFragmentIncludeAndSkipDirective;
 

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/__resources__/TestTemplate.txt
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/__resources__/TestTemplate.txt
@@ -6,7 +6,6 @@ using HotChocolate.AspNetCore.Tests.Utilities;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using StrawberryShake.Transport.WebSockets;
-using Xunit;
 
 namespace {Namespace};
 

--- a/src/StrawberryShake/Tooling/test/Configuration.Tests/FileContentsTests.cs
+++ b/src/StrawberryShake/Tooling/test/Configuration.Tests/FileContentsTests.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Xunit;
 
 namespace StrawberryShake.Tools.Configuration;
 

--- a/src/StrawberryShake/Tooling/test/Configuration.Tests/GraphQLConfigTests.cs
+++ b/src/StrawberryShake/Tooling/test/Configuration.Tests/GraphQLConfigTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace StrawberryShake.Tools.Configuration;
 
 public class GraphQLConfigTests

--- a/src/StrawberryShake/Tooling/test/Directory.Build.props
+++ b/src/StrawberryShake/Tooling/test/Directory.Build.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Using Include="CookieCrumble" />
     <Using Include="CookieCrumble.Xunit" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Used global using everywhere for Xunit.