### PR TITLE
[Fusion] Save composition settings in archive

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Logging/LogEntryCodes.cs
@@ -35,6 +35,7 @@ public static class LogEntryCodes
     public const string KeyInvalidSyntax = "KEY_INVALID_SYNTAX";
     public const string LookupReturnsList = "LOOKUP_RETURNS_LIST";
     public const string LookupReturnsNonNullableType = "LOOKUP_RETURNS_NON_NULLABLE_TYPE";
+    public const string ModifiedCompositionSetting = "MODIFIED_COMPOSITION_SETTING";
     public const string NonNullInputFieldIsInaccessible = "NON_NULL_INPUT_FIELD_IS_INACCESSIBLE";
     public const string NoQueries = "NO_QUERIES";
     public const string OutputFieldTypesNotMergeable = "OUTPUT_FIELD_TYPES_NOT_MERGEABLE";

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Options/SchemaComposerOptions.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Composition/Options/SchemaComposerOptions.cs
@@ -2,5 +2,5 @@ namespace HotChocolate.Fusion.Options;
 
 public sealed class SchemaComposerOptions
 {
-    public bool EnableGlobalObjectIdentification { get; init; }
+    public required bool EnableGlobalObjectIdentification { get; init; }
 }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/FusionTestBase.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.Execution.Tests/FusionTestBase.cs
@@ -425,7 +425,8 @@ public abstract class FusionTestBase : IDisposable
         var sourceSchemas = CreateSourceSchemaTexts(schemas);
 
         var compositionLog = new CompositionLog();
-        var composer = new SchemaComposer(sourceSchemas, new SchemaComposerOptions(), compositionLog);
+        var composerOptions = new SchemaComposerOptions { EnableGlobalObjectIdentification = false };
+        var composer = new SchemaComposer(sourceSchemas, composerOptions, compositionLog);
         var result = composer.Compose();
 
         if (!result.IsSuccess)

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionCommand.cs
@@ -6,8 +6,9 @@ internal sealed class FusionCommand : Command
     {
         Description = "Manage Fusion configurations";
 
-        AddCommand(new FusionPublishCommand());
         AddCommand(new FusionDownloadCommand());
+        AddCommand(new FusionPublishCommand());
+        AddCommand(new FusionSettingsCommand());
         AddCommand(new FusionValidateCommand());
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishCommand.cs
@@ -1,7 +1,7 @@
 using System.CommandLine.IO;
 using ChilliCream.Nitro.CommandLine.Cloud.Client;
 using ChilliCream.Nitro.CommandLine.Cloud.Option;
-using HotChocolate.Fusion.CommandLine;
+using ChilliCream.Nitro.CommandLine.Fusion.Commands;
 using HotChocolate.Fusion.Logging;
 using HotChocolate.Fusion.Packaging;
 using static HotChocolate.Fusion.Properties.CommandLineResources;
@@ -303,7 +303,7 @@ internal sealed class FusionPublishCommand : Command
                 sourceSchemaFiles,
                 archive,
                 environment: stageName,
-                false,
+                null, // We'll always take the one already in the configuration
                 cancellationToken);
 
             ComposeCommand.WriteCompositionLog(

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishCommand.cs
@@ -12,7 +12,7 @@ internal sealed class FusionPublishCommand : Command
 {
     public FusionPublishCommand() : base("publish")
     {
-        Description = "Publishes one or more source schemas as a new fusion configuration to Nitro."
+        Description = "Publishes one or more source schemas as a new Fusion configuration to Nitro."
             + System.Environment.NewLine
             + "To take control over the deployment orchestration use sub-commands like 'begin'."
             + System.Environment.NewLine
@@ -79,6 +79,9 @@ internal sealed class FusionPublishCommand : Command
                 apiId,
                 stageName,
                 tag,
+                // We'll always take the setting already in the configuration for this
+                enableGlobalObjectIdentification: null,
+                requireExistingConfiguration: false,
                 console,
                 apiClient,
                 httpClientFactory,
@@ -86,12 +89,14 @@ internal sealed class FusionPublishCommand : Command
         });
     }
 
-    private static async Task<int> ExecuteAsync(
-        string workingDirectory,
+    public static async Task<int> ExecuteAsync(
+        string? workingDirectory,
         List<string> sourceSchemaFiles,
         string apiId,
         string stageName,
         string tag,
+        bool? enableGlobalObjectIdentification,
+        bool requireExistingConfiguration,
         IAnsiConsole console,
         IApiClient client,
         IHttpClientFactory httpClientFactory,
@@ -245,7 +250,12 @@ internal sealed class FusionPublishCommand : Command
 
             if (stream is null)
             {
-                console.WarningLine($"There is not existing configuration on '{stageName}'.");
+                if (requireExistingConfiguration)
+                {
+                    throw new ExitException($"Expected an existing configuration on '{stageName}'.");
+                }
+
+                console.WarningLine($"There is no existing configuration on '{stageName}'.");
             }
             else
             {
@@ -276,22 +286,25 @@ internal sealed class FusionPublishCommand : Command
                 archive = FusionArchive.Create(archiveStream, leaveOpen: true);
             }
 
-            if (sourceSchemaFiles.Count == 0)
+            if (!string.IsNullOrEmpty(workingDirectory))
             {
-                sourceSchemaFiles.AddRange(
-                    new DirectoryInfo(workingDirectory)
-                        .GetFiles("*.graphql*", SearchOption.AllDirectories)
-                        .Where(f => ComposeCommand.IsSchemaFile(f.Name))
-                        .Select(i => i.FullName));
-            }
-            else
-            {
-                for (var i = 0; i < sourceSchemaFiles.Count; i++)
+                if (sourceSchemaFiles.Count == 0)
                 {
-                    var sourceSchemaFile = sourceSchemaFiles[i];
-                    if (!Path.IsPathRooted(sourceSchemaFile))
+                    sourceSchemaFiles.AddRange(
+                        new DirectoryInfo(workingDirectory)
+                            .GetFiles("*.graphql*", SearchOption.AllDirectories)
+                            .Where(f => ComposeCommand.IsSchemaFile(f.Name))
+                            .Select(i => i.FullName));
+                }
+                else
+                {
+                    for (var i = 0; i < sourceSchemaFiles.Count; i++)
                     {
-                        sourceSchemaFiles[i] = Path.Combine(workingDirectory, sourceSchemaFile);
+                        var sourceSchemaFile = sourceSchemaFiles[i];
+                        if (!Path.IsPathRooted(sourceSchemaFile))
+                        {
+                            sourceSchemaFiles[i] = Path.Combine(workingDirectory, sourceSchemaFile);
+                        }
                     }
                 }
             }
@@ -303,7 +316,7 @@ internal sealed class FusionPublishCommand : Command
                 sourceSchemaFiles,
                 archive,
                 environment: stageName,
-                null, // We'll always take the one already in the configuration
+                enableGlobalObjectIdentification,
                 cancellationToken);
 
             ComposeCommand.WriteCompositionLog(

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishHelpers.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionPublishHelpers.cs
@@ -207,8 +207,6 @@ internal static class FusionPublishHelpers
                 case IFusionConfigurationPublishingSuccess:
                     committed = true;
                     stopSignal.OnNext(Unit.Default);
-
-                    console.Success("Fusion composition was successful.");
                     break;
 
                 case IProcessingTaskIsReady:

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionSettingsCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionSettingsCommand.cs
@@ -1,0 +1,11 @@
+namespace ChilliCream.Nitro.CommandLine.Cloud.Commands.Fusion;
+
+internal sealed class FusionSettingsCommand : Command
+{
+    public FusionSettingsCommand() : base("settings")
+    {
+        Description = "Manage Fusion settings";
+
+        AddCommand(new FusionSettingsSetCommand());
+    }
+}

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionSettingsSetCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/FusionSettingsSetCommand.cs
@@ -1,0 +1,93 @@
+using ChilliCream.Nitro.CommandLine.Cloud.Client;
+using ChilliCream.Nitro.CommandLine.Cloud.Option;
+
+namespace ChilliCream.Nitro.CommandLine.Cloud.Commands.Fusion;
+
+internal sealed class FusionSettingsSetCommand : Command
+{
+    public FusionSettingsSetCommand() : base("set")
+    {
+        Description = "Sets a Fusion composition setting and publishes the updated Fusion configuration to Nitro";
+
+        var settingNameArgument = new Argument<string>("SETTING_NAME")
+            .FromAmong(SettingNames.GlobalObjectIdentification);
+
+        var settingValueArgument = new Argument<string>("SETTING_VALUE");
+
+        AddArgument(settingNameArgument);
+        AddArgument(settingValueArgument);
+
+        AddOption(Opt<TagOption>.Instance);
+        AddOption(Opt<StageNameOption>.Instance);
+        AddOption(Opt<ApiIdOption>.Instance);
+        AddOption(Opt<CloudUrlOption>.Instance);
+        AddOption(Opt<ApiKeyOption>.Instance);
+
+        this.SetHandler(async context =>
+        {
+            var settingName = context.ParseResult.GetValueForArgument(settingNameArgument);
+            var settingValue = context.ParseResult.GetValueForArgument(settingValueArgument);
+
+            var stageName = context.ParseResult.GetValueForOption(Opt<StageNameOption>.Instance)!;
+            var apiId = context.ParseResult.GetValueForOption(Opt<ApiIdOption>.Instance)!;
+            var tag = context.ParseResult.GetValueForOption(Opt<TagOption>.Instance)!;
+
+            var console = context.BindingContext.GetRequiredService<IAnsiConsole>();
+            var apiClient = context.BindingContext.GetRequiredService<IApiClient>();
+            var httpClientFactory = context.BindingContext.GetRequiredService<IHttpClientFactory>();
+
+            context.ExitCode = await ExecuteAsync(
+                settingName,
+                settingValue,
+                apiId,
+                stageName,
+                tag,
+                console,
+                apiClient,
+                httpClientFactory,
+                context.GetCancellationToken());
+        });
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string settingName,
+        string settingValue,
+        string apiId,
+        string stageName,
+        string tag,
+        IAnsiConsole console,
+        IApiClient client,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken)
+    {
+        switch (settingName)
+        {
+            case SettingNames.GlobalObjectIdentification:
+                if (!bool.TryParse(settingValue, out var enableGlobalObjectIdentification))
+                {
+                    console.ErrorLine($"Expected a boolean value for setting '{settingName}'.");
+                    return CommandLine.ExitCodes.Error;
+                }
+
+                return await FusionPublishCommand.ExecuteAsync(
+                    null,
+                    [],
+                    apiId,
+                    stageName,
+                    tag,
+                    enableGlobalObjectIdentification,
+                    requireExistingConfiguration: true,
+                    console,
+                    client,
+                    httpClientFactory,
+                    cancellationToken);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(settingName));
+        }
+    }
+
+    private static class SettingNames
+    {
+        public const string GlobalObjectIdentification = "global-object-identification";
+    }
+}

--- a/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/PublishCommand/FusionConfigurationPublishCommitCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Cloud/Commands/Fusion/PublishCommand/FusionConfigurationPublishCommitCommand.cs
@@ -67,6 +67,8 @@ internal sealed class FusionConfigurationPublishCommitCommand : Command
             throw Exit("The commit has failed.");
         }
 
+        console.Success("Fusion composition was successful.");
+
         return ExitCodes.Success;
 
         async Task Commit(StatusContext? ctx)

--- a/src/Nitro/CommandLine/src/CommandLine.Fusion/Extensions/FusionCommandExtensions.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Fusion/Extensions/FusionCommandExtensions.cs
@@ -1,7 +1,7 @@
 using System.CommandLine;
-using System.CommandLine.Builder;
+using ChilliCream.Nitro.CommandLine.Fusion.Commands;
 
-namespace HotChocolate.Fusion.CommandLine;
+namespace ChilliCream.Nitro.CommandLine.Fusion.Extensions;
 
 public static class FusionCommandExtensions
 {

--- a/src/Nitro/CommandLine/src/CommandLine.Fusion/Extensions/FusionCommandExtensions.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Fusion/Extensions/FusionCommandExtensions.cs
@@ -1,7 +1,7 @@
 using System.CommandLine;
 using ChilliCream.Nitro.CommandLine.Fusion.Commands;
 
-namespace ChilliCream.Nitro.CommandLine.Fusion.Extensions;
+namespace ChilliCream.Nitro.CommandLine.Fusion;
 
 public static class FusionCommandExtensions
 {

--- a/src/Nitro/CommandLine/src/CommandLine.Fusion/JsonSourceGenerationContext.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Fusion/JsonSourceGenerationContext.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+using ChilliCream.Nitro.CommandLine.Fusion.Commands;
+
+namespace ChilliCream.Nitro.CommandLine.Fusion;
+
+[JsonSerializable(typeof(ComposeCommand.CompositionSettings))]
+internal partial class JsonSourceGenerationContext : JsonSerializerContext;

--- a/src/Nitro/CommandLine/src/CommandLine.Fusion/Properties/CommandLineResources.Designer.cs
+++ b/src/Nitro/CommandLine/src/CommandLine.Fusion/Properties/CommandLineResources.Designer.cs
@@ -122,5 +122,17 @@ namespace HotChocolate.Fusion.Properties {
                 return ResourceManager.GetString("RootCommand_Description", resourceCulture);
             }
         }
+        
+        internal static string ComposeCommand_GlobalObjectIdentification_Enabled {
+            get {
+                return ResourceManager.GetString("ComposeCommand_GlobalObjectIdentification_Enabled", resourceCulture);
+            }
+        }
+        
+        internal static string ComposeCommand_GlobalObjectIdentification_Disabled {
+            get {
+                return ResourceManager.GetString("ComposeCommand_GlobalObjectIdentification_Disabled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Nitro/CommandLine/src/CommandLine.Fusion/Properties/CommandLineResources.resx
+++ b/src/Nitro/CommandLine/src/CommandLine.Fusion/Properties/CommandLineResources.resx
@@ -57,4 +57,10 @@
   <data name="RootCommand_Description" xml:space="preserve">
     <value>Fusion CLI</value>
   </data>
+  <data name="ComposeCommand_GlobalObjectIdentification_Enabled" xml:space="preserve">
+    <value>Enabled global object identification.</value>
+  </data>
+  <data name="ComposeCommand_GlobalObjectIdentification_Disabled" xml:space="preserve">
+    <value>Disabled global object identification.</value>
+  </data>
 </root>

--- a/src/Nitro/CommandLine/src/CommandLine/Program.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Program.cs
@@ -2,7 +2,7 @@ using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using ChilliCream.Nitro.CommandLine;
 using ChilliCream.Nitro.CommandLine.Cloud;
-using ChilliCream.Nitro.CommandLine.Fusion.Extensions;
+using ChilliCream.Nitro.CommandLine.Fusion;
 
 var builder = new CommandLineBuilder(new NitroRootCommand())
     .AddNitroCloudConfiguration()

--- a/src/Nitro/CommandLine/src/CommandLine/Program.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Program.cs
@@ -2,7 +2,7 @@ using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
 using ChilliCream.Nitro.CommandLine;
 using ChilliCream.Nitro.CommandLine.Cloud;
-using HotChocolate.Fusion.CommandLine;
+using ChilliCream.Nitro.CommandLine.Fusion.Extensions;
 
 var builder = new CommandLineBuilder(new NitroRootCommand())
     .AddNitroCloudConfiguration()

--- a/src/Nitro/CommandLine/test/CommandLine.Fusion.Tests/ComposeCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Fusion.Tests/ComposeCommandTests.cs
@@ -2,10 +2,10 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
-using HotChocolate.Fusion.CommandLine;
+using ChilliCream.Nitro.CommandLine.Fusion.Extensions;
 using HotChocolate.Fusion.Packaging;
 
-namespace HotChocolate.Fusion;
+namespace ChilliCream.Nitro.CommandLine.Fusion.Tests;
 
 public sealed class ComposeCommandTests : IDisposable
 {

--- a/src/Nitro/CommandLine/test/CommandLine.Fusion.Tests/ComposeCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Fusion.Tests/ComposeCommandTests.cs
@@ -2,7 +2,6 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
-using ChilliCream.Nitro.CommandLine.Fusion.Extensions;
 using HotChocolate.Fusion.Packaging;
 
 namespace ChilliCream.Nitro.CommandLine.Fusion.Tests;


### PR DESCRIPTION
- Persists composition settings in archive, so they don't have to be specified with every composition
- Adds a new command to modify composition settings and publish the updated configuration: 
  `nitro fusion settings set <setting-name> <setting-value>`