### PR TITLE
Fixed large json deserialization regression

### DIFF
--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/AnyScalarDefaultSerializationTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/AnyScalarDefaultSerializationTest.cs
@@ -44,10 +44,51 @@ public class AnyScalarDefaultSerializationTest : ServerTestBase
         result.Data?.Json.ToString().MatchSnapshot();
     }
 
+    [Fact]
+    public async Task Execute_AnyScalarDefaultSerialization_TestLarge()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(20_000);
+        using var host = TestServerHelper.CreateServer(
+            builder =>
+            {
+                builder.AddTypeExtension<LargeQueryResolvers>();
+            },
+            out var port);
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddHttpClient(
+            AnyScalarDefaultSerializationClient.ClientName,
+            c => c.BaseAddress = new Uri("http://localhost:" + port + "/graphql"));
+        serviceCollection.AddWebSocketClient(
+            AnyScalarDefaultSerializationClient.ClientName,
+            c => c.Uri = new Uri("ws://localhost:" + port + "/graphql"));
+        serviceCollection.AddAnyScalarDefaultSerializationClient();
+        IServiceProvider services = serviceCollection.BuildServiceProvider();
+        var client =
+            services.GetRequiredService<AnyScalarDefaultSerializationClient>();
+
+        // act
+        IOperationResult<IGetJsonResult> result = await client.GetJson.ExecuteAsync(cts.Token);
+
+        // assert
+        Assert.Empty(result.Errors);
+        result.Data?.Json.ToString().MatchSnapshot();
+    }
+
     [ExtendObjectType(OperationTypeNames.Query)]
     public class QueryResolvers
     {
         [GraphQLType(typeof(NonNullType<AnyType>))]
         public Dictionary<string, object> GetJson() => new() { { "abc", "def" } };
+    }
+
+    [ExtendObjectType(OperationTypeNames.Query)]
+    public class LargeQueryResolvers
+    {
+        [GraphQLType(typeof(NonNullType<AnyType>))]
+        public string[] GetJson() => [
+            $"{0,10000}",
+            $"{1,10000}",
+        ];
     }
 }


### PR DESCRIPTION
The rented array's lifecycle should align with that of the `JsonDocument`.

Closes #8376 
