### PR TITLE
[Fusion] Fix operation plan YAML indentation

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
@@ -112,6 +112,7 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
 
         writer.WriteLine("- document: >-");
         writer.Indent();
+        writer.Indent();
         var reader = new StringReader(plan.Operation.Definition.ToString(indented: true));
         var line = reader.ReadLine();
         while (line != null)
@@ -119,6 +120,7 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
             writer.WriteLine(line);
             line = reader.ReadLine();
         }
+        writer.Unindent();
 
         if (!string.IsNullOrEmpty(plan.Operation.Name))
         {

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field.yaml
@@ -1,10 +1,10 @@
 operation:
   - document: >-
-    query testQuery {
-      votable {
-        viewerCanVote
+      query testQuery {
+        votable {
+          viewerCanVote
+        }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type.yaml
@@ -1,13 +1,13 @@
 operation:
   - document: >-
-    query testQuery {
-      votable {
-        viewerCanVote
-        ... on Discussion {
-          title
+      query testQuery {
+        votable {
+          viewerCanVote
+          ... on Discussion {
+            title
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type_Linked_Field_With_Dependency.yaml
@@ -1,16 +1,16 @@
 operation:
   - document: >-
-    query testQuery {
-      votable {
-        viewerCanVote
-        ... on Discussion {
-          author {
-            displayName
-            id @fusion__requirement
+      query testQuery {
+        votable {
+          viewerCanVote
+          ... on Discussion {
+            author {
+              displayName
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Concrete_Type_With_Dependency.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query testQuery {
-      votable {
-        viewerCanVote
-        ... on Discussion {
-          viewerRating
-          id @fusion__requirement
+      query testQuery {
+        votable {
+          viewerCanVote
+          ... on Discussion {
+            viewerRating
+            id @fusion__requirement
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query testQuery {
-      authorable {
-        author {
-          id
-          displayName
-          id @fusion__requirement
+      query testQuery {
+        authorable {
+          author {
+            id
+            displayName
+            id @fusion__requirement
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
@@ -1,20 +1,20 @@
 operation:
   - document: >-
-    query testQuery {
-      authorable {
-        author {
-          id
-          displayName
-          id @fusion__requirement
-        }
-        ... on Discussion {
+      query testQuery {
+        authorable {
           author {
-            email
+            id
+            displayName
             id @fusion__requirement
+          }
+          ... on Discussion {
+            author {
+              email
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_Field_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      authorable {
-        author {
-          id
-          displayName
-          id @fusion__requirement
-        }
-        ... on Discussion {
+      query testQuery {
+        authorable {
           author {
             id
             displayName
             id @fusion__requirement
           }
+          ... on Discussion {
+            author {
+              id
+              displayName
+              id @fusion__requirement
+            }
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field.yaml
@@ -1,10 +1,10 @@
 operation:
   - document: >-
-    query testQuery {
-      votables {
-        viewerCanVote
+      query testQuery {
+        votables {
+          viewerCanVote
+        }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type.yaml
@@ -1,13 +1,13 @@
 operation:
   - document: >-
-    query testQuery {
-      votables {
-        viewerCanVote
-        ... on Discussion {
-          title
+      query testQuery {
+        votables {
+          viewerCanVote
+          ... on Discussion {
+            title
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type_Linked_Field_With_Dependency.yaml
@@ -1,16 +1,16 @@
 operation:
   - document: >-
-    query testQuery {
-      votables {
-        viewerCanVote
-        ... on Discussion {
-          author {
-            displayName
-            id @fusion__requirement
+      query testQuery {
+        votables {
+          viewerCanVote
+          ... on Discussion {
+            author {
+              displayName
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Concrete_Type_With_Dependency.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query testQuery {
-      votables {
-        viewerCanVote
-        ... on Discussion {
-          viewerRating
-          id @fusion__requirement
+      query testQuery {
+        votables {
+          viewerCanVote
+          ... on Discussion {
+            viewerRating
+            id @fusion__requirement
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query testQuery {
-      authorables {
-        author {
-          id
-          displayName
-          id @fusion__requirement
+      query testQuery {
+        authorables {
+          author {
+            id
+            displayName
+            id @fusion__requirement
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
@@ -1,20 +1,20 @@
 operation:
   - document: >-
-    query testQuery {
-      authorables {
-        author {
-          id
-          displayName
-          id @fusion__requirement
-        }
-        ... on Discussion {
+      query testQuery {
+        authorables {
           author {
-            email
+            id
+            displayName
             id @fusion__requirement
+          }
+          ... on Discussion {
+            author {
+              email
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.Interface_List_Field_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      authorables {
-        author {
-          id
-          displayName
-          id @fusion__requirement
-        }
-        ... on Discussion {
+      query testQuery {
+        authorables {
           author {
             id
             displayName
             id @fusion__requirement
           }
+          ... on Discussion {
+            author {
+              id
+              displayName
+              id @fusion__requirement
+            }
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type.yaml
@@ -1,15 +1,15 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        votable {
-          viewerCanVote
-          ... on Discussion {
-            title
+      query testQuery {
+        wrappers {
+          votable {
+            viewerCanVote
+            ... on Discussion {
+              title
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type_Linked_Field_With_Dependency.yaml
@@ -1,18 +1,18 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        votable {
-          viewerCanVote
-          ... on Discussion {
-            author {
-              displayName
-              id @fusion__requirement
+      query testQuery {
+        wrappers {
+          votable {
+            viewerCanVote
+            ... on Discussion {
+              author {
+                displayName
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Concrete_Type_With_Dependency.yaml
@@ -1,16 +1,16 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        votable {
-          viewerCanVote
-          ... on Discussion {
-            viewerRating
-            id @fusion__requirement
+      query testQuery {
+        wrappers {
+          votable {
+            viewerCanVote
+            ... on Discussion {
+              viewerRating
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency.yaml
@@ -1,15 +1,15 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        authorable {
-          author {
-            displayName
-            id @fusion__requirement
+      query testQuery {
+        wrappers {
+          authorable {
+            author {
+              displayName
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency_Different_Selection_In_Concrete_Type.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        authorable {
-          author {
-            displayName
-            id @fusion__requirement
-          }
-          ... on Discussion {
+      query testQuery {
+        wrappers {
+          authorable {
             author {
-              email
+              displayName
               id @fusion__requirement
+            }
+            ... on Discussion {
+              author {
+                email
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/InterfaceTests.List_Field_Interface_Object_Property_Linked_Field_With_Dependency_Same_Selection_In_Concrete_Type.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      wrappers {
-        authorable {
-          author {
-            displayName
-            id @fusion__requirement
-          }
-          ... on Discussion {
+      query testQuery {
+        wrappers {
+          authorable {
             author {
               displayName
               id @fusion__requirement
             }
+            ... on Discussion {
+              author {
+                displayName
+                id @fusion__requirement
+              }
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Key_Requirement.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Key_Requirement.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query GetTopProducts {
-      topProducts {
-        id
-        name
-        sku @fusion__requirement
-        id @fusion__requirement
-        region @fusion__requirement
+      query GetTopProducts {
+        topProducts {
+          id
+          name
+          sku @fusion__requirement
+          id @fusion__requirement
+          region @fusion__requirement
+        }
       }
-    }
     name: GetTopProducts
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Requirement_That_Cannot_Be_Inlined.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Requirement_That_Cannot_Be_Inlined.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query GetTopProducts {
-      topProducts {
-        id
-        name
-        price
-        id @fusion__requirement
-        region @fusion__requirement
+      query GetTopProducts {
+        topProducts {
+          id
+          name
+          price
+          id @fusion__requirement
+          region @fusion__requirement
+        }
       }
-    }
     name: GetTopProducts
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Lookup.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Lookup.yaml
@@ -1,13 +1,13 @@
 operation:
   - document: >-
-    query GetTopProducts {
-      topProducts {
-        id
-        name
-        price
-        id @fusion__requirement
+      query GetTopProducts {
+        topProducts {
+          id
+          name
+          price
+          id @fusion__requirement
+        }
       }
-    }
     name: GetTopProducts
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_1_Source_Schema.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_1_Source_Schema.yaml
@@ -1,11 +1,11 @@
 operation:
   - document: >-
-    {
-      productBySlug(slug: "1") {
-        id
-        name
+      {
+        productBySlug(slug: "1") {
+          id
+          name
+        }
       }
-    }
     hash: 123
 nodes:
   - id: 1

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_2_Source_Schema.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_2_Source_Schema.yaml
@@ -1,17 +1,17 @@
 operation:
   - document: >-
-    {
-      productBySlug(slug: "1") {
-        id
-        name
-        estimatedDelivery(postCode: "12345")
-        id @fusion__requirement
-        dimension @fusion__requirement {
-          height
-          width
+      {
+        productBySlug(slug: "1") {
+          id
+          name
+          estimatedDelivery(postCode: "12345")
+          id @fusion__requirement
+          dimension @fusion__requirement {
+            height
+            width
+          }
         }
       }
-    }
     hash: 123
 nodes:
   - id: 1

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_3_Source_Schema.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Operation_3_Source_Schema.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    {
-      productBySlug(slug: "1") {
-        name
-        reviews(first: 10) {
-          nodes {
-            body
-            stars
-            author {
-              displayName
-              id @fusion__requirement
+      {
+        productBySlug(slug: "1") {
+          name
+          reviews(first: 10) {
+            nodes {
+              body
+              stars
+              author {
+                displayName
+                id @fusion__requirement
+              }
             }
           }
+          id @fusion__requirement
         }
-        id @fusion__requirement
       }
-    }
     hash: 123
 nodes:
   - id: 1

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Requirement.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/OperationPlannerTests.Plan_Simple_Requirement.yaml
@@ -1,14 +1,14 @@
 operation:
   - document: >-
-    query GetTopProducts {
-      topProducts {
-        id
-        name
-        price
-        id @fusion__requirement
-        region @fusion__requirement
+      query GetTopProducts {
+        topProducts {
+          id
+          name
+          price
+          id @fusion__requirement
+          region @fusion__requirement
+        }
       }
-    }
     name: GetTopProducts
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/RequirementTests.Plan_Simple_Operation_1_Source_Schema.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/RequirementTests.Plan_Simple_Operation_1_Source_Schema.yaml
@@ -1,12 +1,12 @@
 operation:
   - document: >-
-    {
-      books {
-        titleAndId
-        id @fusion__requirement
-        title @fusion__requirement
+      {
+        books {
+          titleAndId
+          id @fusion__requirement
+          title @fusion__requirement
+        }
       }
-    }
     hash: 123
 nodes:
   - id: 1

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Has_Dependency.yaml
@@ -1,18 +1,18 @@
 operation:
   - document: >-
-    query testQuery {
-      postEdges {
-        node {
-          ... on Photo {
-            subgraph2
-            id @fusion__requirement
-          }
-          ... on Discussion {
-            subgraph1
+      query testQuery {
+        postEdges {
+          node {
+            ... on Photo {
+              subgraph2
+              id @fusion__requirement
+            }
+            ... on Discussion {
+              subgraph1
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selection_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selection_Has_Dependency.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      postEdges {
-        node {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        postEdges {
+          node {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            author {
-              subgraph3
-              id @fusion__requirement
+            ... on Discussion {
+              author {
+                subgraph3
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      postEdges {
-        node {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        postEdges {
+          node {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            author {
-              subgraph2
-              id @fusion__requirement
+            ... on Discussion {
+              author {
+                subgraph2
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selections_Have_Same_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_Field_Concrete_Type_Selections_Have_Same_Dependency.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      postEdges {
-        node {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        postEdges {
+          node {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            product {
-              subgraph2
-              id @fusion__requirement
+            ... on Discussion {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Has_Dependency.yaml
@@ -1,18 +1,18 @@
 operation:
   - document: >-
-    query testQuery {
-      users {
-        posts {
-          ... on Photo {
-            subgraph2
-            id @fusion__requirement
-          }
-          ... on Discussion {
-            subgraph1
+      query testQuery {
+        users {
+          posts {
+            ... on Photo {
+              subgraph2
+              id @fusion__requirement
+            }
+            ... on Discussion {
+              subgraph1
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selection_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selection_Has_Dependency.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      users {
-        posts {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        users {
+          posts {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            author {
-              subgraph3
-              id @fusion__requirement
+            ... on Discussion {
+              author {
+                subgraph3
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      users {
-        posts {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        users {
+          posts {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            author {
-              subgraph2
-              id @fusion__requirement
+            ... on Discussion {
+              author {
+                subgraph2
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selections_Have_Same_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Object_List_Union_List_Concrete_Type_Selections_Have_Same_Dependency.yaml
@@ -1,23 +1,23 @@
 operation:
   - document: >-
-    query testQuery {
-      users {
-        posts {
-          ... on Photo {
-            product {
-              subgraph2
-              id @fusion__requirement
+      query testQuery {
+        users {
+          posts {
+            ... on Photo {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
-          }
-          ... on Discussion {
-            product {
-              subgraph2
-              id @fusion__requirement
+            ... on Discussion {
+              product {
+                subgraph2
+                id @fusion__requirement
+              }
             }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Has_Dependency.yaml
@@ -1,16 +1,16 @@
 operation:
   - document: >-
-    query testQuery {
-      post {
-        ... on Photo {
-          subgraph2
-          id @fusion__requirement
-        }
-        ... on Discussion {
-          subgraph1
+      query testQuery {
+        post {
+          ... on Photo {
+            subgraph2
+            id @fusion__requirement
+          }
+          ... on Discussion {
+            subgraph1
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selection_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selection_Has_Dependency.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      post {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        post {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          author {
-            subgraph3
-            id @fusion__requirement
+          ... on Discussion {
+            author {
+              subgraph3
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      post {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        post {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          author {
-            subgraph2
-            id @fusion__requirement
+          ... on Discussion {
+            author {
+              subgraph2
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selections_Have_Same_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Concrete_Type_Selections_Have_Same_Dependency.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      post {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        post {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          product {
-            subgraph2
-            id @fusion__requirement
+          ... on Discussion {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Just_Typename_Selected.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_Field_Just_Typename_Selected.yaml
@@ -1,10 +1,10 @@
 operation:
   - document: >-
-    query testQuery {
-      post {
-        __typename
+      query testQuery {
+        post {
+          __typename
+        }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Has_Dependency.yaml
@@ -1,16 +1,16 @@
 operation:
   - document: >-
-    query testQuery {
-      posts {
-        ... on Photo {
-          subgraph2
-          id @fusion__requirement
-        }
-        ... on Discussion {
-          subgraph1
+      query testQuery {
+        posts {
+          ... on Photo {
+            subgraph2
+            id @fusion__requirement
+          }
+          ... on Discussion {
+            subgraph1
+          }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selection_Has_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selection_Has_Dependency.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      posts {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        posts {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          author {
-            subgraph3
-            id @fusion__requirement
+          ... on Discussion {
+            author {
+              subgraph3
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selections_Have_Dependency_To_Same_Subgraph.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      posts {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        posts {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          author {
-            subgraph2
-            id @fusion__requirement
+          ... on Discussion {
+            author {
+              subgraph2
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selections_Have_Same_Dependency.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/Planning/__snapshots__/UnionTests.Union_List_Concrete_Type_Selections_Have_Same_Dependency.yaml
@@ -1,21 +1,21 @@
 operation:
   - document: >-
-    query testQuery {
-      posts {
-        ... on Photo {
-          product {
-            subgraph2
-            id @fusion__requirement
+      query testQuery {
+        posts {
+          ... on Photo {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
-        }
-        ... on Discussion {
-          product {
-            subgraph2
-            id @fusion__requirement
+          ... on Discussion {
+            product {
+              subgraph2
+              id @fusion__requirement
+            }
           }
         }
       }
-    }
     name: testQuery
     hash: 123
 nodes:


### PR DESCRIPTION
Indents the raw operation text below `- document: >-` to be proper YAML.