### PR TITLE
Infer `@deprecated` for FilterInput/SortInput

### DIFF
--- a/src/HotChocolate/Data/src/Data/Filters/FilterFieldDescriptor.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/FilterFieldDescriptor.cs
@@ -35,6 +35,11 @@ public class FilterFieldDescriptor
         Configuration.Description = convention.GetFieldDescription(member);
         Configuration.Type = convention.GetFieldType(member);
         Configuration.Scope = scope;
+
+        if (context.Naming.IsDeprecated(member, out var reason))
+        {
+            Deprecated(reason);
+        }
     }
 
     protected FilterFieldDescriptor(

--- a/src/HotChocolate/Data/src/Data/Sorting/SortFieldDescriptor.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/SortFieldDescriptor.cs
@@ -46,6 +46,11 @@ public class SortFieldDescriptor
         Configuration.Type = convention.GetFieldType(member);
         Configuration.Scope = scope;
         Configuration.Flags = CoreFieldFlags.SortOperationField;
+
+        if (context.Naming.IsDeprecated(member, out var reason))
+        {
+            Deprecated(reason);
+        }
     }
 
     protected internal SortFieldDescriptor(IDescriptorContext context, string? scope)

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/FilterInputTypeTest.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/FilterInputTypeTest.cs
@@ -407,6 +407,18 @@ public class FilterInputTypeTest : FilterTestBase
         result.MatchSnapshot();
     }
 
+    [Fact]
+    public void FilterInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields()
+    {
+        // arrange
+        // act
+        var schema = CreateSchema(
+            s => s.AddType(new FilterInputType<TypeWithDeprecatedField>()));
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
     public class FooDirectiveType
         : DirectiveType<FooDirective>
     {
@@ -608,4 +620,8 @@ public class FilterInputTypeTest : FilterTestBase
     }
 
     public record struct ExampleValueType(string Foo, string Bar);
+
+    public record TypeWithDeprecatedField(
+        string Foo,
+        [property: GraphQLDeprecated("old")] string? DeprecatedField = null);
 }

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields.graphql
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/__snapshots__/FilterInputTypeTest.FilterInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields.graphql
@@ -1,0 +1,29 @@
+schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+input StringOperationFilterInput {
+  and: [StringOperationFilterInput!]
+  or: [StringOperationFilterInput!]
+  eq: String
+  neq: String
+  contains: String
+  ncontains: String
+  in: [String]
+  nin: [String]
+  startsWith: String
+  nstartsWith: String
+  endsWith: String
+  nendsWith: String
+}
+
+input TypeWithDeprecatedFieldFilterInput {
+  and: [TypeWithDeprecatedFieldFilterInput!]
+  or: [TypeWithDeprecatedFieldFilterInput!]
+  foo: StringOperationFilterInput
+  deprecatedField: StringOperationFilterInput @deprecated(reason: "old")
+}

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/SortInputTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/SortInputTypeTests.cs
@@ -237,6 +237,18 @@ public class SortInputTypeTests : SortTestBase
         schema.ToString().MatchSnapshot();
     }
 
+    [Fact]
+    public void SortInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields()
+    {
+        // arrange
+        // act
+        var schema = CreateSchema(
+            s => s.AddType(new SortInputType<TypeWithDeprecatedField>()));
+
+        // assert
+        schema.MatchSnapshot();
+    }
+
     public class IgnoreTest
     {
         public int Id { get; set; }
@@ -368,4 +380,8 @@ public class SortInputTypeTests : SortTestBase
             descriptor.Field(x => x.Root).UseFiltering();
         }
     }
+
+    public record TypeWithDeprecatedField(
+        string Foo,
+        [property: GraphQLDeprecated("old")] string? DeprecatedField = null);
 }

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields.graphql
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/__snapshots__/SortInputTypeTests.SortInputType_ShouldInferDeprecatedDirective_ForDeprecatedFields.graphql
@@ -1,0 +1,17 @@
+schema {
+  query: Query
+}
+
+type Query {
+  foo: String
+}
+
+input TypeWithDeprecatedFieldSortInput {
+  foo: SortEnumType
+  deprecatedField: SortEnumType @deprecated(reason: "old")
+}
+
+enum SortEnumType {
+  ASC
+  DESC
+}


### PR DESCRIPTION
Infer `@deprecated` for FilterInput/SortInput from the actual field.

Closes #8527 