### PR TITLE
Removed quotes from JSON string values in JsonValueParser

### DIFF
--- a/src/HotChocolate/Language/src/Language.Web/JsonValueParser.cs
+++ b/src/HotChocolate/Language/src/Language.Web/JsonValueParser.cs
@@ -70,6 +70,7 @@ public ref struct JsonValueParser
             case JsonValueKind.String:
             {
                 var value = JsonMarshal.GetRawUtf8Value(element);
+                value = value.Slice(1, value.Length - 2); // Remove quotes.
                 var segment = WriteValue(value);
                 return new StringValueNode(null, segment, false);
             }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Removed quotes from JSON string values in JsonValueParser.