### PR TITLE
Docs: Added examples for With-methods

### DIFF
--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetFriendsTest.cs
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/StarWarsGetFriendsTest.cs
@@ -95,6 +95,7 @@ public class StarWarsGetFriendsTest : ServerTestBase
             item => Assert.Equal("Luke Skywalker", item?.Name),
             item => Assert.Equal("Han Solo", item?.Name),
             item => Assert.Equal("Leia Organa", item?.Name));
+        Assert.Throws<ObjectDisposedException>(() => httpClient.CancelPendingRequests());
     }
 
     [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Docs: Added examples for With-methods
- Test: Added validation for disposed HttpClient

Related
- https://github.com/ChilliCream/graphql-platform/issues/3467#issuecomment-2900815908
- https://hotchocolategraphql.slack.com/archives/CMUJ40EHJ/p1756738589396969?thread_ts=1756722636.163949&cid=CMUJ40EHJ
