### PR TITLE
Marked structs as 'readonly' (where applicable)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -229,6 +229,8 @@ dotnet_remove_unnecessary_suppression_exclusions = CA1822, InconsistentNaming, R
 dotnet_diagnostic.IDE0083.severity = warning
 # Remove unnecessary lambda expression.
 dotnet_diagnostic.IDE0200.severity = warning
+# Struct can be made 'readonly'.
+dotnet_diagnostic.IDE0250.severity = warning
 # Use collection expression for array.
 dotnet_diagnostic.IDE0300.severity = warning
 # Use collection expression for empty.

--- a/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeResolverTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Configuration/SchemaTypeResolverTests.cs
@@ -147,12 +147,12 @@ public class SchemaTypeResolverTests
         public string Baz { get; }
     }
 
-    public struct BarStruct
+    public readonly struct BarStruct
     {
         public string Baz { get; }
     }
 
-    public ref struct BarRefStruct
+    public readonly ref struct BarRefStruct
     {
         public string Baz { get; }
     }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeAttributeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/ObjectTypeAttributeTests.cs
@@ -187,7 +187,7 @@ public class ObjectTypeAttributeTests
     }
 
     [ObjectType("Query")]
-    public struct StructQuery
+    public readonly struct StructQuery
     {
         public string? Foo { get; }
     }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInputFieldCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInputFieldCompletionContext.cs
@@ -4,7 +4,7 @@ using HotChocolate.Types;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeInputFieldCompletionContext(
+internal readonly ref struct CompositeInputFieldCompletionContext(
     ITypeSystemMember declaringMember,
     FusionDirectiveCollection directives,
     IInputType type,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInputObjectTypeCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInputObjectTypeCompletionContext.cs
@@ -3,7 +3,7 @@ using HotChocolate.Fusion.Types.Collections;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeInputObjectTypeCompletionContext(
+internal readonly ref struct CompositeInputObjectTypeCompletionContext(
     FusionDirectiveCollection directives,
     IFeatureCollection features)
 {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInterfaceTypeCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeInterfaceTypeCompletionContext.cs
@@ -3,7 +3,7 @@ using HotChocolate.Fusion.Types.Collections;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeInterfaceTypeCompletionContext(
+internal readonly ref struct CompositeInterfaceTypeCompletionContext(
     FusionDirectiveCollection directives,
     FusionInterfaceTypeDefinitionCollection interfaces,
     SourceInterfaceTypeCollection sources,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeObjectFieldCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeObjectFieldCompletionContext.cs
@@ -4,7 +4,7 @@ using HotChocolate.Types;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeObjectFieldCompletionContext(
+internal readonly ref struct CompositeObjectFieldCompletionContext(
     FusionComplexTypeDefinition declaringType,
     FusionDirectiveCollection directives,
     IOutputType type,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeObjectTypeCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeObjectTypeCompletionContext.cs
@@ -3,7 +3,7 @@ using HotChocolate.Fusion.Types.Collections;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeObjectTypeCompletionContext(
+internal readonly ref struct CompositeObjectTypeCompletionContext(
     FusionDirectiveCollection directives,
     FusionInterfaceTypeDefinitionCollection interfaces,
     SourceObjectTypeCollection sources,

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeScalarTypeCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeScalarTypeCompletionContext.cs
@@ -2,7 +2,7 @@ using HotChocolate.Fusion.Types.Collections;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeScalarTypeCompletionContext(
+internal readonly ref struct CompositeScalarTypeCompletionContext(
     ScalarValueKind valueKind,
     FusionDirectiveCollection directives)
 {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeUnionTypeCompletionContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution.Types/Completion/CompositeUnionTypeCompletionContext.cs
@@ -3,7 +3,7 @@ using HotChocolate.Fusion.Types.Collections;
 
 namespace HotChocolate.Fusion.Types.Completion;
 
-internal ref struct CompositeUnionTypeCompletionContext(
+internal readonly ref struct CompositeUnionTypeCompletionContext(
     FusionObjectTypeDefinitionCollection types,
     FusionDirectiveCollection directives,
     IFeatureCollection features)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Marked structs as 'readonly' (where applicable).