### PR TITLE
removes unecessary generic on `IOperation`

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Operation.cs
@@ -155,7 +155,7 @@ internal sealed class Operation : IOperation
         return (TState)state!;
     }
 
-    public TState GetOrAddState<TState, TContext>(
+    public TState GetOrAddState<TState>(
         string key,
         Func<string, TState> createState)
         => GetOrAddState<TState, object?>(key, (k, _) => createState(k), null);

--- a/src/HotChocolate/Core/src/Types/Execution/Processing/IOperation.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/IOperation.cs
@@ -153,9 +153,6 @@ public interface IOperation : IHasReadOnlyContextData, IEnumerable<ISelectionSet
     /// <typeparam name="TState">
     /// The type of the state.
     /// </typeparam>
-    /// <typeparam name="TContext">
-    /// The type of the context.
-    /// </typeparam>
     /// <param name="key">
     /// The key of the state.
     /// </param>
@@ -165,7 +162,7 @@ public interface IOperation : IHasReadOnlyContextData, IEnumerable<ISelectionSet
     /// <returns>
     /// Returns the state.
     /// </returns>
-    TState GetOrAddState<TState, TContext>(
+    TState GetOrAddState<TState>(
         string key,
         Func<string, TState> createState);
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Closes #bugnumber (in this specific format)
