### PR TITLE
Ignore type members in TypeInspector

### DIFF
--- a/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
+++ b/src/HotChocolate/Core/src/Types/Types/Descriptors/Conventions/DefaultTypeInspector.cs
@@ -643,8 +643,9 @@ public class DefaultTypeInspector(bool ignoreRequiredAttribute = false) : Conven
             return false;
         }
 
-        if (member.IsDefined(typeof(GraphQLTypeAttribute), true) ||
-            member.IsDefined(typeof(DescriptorAttribute), true))
+        if ((member.IsDefined(typeof(GraphQLTypeAttribute), true) ||
+                member.IsDefined(typeof(DescriptorAttribute), true)) &&
+            member is PropertyInfo or MethodInfo)
         {
             return true;
         }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeTests.cs
@@ -2124,6 +2124,35 @@ public class ObjectTypeTests : TypeTestBase
         schema.MatchSnapshot();
     }
 
+    [Fact]
+    public async Task Ignore_Type_Members()
+    {
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<QueryWithTypeExtension>()
+            .AddTypeExtension<QueryWithTypeExtension.SomeClassExtension>()
+            .BuildSchemaAsync();
+
+        schema.MatchSnapshot();
+    }
+
+    [GraphQLName("Query")]
+    public class QueryWithTypeExtension
+    {
+        public SomeClass GetSomeClass() => null!;
+
+        [ExtendObjectType("SomeClass")]
+        public class SomeClassExtension
+        {
+            public int SomethingElse { get; set; }
+        }
+    }
+
+    public class SomeClass
+    {
+        public int Something { get; set; }
+    }
+
     public abstract class ResolverBase
     {
         public int GetValue() => 1024;

--- a/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.Ignore_Type_Members.graphql
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/__snapshots__/ObjectTypeTests.Ignore_Type_Members.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: Query
+}
+
+type Query {
+  someClass: SomeClass
+}
+
+type SomeClass {
+  something: Int!
+  somethingElse: Int!
+}


### PR DESCRIPTION
Type extensions being declared within other classes

```csharp
public class Query {
    [ExtendObjectType("SomeType")]
    public class SomeTypeExtension { ... }
}
```

was broken by this update: https://github.com/ChilliCream/graphql-platform/commit/879b66005f1ba1e2da635afbfa02524e11a291c0#diff-b06e022ac536fe3fd39b7380835ab6942a0c0dd2397b71a7b31c3e3ffc53d608R718-R723
since the `ExtendTypeObjectTypeAttribute` is a `DescriptorAttribute` and therefore it was assumed the `RuntimeType` member (class definition) could be handled by the type inspector.

This PR changes the attribute check to only apply to `PropertyInfo` or `MethodInfo` members.