### PR TITLE
[Fusion] Fix bug with shared parent selection

### DIFF
--- a/src/HotChocolate/Fusion/test/Core.Tests/DemoIntegrationTests.cs
+++ b/src/HotChocolate/Fusion/test/Core.Tests/DemoIntegrationTests.cs
@@ -16,6 +16,124 @@ public class DemoIntegrationTests(ITestOutputHelper output)
     private readonly Func<ICompositionLog> _logFactory = () => new TestCompositionLog(output);
 
     [Fact]
+    public async Task Viewer_Bug_1()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              recentTestimonial: Testimonial
+              viewer: Viewer
+            }
+            type Testimonial {
+              id: ID!
+            }
+            type Viewer {
+              name: String
+            }
+            """);
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer
+            }
+            type Viewer {
+              exclusiveSubgraphB: String
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+
+        var request = Parse(
+            """
+            query {
+              recentTestimonial {
+                __typename
+              }
+              viewer {
+                exclusiveSubgraphB
+              }
+            }
+            """);
+
+        // act
+        await using var result = await executor.ExecuteAsync(
+            OperationRequestBuilder
+                .New()
+                .SetDocument(request)
+                .Build());
+
+        // assert
+        var snapshot = new Snapshot();
+        CollectSnapshotData(snapshot, request, result);
+        await snapshot.MatchMarkdownAsync();
+    }
+
+    [Fact]
+    public async Task Viewer_Bug_2()
+    {
+        // arrange
+        var subgraphA = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              recentTestimonial: Testimonial
+              viewer: Viewer
+            }
+            type Testimonial {
+              id: ID!
+            }
+            type Viewer {
+              subType: SubType
+            }
+            type SubType {
+              subgraphA: String
+            }
+            """);
+        var subgraphB = await TestSubgraph.CreateAsync(
+            """
+            type Query {
+              viewer: Viewer
+            }
+            type Viewer {
+              subType: SubType
+            }
+            type SubType {
+              subgraphB: String
+            }
+            """);
+
+        using var subgraphs = new TestSubgraphCollection(output, [subgraphA, subgraphB]);
+        var executor = await subgraphs.GetExecutorAsync();
+
+        var request = Parse(
+            """
+            query {
+              recentTestimonial {
+                __typename
+              }
+              viewer {
+                subType {
+                  subgraphB
+                }
+              }
+            }
+            """);
+
+        // act
+        await using var result = await executor.ExecuteAsync(
+            OperationRequestBuilder
+                .New()
+                .SetDocument(request)
+                .Build());
+
+        // assert
+        var snapshot = new Snapshot();
+        CollectSnapshotData(snapshot, request, result);
+        await snapshot.MatchMarkdownAsync();
+    }
+
+    [Fact]
     public async Task Same_Selection_On_Two_Object_Types_That_Require_Data_From_Another_Subgraph()
     {
         // arrange
@@ -2341,7 +2459,7 @@ public class DemoIntegrationTests(ITestOutputHelper output)
         await snapshot.MatchMarkdownAsync();
     }
 
-    [Fact(Skip = "Fix this test in the new planner")]
+    [Fact]
     public async Task Field_Below_Shared_Field_Only_Available_On_One_Subgraph_Type_Of_Shared_Field_Not_Node()
     {
         // arrange

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Field_Below_Shared_Field_Only_Available_On_One_Subgraph_Type_Of_Shared_Field_Not_Node.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Field_Below_Shared_Field_Only_Available_On_One_Subgraph_Type_Of_Shared_Field_Not_Node.md
@@ -93,3 +93,4 @@ query($productId: ID!) {
   }
 }
 ```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Viewer_Bug_1.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Viewer_Bug_1.md
@@ -1,0 +1,73 @@
+# Viewer_Bug_1
+
+## Result
+
+```json
+{
+  "data": {
+    "exclusiveSubgraphA": {
+      "__typename": "ExclusiveSubgraphA"
+    },
+    "viewer": {
+      "exclusiveSubgraphB": "string"
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query testQuery {
+  exclusiveSubgraphA {
+    __typename
+  }
+  viewer {
+    exclusiveSubgraphB
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+1A0ADF8B4DE457E0B7C85E08324A394F9F2FEB91
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query testQuery { exclusiveSubgraphA { __typename } viewer { exclusiveSubgraphB } }",
+  "operation": "testQuery",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query testQuery_1 { exclusiveSubgraphA { __typename } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query testQuery_2 { viewer { exclusiveSubgraphB } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+

--- a/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Viewer_Bug_2.md
+++ b/src/HotChocolate/Fusion/test/Core.Tests/__snapshots__/DemoIntegrationTests.Viewer_Bug_2.md
@@ -1,0 +1,77 @@
+# Viewer_Bug_2
+
+## Result
+
+```json
+{
+  "data": {
+    "exclusiveSubgraphA": {
+      "__typename": "ExclusiveSubgraphA"
+    },
+    "viewer": {
+      "subType": {
+        "subgraphB": "string"
+      }
+    }
+  }
+}
+```
+
+## Request
+
+```graphql
+query testQuery {
+  exclusiveSubgraphA {
+    __typename
+  }
+  viewer {
+    subType {
+      subgraphB
+    }
+  }
+}
+```
+
+## QueryPlan Hash
+
+```text
+9D04321969F1B9D45B0322BFB1B85DD104943530
+```
+
+## QueryPlan
+
+```json
+{
+  "document": "query testQuery { exclusiveSubgraphA { __typename } viewer { subType { subgraphB } } }",
+  "operation": "testQuery",
+  "rootNode": {
+    "type": "Sequence",
+    "nodes": [
+      {
+        "type": "Parallel",
+        "nodes": [
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_1",
+            "document": "query testQuery_1 { exclusiveSubgraphA { __typename } }",
+            "selectionSetId": 0
+          },
+          {
+            "type": "Resolve",
+            "subgraph": "Subgraph_2",
+            "document": "query testQuery_2 { viewer { subType { subgraphB } } }",
+            "selectionSetId": 0
+          }
+        ]
+      },
+      {
+        "type": "Compose",
+        "selectionSetIds": [
+          0
+        ]
+      }
+    ]
+  }
+}
+```
+


### PR DESCRIPTION
Given the following query:

```graphql
{
  something { # Subraph 1
    something  # Subraph 1
  }
  viewer {  # Subraph 1 & 2
    exclusiveSubgraphB  # Subraph 2
  }
}
```

The weighting algorithm will determine it should first plan for Subgraph 1.
The resulting execution step for Subgraph 1 will currently end up with the following selection set as it includes `viewer` but then doesn't have anything it can resolve from Subgraph 1:  
```graphql
{
  something {
    something
  }
  viewer {
   # empty
  }
}
```

This PR adds some checks to remove the empty `viewer` selection from the Subgraph 1 execution step, so it doesn't crash further down the line when attempting to create a request document for the subgraph call.