### PR TITLE
Allow listening to failed Subscription

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Instrumentation/ExecutionDiagnosticEventListener.cs
+++ b/src/HotChocolate/Core/src/Execution/Instrumentation/ExecutionDiagnosticEventListener.cs
@@ -136,7 +136,7 @@ public class ExecutionDiagnosticEventListener : IExecutionDiagnosticEventListene
     }
 
     /// <inheritdoc />
-    public void SubscriptionEventError(
+    public virtual void SubscriptionEventError(
         ISubscription subscription,
         Exception exception)
     {


### PR DESCRIPTION
**Context**
There are two overloaded methods for `SubscriptionEventError`.
 One called with `payload` in `Subscription.OnEvent`; the other when enumerating subscriptions in `SubscriptionEnumerable` and `SubscriptionEnumerator`.

Users can override the former when deriving from `ExecutionDiagnosticEventListener`, but cannot override the latter.
If an exception happens during subscribing, `AggregateExecutionDiagnosticEvents` calls `SubscriptionEventError(ISubscription, Exception)`. No listener deriving from `ExecutionDiagnosticEventListener` cannot override this and the call results in no-op.

**Notes**
I'm making only this small change for v15, because I understand `ExecutionDiagnosticEventListener` is being refactored for v16.

**Tests**
I haven't found any relevant tests for this particular functionality, but if they exist, please point them out to me.