### PR TITLE
Fix Nitro CLI AOT build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
             --self-contained true \
             -p:PublishAot=true \
             -p:TargetFrameworks=NET10.0 \
+            -p:RuntimeIdentifiers=${{ matrix.rid }} \
             -o ./publish
 
       - name: 📦 Zip Binary (Windows)

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/HotChocolate.Fusion.CommandLine.csproj
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.CommandLine/HotChocolate.Fusion.CommandLine.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PublishAot>false</PublishAot>
+    <UseAppHost>false</UseAppHost>
     <RootNamespace>HotChocolate.Fusion</RootNamespace>
     <PackageId>HotChocolate.Fusion.CommandLine</PackageId>
     <ToolCommandName>fusion</ToolCommandName>

--- a/src/Nitro/CommandLine/src/CommandLine/Nitro.CommandLine.csproj
+++ b/src/Nitro/CommandLine/src/CommandLine/Nitro.CommandLine.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
+    <PublishAot>false</PublishAot>
     <UseAppHost>false</UseAppHost>
     <ToolCommandName>nitro</ToolCommandName>
     <RootNamespace>ChilliCream.Nitro.CommandLine</RootNamespace>


### PR DESCRIPTION
Since integrating the Fusion CLI as a referenced project in the Nitro.CommandLine project we also need to specify the runtime identifier as a MSBuild property, or the build fails like this: https://github.com/ChilliCream/graphql-platform/actions/runs/17332856156/job/49213141019