### PR TITLE
[Fusion] Add more operation plan telemetry

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Clients/SourceSchemaResult.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Clients/SourceSchemaResult.cs
@@ -20,7 +20,7 @@ public sealed class SourceSchemaResult : IDisposable
         _resource = resource;
         Path = path;
         Data = data;
-        Errors = SourceSchemaErrors.From(errors);
+        Errors = errors;
         Extensions = extensions;
         Final = final;
     }
@@ -29,7 +29,7 @@ public sealed class SourceSchemaResult : IDisposable
 
     public JsonElement Data { get; }
 
-    public SourceSchemaErrors? Errors { get; }
+    public JsonElement Errors { get; }
 
     public JsonElement Extensions { get; }
 

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/ExecutionState.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/ExecutionState.cs
@@ -110,7 +110,8 @@ internal sealed class ExecutionState
                 SpanId = result.Activity?.SpanId.ToHexString(),
                 Status = result.Status,
                 Duration = result.Duration,
-                VariableSets = result.VariableValueSets
+                VariableSets = result.VariableValueSets,
+                SchemaName = result.SchemaName
             });
         }
 

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNode.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNode.cs
@@ -57,7 +57,8 @@ public abstract class ExecutionNode : IEquatable<ExecutionNode>
             Stopwatch.GetElapsedTime(start),
             error,
             context.GetDependentsToExecute(this),
-            context.GetVariableValueSets(this));
+            context.GetVariableValueSets(this),
+            context.GetSchemaName(this));
 
         context.CompleteNode(result);
     }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNodeResult.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNodeResult.cs
@@ -10,4 +10,5 @@ internal sealed record ExecutionNodeResult(
     TimeSpan Duration,
     Exception? Exception,
     ImmutableArray<ExecutionNode> DependentsToExecute,
-    ImmutableArray<VariableValues> VariableValueSets);
+    ImmutableArray<VariableValues> VariableValueSets,
+    string? SchemaName);

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNodeTrace.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/ExecutionNodeTrace.cs
@@ -12,5 +12,7 @@ public sealed class ExecutionNodeTrace
 
     public required ExecutionStatus Status { get; init; }
 
-    public ImmutableArray<VariableValues> VariableSets { get; init; }
+    public required ImmutableArray<VariableValues> VariableSets { get; init; }
+
+    public required string? SchemaName { get; init; }
 }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/NodeExecutionNode.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/NodeExecutionNode.cs
@@ -68,12 +68,16 @@ public sealed class NodeExecutionNode : ExecutionNode
             || !context.TryGetNodeLookupSchemaForType(typeName, out var schemaName))
         {
             // We have an invalid id or a valid id of a type that does not implement the Node interface
-            var error = ErrorBuilder.New()
+            var errorBuilder = ErrorBuilder.New()
                 .SetMessage("The node ID string has an invalid format.")
-                .SetExtension("originalValue", id)
-                .Build();
+                .SetExtension(WellKnownErrorExtensions.OriginalIdValue, id);
 
-            context.AddErrors(error, [_responseName], Path.Root);
+            if (context.CollectTelemetry)
+            {
+                errorBuilder.SetExtension(WellKnownErrorExtensions.SourceOperationPlanNodeId, Id);
+            }
+
+            context.AddErrors(errorBuilder.Build(), [_responseName], Path.Root);
 
             return ValueTask.FromResult(ExecutionStatus.Failed);
         }

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanFormatter.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/JsonOperationPlanFormatter.cs
@@ -140,9 +140,11 @@ public sealed class JsonOperationPlanFormatter : OperationPlanFormatter
         jsonWriter.WriteNumber("id", node.Id);
         jsonWriter.WriteString("type", node.Type.ToString());
 
-        if (!string.IsNullOrEmpty(node.SchemaName))
+        var schemaName = node.SchemaName ?? trace?.SchemaName;
+
+        if (!string.IsNullOrEmpty(schemaName))
         {
-            jsonWriter.WriteString("schema", node.SchemaName);
+            jsonWriter.WriteString("schema", schemaName);
         }
 
         jsonWriter.WriteStartObject("operation");

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Nodes/Serialization/YamlOperationPlanFormatter.cs
@@ -96,9 +96,11 @@ public sealed class YamlOperationPlanFormatter : OperationPlanFormatter
 
         writer.WriteLine("type: {0}", "Operation");
 
-        if (node.SchemaName is not null)
+        var schemaName = node.SchemaName ?? trace?.SchemaName;
+
+        if (!string.IsNullOrEmpty(schemaName))
         {
-            writer.WriteLine("schema: {0}", node.SchemaName);
+            writer.WriteLine("schema: {0}", schemaName);
         }
 
         writer.WriteLine("operation: >-");

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanContext.cs
@@ -182,8 +182,9 @@ public sealed class OperationPlanContext : IFeatureProvider, IAsyncDisposable
     internal void AddPartialResults(
         SelectionPath sourcePath,
         ReadOnlySpan<SourceSchemaResult> results,
+        ReadOnlySpan<SourceSchemaErrors?> errors,
         ReadOnlySpan<string> responseNames)
-        => _resultStore.AddPartialResults(sourcePath, results, responseNames);
+        => _resultStore.AddPartialResults(sourcePath, results, errors, responseNames);
 
     internal void AddPartialResults(ObjectResult result, ReadOnlySpan<Selection> selections)
         => _resultStore.AddPartialResults(result, selections);

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanContext.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanContext.cs
@@ -147,9 +147,21 @@ public sealed class OperationPlanContext : IFeatureProvider, IAsyncDisposable
             return [];
         }
 
-        return _nodeContexts.TryGetValue(node.Id, out var variableValueSets)
-            ? variableValueSets.Variables
+        return _nodeContexts.TryGetValue(node.Id, out var context)
+            ? context.Variables
             : [];
+    }
+
+    internal string? GetSchemaName(ExecutionNode node)
+    {
+        if (!CollectTelemetry)
+        {
+            return null;
+        }
+
+        return _nodeContexts.TryGetValue(node.Id, out var context)
+            ? context.SchemaName
+            : null;
     }
 
     internal void CompleteNode(ExecutionNodeResult result)

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/OperationPlanExecutor.cs
@@ -186,7 +186,8 @@ internal sealed class OperationPlanExecutor
                             eventArgs.Duration,
                             Exception: null,
                             DependentsToExecute: [],
-                            VariableValueSets: eventArgs.VariableValueSets));
+                            VariableValueSets: eventArgs.VariableValueSets,
+                            SchemaName: null));
 
                     while (!cancellationToken.IsCancellationRequested && executionState.IsProcessing())
                     {

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/WellKnownErrorExtensions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/WellKnownErrorExtensions.cs
@@ -1,0 +1,8 @@
+namespace HotChocolate.Fusion.Execution;
+
+public static class WellKnownErrorExtensions
+{
+    public const string OriginalIdValue = "originalValue";
+
+    public const string SourceOperationPlanNodeId = "sourceOperationPlanNodeId";
+}


### PR DESCRIPTION
- Adds `sourceOperationPlanNodeId` to GraphQL errors
- Adds value for dynamic `schemaName` to operation plan

TODO: I don't like the extra work we have to do for this...