### PR TITLE
Add managed templates

### DIFF
--- a/templates/gateway-managed/.template.config/template.json
+++ b/templates/gateway-managed/.template.config/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Michael Staib",
+  "classifications": ["Web", "GraphQL"],
+  "identity": "HotChocolate.Template.ManagedGateway",
+  "sourceName": "HotChocolate.Template.Gateway",
+  "name": "GraphQL Managed Gateway",
+  "shortName": "graphql-managed-gateway",
+  "defaultName": "GraphQL Gateway",
+  "description": "",
+  "preferNameDirectory": true,
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8"
+        },
+        {
+          "choice": "net9.0",
+          "description": "Target .NET 9"
+        },
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10"
+        }
+      ],
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
+    }
+  },
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/gateway-managed/HotChocolate.Template.Gateway.csproj
+++ b/templates/gateway-managed/HotChocolate.Template.Gateway.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ChilliCream.Nitro.Fusion" Version="15.0.0" />
+    <PackageReference Include="ChilliCream.Nitro.Telemetry" Version="15.0.0" />
+    <PackageReference Include="HotChocolate.Fusion.AspNetCore" Version="14.0.0-preview.build.0" />
+    <!-- TODO: This should be based on the target framework selection -->
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.8" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+
+  </ItemGroup>
+
+</Project>

--- a/templates/gateway-managed/Program.cs
+++ b/templates/gateway-managed/Program.cs
@@ -1,0 +1,50 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddHeaderPropagation(c =>
+    {
+        c.Headers.Add("GraphQL-Preflight");
+        c.Headers.Add("Authorization");
+    });
+
+builder.Services
+    .AddHttpClient("fusion")
+    .AddHeaderPropagation();
+
+builder.Services
+    .AddGraphQLGatewayServer()
+    .ConfigureFromCloud(options =>
+    {
+        options.ApiId = "YOUR_API_ID";
+        options.Stage = "prod";
+        options.ApiKey = "YOUR_API_KEY";
+    })
+    // TODO: This needs to go
+    .CoreBuilder.AddInstrumentation();
+
+builder.Services.AddNitroTelemetry(options =>
+{
+    options.ApiId = "YOUR_API_ID";
+    options.Stage = "prod";
+    options.ApiKey = "YOUR_API_KEY";
+});
+
+builder.Services
+    .AddOpenTelemetry()
+    .WithTracing(builder =>
+    {
+        builder.AddHttpClientInstrumentation();
+        builder.AddAspNetCoreInstrumentation();
+        builder.AddNitroExporter();
+    })
+    .WithLogging(builder =>
+    {
+        builder.AddNitroExporter();
+    });
+
+var app = builder.Build();
+
+app.UseHeaderPropagation();
+app.MapGraphQL();
+
+app.Run();

--- a/templates/gateway-managed/Properties/launchSettings.json
+++ b/templates/gateway-managed/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5098/graphql",
+      "applicationUrl": "http://localhost:5098",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/gateway-managed/appsettings.Development.json
+++ b/templates/gateway-managed/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/templates/gateway-managed/appsettings.json
+++ b/templates/gateway-managed/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/templates/server-managed/.template.config/template.json
+++ b/templates/server-managed/.template.config/template.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Michael Staib",
+  "classifications": ["Web", "GraphQL"],
+  "identity": "HotChocolate.Template.ManagedServer",
+  "sourceName": "HotChocolate.Template.Server",
+  "name": "GraphQL Managed Server",
+  "shortName": "graphql-managed",
+  "defaultName": "GraphQL",
+  "description": "",
+  "preferNameDirectory": true,
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": "Target .NET 8"
+        },
+        {
+          "choice": "net9.0",
+          "description": "Target .NET 9"
+        },
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10"
+        }
+      ],
+      "replaces": "net8.0",
+      "defaultValue": "net8.0"
+    }
+  },
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/templates/server-managed/HotChocolate.Template.Server.csproj
+++ b/templates/server-managed/HotChocolate.Template.Server.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable'">
+    <Using Include="HotChocolate.Template.Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ChilliCream.Nitro" Version="15.0.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="14.0.0-preview.build.0" />
+    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="14.0.0-preview.build.0" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.0.0-preview.build.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/templates/server-managed/Program.cs
+++ b/templates/server-managed/Program.cs
@@ -1,0 +1,37 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddGraphQL()
+    .AddTypes()
+    .AddInstrumentation()
+    .AddNitro(options =>
+    {
+        options.ApiId = "YOUR_API_ID";
+        options.Stage = "prod";
+        options.ApiKey = "YOUR_API_KEY";
+    });
+
+builder.Services
+    .AddNitroTelemetry(options =>
+    {
+        options.ApiId = "YOUR_API_ID";
+        options.Stage = "prod";
+        options.ApiKey = "YOUR_API_KEY";
+    });
+
+builder.Services
+    .AddOpenTelemetry()
+    .WithTracing(builder =>
+    {
+        builder.AddAspNetCoreInstrumentation();
+        builder.AddNitroExporter();
+    })
+    .WithLogging(builder =>
+    {
+        builder.AddNitroExporter();
+    });
+
+var app = builder.Build();
+
+app.MapGraphQL();
+
+app.RunWithGraphQLCommands(args);

--- a/templates/server-managed/Properties/ModuleInfo.cs
+++ b/templates/server-managed/Properties/ModuleInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Module("Types")]

--- a/templates/server-managed/Properties/launchSettings.json
+++ b/templates/server-managed/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5095/graphql",
+      "applicationUrl": "http://localhost:5095",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/server-managed/Types/Author.cs
+++ b/templates/server-managed/Types/Author.cs
@@ -1,0 +1,3 @@
+namespace HotChocolate.Template.Server.Types;
+
+public record Author(string Name);

--- a/templates/server-managed/Types/Book.cs
+++ b/templates/server-managed/Types/Book.cs
@@ -1,0 +1,3 @@
+namespace HotChocolate.Template.Server.Types;
+
+public record Book(string Title, Author Author);

--- a/templates/server-managed/Types/Query.cs
+++ b/templates/server-managed/Types/Query.cs
@@ -1,0 +1,8 @@
+namespace HotChocolate.Template.Server.Types;
+
+[QueryType]
+public static class Query
+{
+    public static Book GetBook()
+        => new Book("C# in depth.", new Author("Jon Skeet"));
+}

--- a/templates/server-managed/appsettings.Development.json
+++ b/templates/server-managed/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/templates/server-managed/appsettings.json
+++ b/templates/server-managed/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
While playing around with Nitro today, I thought it would make things a lot easier if you could just spin up a template with telemetry integration.

This needs to be updated, once ChilliCream.Nitro supports v16 and the new Fusion.