### PR TITLE
Fixed usage of ArgumentException.ThrowIfNullOrEmpty

### DIFF
--- a/src/HotChocolate/OpenApi/src/HotChocolate.OpenApi/Extensions/RequestExecutorBuilderExtensions.cs
+++ b/src/HotChocolate/OpenApi/src/HotChocolate.OpenApi/Extensions/RequestExecutorBuilderExtensions.cs
@@ -18,8 +18,8 @@ public static class RequestExecutorBuilderExtensions
         MutationConventionOptions mutationConventionOptions = default)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentException.ThrowIfNullOrEmpty(nameof(httpClientName));
-        ArgumentException.ThrowIfNullOrEmpty(nameof(openApiDocumentText));
+        ArgumentException.ThrowIfNullOrEmpty(httpClientName);
+        ArgumentException.ThrowIfNullOrEmpty(openApiDocumentText);
 
         // Create OpenAPI document from the provided string.
         var openApiStringReader = new OpenApiStringReader();

--- a/src/HotChocolate/OpenApi/src/HotChocolate.OpenApi/Helpers/GraphQLNamingHelper.cs
+++ b/src/HotChocolate/OpenApi/src/HotChocolate.OpenApi/Helpers/GraphQLNamingHelper.cs
@@ -22,7 +22,7 @@ internal static class GraphQLNamingHelper
 
     public static string CreateName(string name)
     {
-        ArgumentException.ThrowIfNullOrEmpty(nameof(name));
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         var stringBuilder = new StringBuilder();
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fixed usage of ArgumentException.ThrowIfNullOrEmpty.