### PR TITLE
adds overload for parsing mutable schema based on `DocumentNode`

### DIFF
--- a/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
@@ -28,6 +28,14 @@ public static class SchemaParser
         SchemaParserOptions options = default)
     {
         var document = Utf8GraphQLParser.Parse(sourceText);
+        return Parse(schema, document, options);
+    }
+
+    public static void Parse(
+        MutableSchemaDefinition schema,
+        DocumentNode document,
+        SchemaParserOptions options = default)
+    {
         var existingTypeNames = schema.Types.Select(t => t.Name);
         var existingDirectiveNames = schema.DirectiveDefinitions.AsEnumerable().Select(d => d.Name);
         var skippedNodes = new HashSet<ISyntaxNode>();


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Detail 1
- Detail 2

Closes #bugnumber (in this specific format)
