### PR TITLE
[fusion] Fixed issue with forwarded variables

### DIFF
--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/BookStoreTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/BookStoreTests.cs
@@ -245,6 +245,141 @@ public class BookStoreTests : FusionTestBase
     }
 
     [Fact]
+    public async Task Fetch_Books_With_Variable_First_And_First_Is_1()
+    {
+        // arrange
+        using var server1 = CreateSourceSchema(
+            "A",
+            b => b.AddQueryType<SourceSchema1.Query>());
+
+        using var server2 = CreateSourceSchema(
+            "B",
+            b => b.AddQueryType<SourceSchema2.Query>());
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", server1),
+            ("B", server2)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        using var result = await client.PostAsync(
+            """
+            query GetBooks($first: Int) {
+              books(first: $first) {
+                nodes {
+                  id
+                  title
+                  author {
+                    name
+                  }
+                }
+              }
+            }
+            """,
+            variables: new Dictionary<string, object?>
+            {
+                { "first", 1 }
+            },
+            uri: new Uri("http://localhost:5000/graphql"));
+
+        // assert
+        using var response = await result.ReadAsResultAsync();
+        response.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Fetch_Books_With_Variable_First_And_First_Omitted()
+    {
+        // arrange
+        using var server1 = CreateSourceSchema(
+            "A",
+            b => b.AddQueryType<SourceSchema1.Query>());
+
+        using var server2 = CreateSourceSchema(
+            "B",
+            b => b.AddQueryType<SourceSchema2.Query>());
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", server1),
+            ("B", server2)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        using var result = await client.PostAsync(
+            """
+            query GetBooks($first: Int) {
+              books(first: $first) {
+                nodes {
+                  id
+                  title
+                  author {
+                    name
+                  }
+                }
+              }
+            }
+            """,
+            variables: new Dictionary<string, object?>(),
+            uri: new Uri("http://localhost:5000/graphql"));
+
+        // assert
+        using var response = await result.ReadAsResultAsync();
+        response.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Fetch_Books_With_Variable_First_Last_And_First_1_And_Last_Omitted()
+    {
+        // arrange
+        using var server1 = CreateSourceSchema(
+            "A",
+            b => b.AddQueryType<SourceSchema1.Query>());
+
+        using var server2 = CreateSourceSchema(
+            "B",
+            b => b.AddQueryType<SourceSchema2.Query>());
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", server1),
+            ("B", server2)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        using var result = await client.PostAsync(
+            """
+            query GetBooks($first: Int, $last: Int) {
+              books(first: $first, last: $last) {
+                nodes {
+                  id
+                  title
+                  author {
+                    name
+                  }
+                }
+              }
+            }
+            """,
+            variables: new Dictionary<string, object?>
+            {
+                { "first", 1 }
+            },
+            uri: new Uri("http://localhost:5000/graphql"));
+
+        // assert
+        using var response = await result.ReadAsResultAsync();
+        response.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task Fetch_Books_With_Requirements_To_SourceSchema1()
     {
         // arrange
@@ -458,7 +593,11 @@ public class BookStoreTests : FusionTestBase
 
             public Query()
             {
-                _authors = new() { [1] = new Author(1, "Jon Skeet"), [2] = new Author(2, "JRR Tolkien") };
+                _authors = new()
+                {
+                    [1] = new Author(1, "Jon Skeet"),
+                    [2] = new Author(2, "JRR Tolkien")
+                };
 
                 _books = new()
                 {

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_And_First_Is_1.snap
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_And_First_Is_1.snap
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "books": {
+      "nodes": [
+        {
+          "id": 1,
+          "title": "C# in Depth",
+          "author": {
+            "name": "Jon Skeet"
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "fusion": {
+      "operationPlan": {
+        "id": "05bf4dd657b2a180207f5491f1bc6c2224acbd32e538dae495d2c463e60cbdf4",
+        "operation": {
+          "name": "GetBooks",
+          "kind": "Query",
+          "document": "query GetBooks(\n  $first: Int\n) {\n  books(first: $first) {\n    nodes {\n      id\n      title\n      author {\n        name\n        id @fusion__requirement\n      }\n    }\n  }\n}",
+          "id": "f1bed549ddb5fadb135070be28b9aa58",
+          "hash": "f1bed549ddb5fadb135070be28b9aa58",
+          "shortHash": "f1bed549"
+        },
+        "nodes": [
+          {
+            "id": 1,
+            "type": "Operation",
+            "schema": "A",
+            "operation": {
+              "name": "GetBooks_f1bed549_1",
+              "type": "Query",
+              "document": "query GetBooks_f1bed549_1(\n  $first: Int\n) {\n  books(first: $first) {\n    nodes {\n      id\n      title\n      author {\n        id\n      }\n    }\n  }\n}",
+              "hash": "ca150b9396d3101411a6c840df8109f3f6dda216e385328d8d73252f68334826",
+              "shortHash": "ca150b93"
+            },
+            "responseNames": [
+              "books"
+            ]
+          },
+          {
+            "id": 2,
+            "type": "Operation",
+            "schema": "B",
+            "operation": {
+              "name": "GetBooks_f1bed549_2",
+              "type": "Query",
+              "document": "query GetBooks_f1bed549_2(\n  $__fusion_1_id: Int!\n) {\n  authorById(id: $__fusion_1_id) {\n    name\n  }\n}",
+              "hash": "7465d9b6f56139686be87c8c5738678018ad63abf5f2c9bce288c17559872419",
+              "shortHash": "7465d9b6"
+            },
+            "responseNames": [
+              "name"
+            ],
+            "source": "$.authorById",
+            "target": "$.books.nodes.author",
+            "requirements": [
+              {
+                "name": "__fusion_1_id",
+                "type": "Int!",
+                "path": "$.books.nodes.author",
+                "selectionMap": "id"
+              }
+            ],
+            "forwardedVariables": [],
+            "dependencies": [
+              1
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_And_First_Omitted.snap
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_And_First_Omitted.snap
@@ -1,0 +1,97 @@
+{
+  "data": {
+    "books": {
+      "nodes": [
+        {
+          "id": 1,
+          "title": "C# in Depth",
+          "author": {
+            "name": "Jon Skeet"
+          }
+        },
+        {
+          "id": 2,
+          "title": "The Lord of the Rings",
+          "author": {
+            "name": "JRR Tolkien"
+          }
+        },
+        {
+          "id": 3,
+          "title": "The Hobbit",
+          "author": {
+            "name": "JRR Tolkien"
+          }
+        },
+        {
+          "id": 4,
+          "title": "The Silmarillion",
+          "author": {
+            "name": "JRR Tolkien"
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "fusion": {
+      "operationPlan": {
+        "id": "05bf4dd657b2a180207f5491f1bc6c2224acbd32e538dae495d2c463e60cbdf4",
+        "operation": {
+          "name": "GetBooks",
+          "kind": "Query",
+          "document": "query GetBooks(\n  $first: Int\n) {\n  books(first: $first) {\n    nodes {\n      id\n      title\n      author {\n        name\n        id @fusion__requirement\n      }\n    }\n  }\n}",
+          "id": "f1bed549ddb5fadb135070be28b9aa58",
+          "hash": "f1bed549ddb5fadb135070be28b9aa58",
+          "shortHash": "f1bed549"
+        },
+        "nodes": [
+          {
+            "id": 1,
+            "type": "Operation",
+            "schema": "A",
+            "operation": {
+              "name": "GetBooks_f1bed549_1",
+              "type": "Query",
+              "document": "query GetBooks_f1bed549_1(\n  $first: Int\n) {\n  books(first: $first) {\n    nodes {\n      id\n      title\n      author {\n        id\n      }\n    }\n  }\n}",
+              "hash": "ca150b9396d3101411a6c840df8109f3f6dda216e385328d8d73252f68334826",
+              "shortHash": "ca150b93"
+            },
+            "responseNames": [
+              "books"
+            ]
+          },
+          {
+            "id": 2,
+            "type": "Operation",
+            "schema": "B",
+            "operation": {
+              "name": "GetBooks_f1bed549_2",
+              "type": "Query",
+              "document": "query GetBooks_f1bed549_2(\n  $__fusion_1_id: Int!\n) {\n  authorById(id: $__fusion_1_id) {\n    name\n  }\n}",
+              "hash": "7465d9b6f56139686be87c8c5738678018ad63abf5f2c9bce288c17559872419",
+              "shortHash": "7465d9b6"
+            },
+            "responseNames": [
+              "name"
+            ],
+            "source": "$.authorById",
+            "target": "$.books.nodes.author",
+            "requirements": [
+              {
+                "name": "__fusion_1_id",
+                "type": "Int!",
+                "path": "$.books.nodes.author",
+                "selectionMap": "id"
+              }
+            ],
+            "forwardedVariables": [],
+            "dependencies": [
+              1
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_Last_And_First_1_And_Last_Omitted.snap
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/BookStoreTests.Fetch_Books_With_Variable_First_Last_And_First_1_And_Last_Omitted.snap
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "books": {
+      "nodes": [
+        {
+          "id": 1,
+          "title": "C# in Depth",
+          "author": {
+            "name": "Jon Skeet"
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "fusion": {
+      "operationPlan": {
+        "id": "b7ebef371188ac1b8e94f209239d026e8c43153742f786e896055eb8afbe884d",
+        "operation": {
+          "name": "GetBooks",
+          "kind": "Query",
+          "document": "query GetBooks(\n  $first: Int\n  $last: Int\n) {\n  books(first: $first, last: $last) {\n    nodes {\n      id\n      title\n      author {\n        name\n        id @fusion__requirement\n      }\n    }\n  }\n}",
+          "id": "938ff9c055f12c1e277010b7756339fa",
+          "hash": "938ff9c055f12c1e277010b7756339fa",
+          "shortHash": "938ff9c0"
+        },
+        "nodes": [
+          {
+            "id": 1,
+            "type": "Operation",
+            "schema": "A",
+            "operation": {
+              "name": "GetBooks_938ff9c0_1",
+              "type": "Query",
+              "document": "query GetBooks_938ff9c0_1(\n  $first: Int\n  $last: Int\n) {\n  books(first: $first, last: $last) {\n    nodes {\n      id\n      title\n      author {\n        id\n      }\n    }\n  }\n}",
+              "hash": "f7a1e037efde48a7a307cfd09902e55a8055db3feb1a16b6056f725be4515934",
+              "shortHash": "f7a1e037"
+            },
+            "responseNames": [
+              "books"
+            ]
+          },
+          {
+            "id": 2,
+            "type": "Operation",
+            "schema": "B",
+            "operation": {
+              "name": "GetBooks_938ff9c0_2",
+              "type": "Query",
+              "document": "query GetBooks_938ff9c0_2(\n  $__fusion_1_id: Int!\n) {\n  authorById(id: $__fusion_1_id) {\n    name\n  }\n}",
+              "hash": "8cd0f1894efe9efd6d0fe929722c5773471ad71f0e5f137a0886e7662a56fd28",
+              "shortHash": "8cd0f189"
+            },
+            "responseNames": [
+              "name"
+            ],
+            "source": "$.authorById",
+            "target": "$.books.nodes.author",
+            "requirements": [
+              {
+                "name": "__fusion_1_id",
+                "type": "Int!",
+                "path": "$.books.nodes.author",
+                "selectionMap": "id"
+              }
+            ],
+            "forwardedVariables": [],
+            "dependencies": [
+              1
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Forwarded variables caused a runtime exception when they were explicitly omitted. However, GraphQL allows to omit nullable variables. This PR fixes this issue.