### PR TITLE
[Fusion] Re-throw operation planning exception

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Pipeline/OperationPlanMiddleware.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Pipeline/OperationPlanMiddleware.cs
@@ -69,9 +69,11 @@ internal sealed class OperationPlanMiddleware
             OnAfterPlanCompleted(operationDocumentInfo, operationPlan);
             context.SetOperationPlan(operationPlan);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             _diagnosticsEvents.PlanOperationError(context, operationId, ex);
+
+            throw;
         }
     }
 


### PR DESCRIPTION
Not doing this causes the pipeline to continue and you end up with 

```json
{
  "errors": [
    {
      "message": "The variable coercion requires an operation execution plan."
    }
  ]
}
```