### PR TITLE
Re-add Nitro CLI --output json option

### DIFF
--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/Component/ApiDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/Component/ApiDetailPrompt.cs
@@ -12,27 +12,57 @@ internal sealed class ApiDetailPrompt
         _data = data;
     }
 
-    public Result ToResult()
+    public ApiDetailPromptResult ToObject()
     {
-        return new ObjectResult(new
+        return new ApiDetailPromptResult
         {
-            _data.Id,
-            _data.Name,
+            Id = _data.Id,
+            Name = _data.Name,
             Path = string.Join("/", _data.Path),
             Workspace = _data.Workspace is { } workspace
-                ? new { workspace.Name }
+                ? new ApiDetailPromptWorkspace { Name = workspace.Name }
                 : null,
-            Settings = new
+            ApiDetailPromptSettings = new ApiDetailPromptSettings
             {
-                SchemaRegistry = new
+                ApiDetailPromptSchemaRegistry = new ApiDetailPromptSchemaRegistrySettings
                 {
-                    _data.Settings.SchemaRegistry.TreatDangerousAsBreaking,
-                    _data.Settings.SchemaRegistry.AllowBreakingSchemaChanges
+                    TreatDangerousAsBreaking = _data.Settings.SchemaRegistry.TreatDangerousAsBreaking,
+                    AllowBreakingSchemaChanges = _data.Settings.SchemaRegistry.AllowBreakingSchemaChanges
                 }
             }
-        });
+        };
     }
 
     public static ApiDetailPrompt From(IApiDetailPrompt_Api data)
         => new(data);
+
+    public class ApiDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required string Path { get; init; }
+
+        public required ApiDetailPromptWorkspace? Workspace { get; init; }
+
+        public required ApiDetailPromptSettings ApiDetailPromptSettings { get; init; }
+    }
+
+    public class ApiDetailPromptWorkspace
+    {
+        public required string Name { get; init; }
+    }
+
+    public class ApiDetailPromptSettings
+    {
+        public required ApiDetailPromptSchemaRegistrySettings ApiDetailPromptSchemaRegistry { get; init; }
+    }
+
+    public class ApiDetailPromptSchemaRegistrySettings
+    {
+        public required bool TreatDangerousAsBreaking { get; init; }
+
+        public required bool AllowBreakingSchemaChanges { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/CreateApiCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/CreateApiCommand.cs
@@ -76,7 +76,7 @@ internal sealed class CreateApiCommand : Command
 
         if (changeResult.Result is IApiDetailPrompt_Api detail)
         {
-            context.SetResult(ApiDetailPrompt.From(detail).ToResult());
+            context.SetResult(ApiDetailPrompt.From(detail).ToObject());
         }
 
         return ExitCodes.Success;

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/DeleteApiCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/DeleteApiCommand.cs
@@ -70,7 +70,7 @@ internal sealed class DeleteApiCommand : Command
         console.OkLine(
             $"Api {changeResult.Name.AsHighlight()} [dim](ID:{changeResult.Id})[/] was deleted");
 
-        context.SetResult(ApiDetailPrompt.From(changeResult).ToResult());
+        context.SetResult(ApiDetailPrompt.From(changeResult).ToObject());
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/ListApiCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/ListApiCommand.cs
@@ -63,7 +63,7 @@ internal sealed class ListApiCommand : Command
 
         if (api?.Node is IApiDetailPrompt_Api node)
         {
-            context.SetResult(ApiDetailPrompt.From(node).ToResult());
+            context.SetResult(ApiDetailPrompt.From(node).ToObject());
         }
 
         return ExitCodes.Success;
@@ -86,25 +86,10 @@ internal sealed class ListApiCommand : Command
         var endCursor = result.Data?.WorkspaceById?.Apis?.PageInfo.EndCursor;
 
         var items = result.Data?.WorkspaceById?.Apis?.Edges?.Select(x =>
-                new
-                {
-                    x.Node.Id,
-                    x.Node.Name,
-                    x.Node.Path,
-                    Settings = new
-                    {
-                        SchemaRegistry = new
-                        {
-                            x.Node.Settings.SchemaRegistry.TreatDangerousAsBreaking,
-                            x.Node.Settings.SchemaRegistry
-                                .AllowBreakingSchemaChanges
-                        }
-                    }
-                })
-            .Cast<object>()
+                ApiDetailPrompt.From(x.Node).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<ApiDetailPrompt.ApiDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/SetApiSettingsCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/SetApiSettingsCommand.cs
@@ -80,7 +80,7 @@ internal sealed class SetApiSettingsApiCommand : Command
 
         if (api is IApiDetailPrompt_Api detail)
         {
-            context.SetResult(ApiDetailPrompt.From(detail).ToResult());
+            context.SetResult(ApiDetailPrompt.From(detail).ToObject());
         }
 
         return ExitCodes.Success;

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/ShowApiCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Api/ShowApiCommand.cs
@@ -37,7 +37,7 @@ internal sealed class ShowApiCommand : Command
 
         if (data.Node is IApiDetailPrompt_Api node)
         {
-            context.SetResult(ApiDetailPrompt.From(node).ToResult());
+            context.SetResult(ApiDetailPrompt.From(node).ToObject());
         }
         else
         {

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/Component/ApiKeyDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/Component/ApiKeyDetailPrompt.cs
@@ -12,18 +12,32 @@ internal sealed class ApiKeyDetailPrompt
         _data = data;
     }
 
-    public Result ToResult()
+    public ApiKeyDetailPromptResult ToObject()
     {
-        return new ObjectResult(new
+        return new ApiKeyDetailPromptResult
         {
-            _data.Id,
-            _data.Name,
+            Id = _data.Id,
+            Name = _data.Name,
             Workspace = _data.Workspace is { } workspace
-                ? new { workspace.Name }
+                ? new ApiKeyDetailPromptWorkspace { Name = workspace.Name }
                 : null
-        });
+        };
     }
 
     public static ApiKeyDetailPrompt From(IApiKeyDetailPrompt_ApiKey data)
         => new(data);
+
+    public class ApiKeyDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required ApiKeyDetailPromptWorkspace? Workspace { get; init; }
+    }
+
+    public class ApiKeyDetailPromptWorkspace
+    {
+        public required string Name { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/CreateApiKeyCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/CreateApiKeyCommand.cs
@@ -61,13 +61,20 @@ internal sealed class CreateApiKeyCommand : Command
 
         if (changeResult.Key is IApiKeyDetailPrompt_ApiKey detail)
         {
-            context.SetResult(new
+            context.SetResult(new CreateApiKeyResult
             {
-                changeResult.Secret,
-                Details = ApiKeyDetailPrompt.From(detail).ToResult()
+                Secret = changeResult.Secret,
+                Details = ApiKeyDetailPrompt.From(detail).ToObject()
             });
         }
 
         return ExitCodes.Success;
+    }
+
+    public class CreateApiKeyResult
+    {
+        public required string Secret { get; init; }
+
+        public required ApiKeyDetailPrompt.ApiKeyDetailPromptResult Details { get; init; }
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/DeleteApiKeyCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/DeleteApiKeyCommand.cs
@@ -59,7 +59,7 @@ internal sealed class DeleteApiKeyCommand : Command
         console.OkLine(
             $"ApiKey {changeResult.Name.AsHighlight()} [dim](ID:{changeResult.Id})[/] was deleted");
 
-        context.SetResult(ApiKeyDetailPrompt.From(changeResult).ToResult());
+        context.SetResult(ApiKeyDetailPrompt.From(changeResult).ToObject());
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/ListApiKeyCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/ApiKeys/ListApiKeyCommand.cs
@@ -62,7 +62,7 @@ internal sealed class ListApiKeyCommand : Command
 
         if (api?.Node is IApiKeyDetailPrompt_ApiKey node)
         {
-            context.SetResult(ApiKeyDetailPrompt.From(node).ToResult());
+            context.SetResult(ApiKeyDetailPrompt.From(node).ToObject());
         }
 
         return ExitCodes.Success;
@@ -84,19 +84,11 @@ internal sealed class ListApiKeyCommand : Command
 
         var endCursor = result.Data?.WorkspaceById?.ApiKeys?.PageInfo.EndCursor;
 
-        var items = result.Data?.WorkspaceById?.ApiKeys?.Edges?.Select(x =>
-                new
-                {
-                    x.Node.Id,
-                    x.Node.Name,
-                    Workspace = x.Node.Workspace is { } workspace
-                        ? new { workspace.Name }
-                        : null
-                })
-            .Cast<object>()
+        var items =  result.Data?.WorkspaceById?.ApiKeys?.Edges?.Select(x =>
+                ApiKeyDetailPrompt.From(x.Node).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<ApiKeyDetailPrompt.ApiKeyDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Client/ListClientCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Client/ListClientCommand.cs
@@ -91,13 +91,12 @@ internal sealed class ListClientCommand : Command
         var endCursor = (result.Data?.Node as IListClientCommandQuery_Node_Api)?.Clients?.PageInfo
             .EndCursor;
 
-        var items = (result.Data?.Node as IListClientCommandQuery_Node_Api)?.Clients?.Edges?.Select(
-                x =>
-                    new { x.Node.Id, x.Node.Name })
-            .Cast<object>()
+        var taskItems = (result.Data?.Node as IListClientCommandQuery_Node_Api)?.Clients?.Edges?.Select(x =>
+                ClientDetailPrompt.From(x.Node, client).ToObject([]))
             .ToArray() ?? [];
+        var items = await Task.WhenAll(taskItems);
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<ClientDetailPrompt.ClientDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Environments/Component/EnvironmentDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Environments/Component/EnvironmentDetailPrompt.cs
@@ -11,18 +11,32 @@ internal sealed class EnvironmentDetailPrompt
         _data = data;
     }
 
-    public object ToObject()
+    public EnvironmentDetailPromptResult ToObject()
     {
-        return new
+        return new EnvironmentDetailPromptResult
         {
-            _data.Id,
-            _data.Name,
+            Id = _data.Id,
+            Name = _data.Name,
             Workspace = _data.Workspace is { } workspace
-                ? new { workspace.Name }
+                ? new EnvironmentDetailPromptWorkspace { Name = workspace.Name }
                 : null
         };
     }
 
     public static EnvironmentDetailPrompt From(IEnvironmentDetailPrompt_Environment data)
         => new(data);
+
+    public class EnvironmentDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required EnvironmentDetailPromptWorkspace? Workspace { get; init; }
+    }
+
+    public class EnvironmentDetailPromptWorkspace
+    {
+        public required string Name { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Environments/ListEnvironmentCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Environments/ListEnvironmentCommand.cs
@@ -85,11 +85,10 @@ internal sealed class ListEnvironmentCommand : Command
         var endCursor = result.Data?.WorkspaceById?.Environments?.PageInfo.EndCursor;
 
         var items = result.Data?.WorkspaceById?.Environments?.Edges?.Select(x =>
-                new { x.Node.Id, x.Node.Name })
-            .Cast<object>()
+                EnvironmentDetailPrompt.From(x.Node).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<EnvironmentDetailPrompt.EnvironmentDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/FusionConfiguration/PublishCommand/FusionConfigurationPublishBeginCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/FusionConfiguration/PublishCommand/FusionConfigurationPublishBeginCommand.cs
@@ -147,8 +147,13 @@ internal sealed class FusionConfigurationPublishBeginCommand : Command
 
             console.WriteLine("Request ID:");
             console.WriteLine(requestId);
-            context.SetResult(new { RequestId = requestId });
+            context.SetResult(new FusionConfigurationPublishBeginCommandResult { RequestId = requestId });
             await FusionConfigurationPublishingState.SetRequestId(requestId, ct);
         }
+    }
+
+    public class FusionConfigurationPublishBeginCommandResult
+    {
+        public required string RequestId { get; init; }
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Mock/Component/MockSchemaDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Mock/Component/MockSchemaDetailPrompt.cs
@@ -4,19 +4,48 @@ namespace ChilliCream.Nitro.CommandLine.Cloud.Commands.Mock.Component;
 
 internal sealed class MockSchemaDetailPrompt(IMockSchemaDetailPrompt data)
 {
-    public object ToObject()
+    public MockSchemaDetailPromptResult ToObject()
     {
-        return new
+        return new MockSchemaDetailPromptResult
         {
-            data.Id,
-            data.Name,
-            data.Url,
-            data.DownstreamUrl,
-            CreatedBy = new { data.CreatedBy.Username, data.CreatedAt },
-            ModifiedBy = new { data.ModifiedBy.Username, data.ModifiedAt }
+            Id = data.Id,
+            Name = data.Name,
+            Url = data.Url,
+            DownstreamUrl = data.DownstreamUrl.ToString(),
+            CreatedBy = new CreatedBy { Username = data.CreatedBy.Username, CreatedAt = data.CreatedAt },
+            ModifiedBy = new ModifiedBy { Username = data.ModifiedBy.Username, ModifiedAt = data.ModifiedAt }
         };
     }
 
     public static MockSchemaDetailPrompt From(IMockSchemaDetailPrompt data)
         => new(data);
+
+    public class MockSchemaDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required string Url { get; init; }
+
+        public required string DownstreamUrl { get; init; }
+
+        public required CreatedBy CreatedBy { get; init; }
+
+        public required ModifiedBy ModifiedBy { get; init; }
+    }
+
+    public class CreatedBy
+    {
+        public required string Username { get; init; }
+
+        public required DateTimeOffset CreatedAt { get; init; }
+    }
+
+    public class ModifiedBy
+    {
+        public required string Username { get; init; }
+
+        public required DateTimeOffset ModifiedAt { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Mock/ListMockCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Mock/ListMockCommand.cs
@@ -96,7 +96,7 @@ internal sealed class ListMockCommand : Command
                 MockSchemaDetailPrompt.From(x.Node).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<MockSchemaDetailPrompt.MockSchemaDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/Component/PersonalAccessTokenDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/Component/PersonalAccessTokenDetailPrompt.cs
@@ -12,12 +12,29 @@ internal sealed class PersonalAccessTokenDetailPrompt
         _data = data;
     }
 
-    public object ToObject()
+    public PersonalAccessTokenDetailPromptResult ToObject()
     {
-        return new { _data.Id, _data.Description, _data.CreatedAt, _data.ExpiresAt };
+        return new PersonalAccessTokenDetailPromptResult
+        {
+            Id = _data.Id,
+            Description = _data.Description,
+            CreatedAt = _data.CreatedAt,
+            ExpiresAt = _data.ExpiresAt
+        };
     }
 
     public static PersonalAccessTokenDetailPrompt From(
         IPersonalAccessTokenDetailPrompt_PersonalAccessToken data)
         => new(data);
+
+    public class PersonalAccessTokenDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Description { get; init; }
+
+        public required DateTimeOffset CreatedAt { get; init; }
+
+        public required DateTimeOffset ExpiresAt { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/CreatePersonalAccessTokenCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/CreatePersonalAccessTokenCommand.cs
@@ -69,13 +69,20 @@ internal sealed class CreatePersonalAccessTokenCommand : Command
         if (changeResult.Token is IPersonalAccessTokenDetailPrompt_PersonalAccessToken detail)
         {
             context.SetResult(
-                new
+                new CreatePersonalAccessTokenCommandResult
                 {
-                    changeResult.Secret,
+                    Secret = changeResult.Secret,
                     Details = PersonalAccessTokenDetailPrompt.From(detail).ToObject()
                 });
         }
 
         return ExitCodes.Success;
+    }
+
+    public class CreatePersonalAccessTokenCommandResult
+    {
+        public required string Secret { get; init; }
+
+        public required PersonalAccessTokenDetailPrompt.PersonalAccessTokenDetailPromptResult Details { get; init; }
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/ListPersonalAccessTokenCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/PersonalAccessTokens/ListPersonalAccessTokenCommand.cs
@@ -91,11 +91,14 @@ internal sealed class ListPersonalAccessTokenCommand : Command
 
         var endCursor = result.Data?.Me?.PersonalAccessTokens?.PageInfo.EndCursor;
 
-        var items = result.Data?.Me?.PersonalAccessTokens?.Edges?
-            .Select(x => PersonalAccessTokenDetailPrompt.From(x.Node).ToObject())
-            .ToArray() ?? [];
+        var items = result.Data?.Me?.PersonalAccessTokens?.Edges?.Select(x =>
+                    PersonalAccessTokenDetailPrompt.From(x.Node).ToObject())
+                .ToArray() ??
+            [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(
+            new PaginatedListResult<PersonalAccessTokenDetailPrompt.PersonalAccessTokenDetailPromptResult>(items,
+                endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/Component/StageDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/Component/StageDetailPrompt.cs
@@ -11,18 +11,35 @@ internal sealed class StageDetailPrompt
         _data = data;
     }
 
-    public object ToObject()
+    public StageDetailPromptResult ToObject()
     {
-        return new
+        return new StageDetailPromptResult
         {
-            _data.Id,
-            _data.Name,
+            Id = _data.Id,
+            Name = _data.Name,
             Conditions = _data.Conditions
                 .OfType<IAfterStageCondition>()
-                .Select(x => new { Kind = "AfterStage", x.AfterStage!.Name })
+                .Select(x => new StageCondition { Kind = "AfterStage", Name =  x.AfterStage!.Name })
+                .ToList()
         };
     }
 
     public static StageDetailPrompt From(IStageDetailPrompt_Stage data)
         => new(data);
+
+    public class StageDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required IReadOnlyList<StageCondition> Conditions { get; init; }
+    }
+
+    public class StageCondition
+    {
+        public required string Kind { get; init; }
+
+        public required string Name { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/EditStagesCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/EditStagesCommand.cs
@@ -195,14 +195,11 @@ file static class ClientExtensions
         updateResult.EnsureData();
         console.PrintErrorsAndExit(updateResult.Data?.UpdateStages.Errors);
 
-        context.SetResult(
-            new
-            {
-                Stages = updateResult.Data?.UpdateStages.Api?.Stages.Select(y =>
-                    StageDetailPrompt.From(y).ToObject()
-                )
-            }
-        );
+        var items =  updateResult.Data?.UpdateStages.Api?.Stages
+            .Select(x => StageDetailPrompt.From(x).ToObject())
+            .ToArray() ?? [];
+
+        context.SetResult(new PaginatedListResult<StageDetailPrompt.StageDetailPromptResult>(items, null));
 
         console.OkLine("Successfully updated stages");
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/ListStagesCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Stages/ListStagesCommand.cs
@@ -94,7 +94,7 @@ internal sealed class ListStagesCommand : Command
             .Select(x => StageDetailPrompt.From(x).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new { Values = items });
+        context.SetResult(new PaginatedListResult<StageDetailPrompt.StageDetailPromptResult>(items, null));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Workspace/Component/WorkspaceDetailPrompt.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Workspace/Component/WorkspaceDetailPrompt.cs
@@ -11,11 +11,25 @@ internal sealed class WorkspaceDetailPrompt
         _data = data;
     }
 
-    public object ToObject()
+    public WorkspaceDetailPromptResult ToObject()
     {
-        return new { _data.Id, _data.Name, _data.Personal };
+        return new WorkspaceDetailPromptResult
+        {
+            Id = _data.Id,
+            Name = _data.Name,
+            Personal = _data.Personal
+        };
     }
 
     public static WorkspaceDetailPrompt From(IWorkspaceDetailPrompt_Workspace data)
         => new(data);
+
+    public class WorkspaceDetailPromptResult
+    {
+        public required string Id { get; init; }
+
+        public required string Name { get; init; }
+
+        public required bool Personal { get; init; }
+    }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Workspace/ListWorkspaceCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Workspace/ListWorkspaceCommand.cs
@@ -84,7 +84,7 @@ internal sealed class ListWorkspaceCommand : Command
                 WorkspaceDetailPrompt.From(x.Node).ToObject())
             .ToArray() ?? [];
 
-        context.SetResult(new PaginatedListResult(items, endCursor!));
+        context.SetResult(new PaginatedListResult<WorkspaceDetailPrompt.WorkspaceDetailPromptResult>(items, endCursor));
 
         return ExitCodes.Success;
     }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Extensions/NitroCloudCommandExtensions.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Extensions/NitroCloudCommandExtensions.cs
@@ -8,6 +8,7 @@ using ChilliCream.Nitro.CommandLine.Cloud.Commands.PersonalAccessToken;
 using ChilliCream.Nitro.CommandLine.Cloud.Commands.Stages;
 using ChilliCream.Nitro.CommandLine.Cloud.Option;
 using ChilliCream.Nitro.CommandLine.Cloud.Option.Binders;
+using ChilliCream.Nitro.CommandLine.Cloud.Results;
 
 namespace ChilliCream.Nitro.CommandLine.Cloud;
 
@@ -17,15 +18,12 @@ public static class NitroCloudCommandExtensions
     {
         builder.Command.AddNitroCloudCommands();
 
-        // TODO: Re-add the result stuff once we figured out how to be AOT compliant with it
         builder.AddService<IConfigurationService, ConfigurationService>()
             .AddSession()
-            // .AddResult()
+            .AddResult()
             .AddApiClient()
-            .AddSessionMiddleware();
-#pragma warning disable format
-            // .AddResultMiddleware();
-#pragma warning restore format
+            .AddSessionMiddleware()
+            .AddResultMiddleware();
 
         return builder;
     }
@@ -51,7 +49,6 @@ public static class NitroCloudCommandExtensions
     {
         command.AddGlobalOption(Opt<CloudUrlOption>.Instance);
         command.AddGlobalOption(Opt<ApiKeyOption>.Instance);
-        // TODO: Re-add once we figured out how to be AOT compliant with it
-        // command.AddGlobalOption(Opt<OutputFormatOption>.Instance);
+        command.AddGlobalOption(Opt<OutputFormatOption>.Instance);
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/JsonResultFormatter.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/JsonResultFormatter.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using Spectre.Console.Json;
+
 namespace ChilliCream.Nitro.CommandLine.Cloud.Results;
 
 internal sealed class JsonResultFormatter(IAnsiConsole console) : IResultFormatter
@@ -16,6 +19,10 @@ internal sealed class JsonResultFormatter(IAnsiConsole console) : IResultFormatt
 
     private void FormatObjectResult(ObjectResult objectResult)
     {
-        console.Json(objectResult.Value);
+        var obj = objectResult.Value;
+
+        var serializedObj = JsonSerializer.Serialize(obj, obj.GetType(), JsonSourceGenerationContext.Default);
+
+        console.Write(new JsonText(serializedObj));
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/JsonSourceGenerationContext.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/JsonSourceGenerationContext.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+using ChilliCream.Nitro.CommandLine.Cloud.Commands.ApiKey;
+using ChilliCream.Nitro.CommandLine.Cloud.Commands.FusionConfiguration;
+using ChilliCream.Nitro.CommandLine.Cloud.Commands.Mock.Component;
+using ChilliCream.Nitro.CommandLine.Cloud.Commands.PersonalAccessToken;
+
+namespace ChilliCream.Nitro.CommandLine.Cloud.Results;
+
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ClientDetailPrompt.ClientDetailPromptResult))]
+[JsonSerializable(typeof(ApiDetailPrompt.ApiDetailPromptResult))]
+[JsonSerializable(typeof(ApiKeyDetailPrompt.ApiKeyDetailPromptResult))]
+[JsonSerializable(typeof(CreateApiKeyCommand.CreateApiKeyResult))]
+[JsonSerializable(typeof(EnvironmentDetailPrompt.EnvironmentDetailPromptResult))]
+[JsonSerializable(typeof(StageDetailPrompt.StageDetailPromptResult))]
+[JsonSerializable(typeof(WorkspaceDetailPrompt.WorkspaceDetailPromptResult))]
+[JsonSerializable(typeof(MockSchemaDetailPrompt.MockSchemaDetailPromptResult))]
+[JsonSerializable(typeof(PersonalAccessTokenDetailPrompt.PersonalAccessTokenDetailPromptResult))]
+[JsonSerializable(typeof(CreatePersonalAccessTokenCommand.CreatePersonalAccessTokenCommandResult))]
+[JsonSerializable(typeof(FusionConfigurationPublishBeginCommand.FusionConfigurationPublishBeginCommandResult))]
+[JsonSerializable(typeof(PaginatedListResult<ApiDetailPrompt.ApiDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<ApiKeyDetailPrompt.ApiKeyDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<ClientDetailPrompt.ClientDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<EnvironmentDetailPrompt.EnvironmentDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<MockSchemaDetailPrompt.MockSchemaDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<PersonalAccessTokenDetailPrompt.PersonalAccessTokenDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<StageDetailPrompt.StageDetailPromptResult>))]
+[JsonSerializable(typeof(PaginatedListResult<WorkspaceDetailPrompt.WorkspaceDetailPromptResult>))]
+internal partial class JsonSourceGenerationContext : JsonSerializerContext;

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/Result.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/Result.cs
@@ -7,5 +7,4 @@ internal class ObjectResult(object value) : Result
     public object Value { get; } = value;
 }
 
-internal sealed class PaginatedListResult(object[] values, string cursor)
-    : ObjectResult(new { Values = values, Cursor = cursor });
+internal sealed record PaginatedListResult<TItem>(TItem[] Values, string? Cursor);

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/ResultCommandLineBuilderExtensions.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Result/ResultCommandLineBuilderExtensions.cs
@@ -52,12 +52,6 @@ internal static class ResultCommandLineBuilderExtensions
         }
     }
 
-    public static void SetResult(this InvocationContext context, Result result)
-    {
-        var resultHolder = context.BindingContext.GetRequiredService<ResultHolder>();
-        resultHolder.Result = result;
-    }
-
     public static void SetResult(this InvocationContext context, object result)
     {
         var resultHolder = context.BindingContext.GetRequiredService<ResultHolder>();

--- a/src/Nitro/CommandLine/src/CommandLine.Core/Helpers/ConsoleHelpers.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Core/Helpers/ConsoleHelpers.cs
@@ -32,15 +32,6 @@ public static class ConsoleHelpers
         console.MarkupLine(Glyphs.Check.Space() + message);
     }
 
-    public static void Json(this IAnsiConsole console, object obj)
-    {
-        // TODO: enable for full AOT compliancy
-        // console.Write(new JsonText(
-        //     JsonSerializer.Serialize(obj,
-        //         new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase })));
-        console.WriteLine("NOT SUPPORTED");
-    }
-
     public static void ErrorLine(this IAnsiConsole console, string message)
     {
         console.MarkupLine(Glyphs.Cross.Space() + message);


### PR DESCRIPTION
Converts all anonymous objects used for command results into typed objects in order to construct a `JsonSerializerContext` that allows for AOT-safe JSON serialization.