### PR TITLE
Replaced deprecated `IdentityModel` package with `Duende.IdentityModel`

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="ChilliCream.Testing.Utilities" Version="0.2.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="DiffPlex" Version="1.8.0" />
+    <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageVersion Include="Glob" Version="1.1.9" />
-    <PackageVersion Include="IdentityModel" Version="4.1.1" />
     <PackageVersion Include="JsonPointer.Net" Version="5.0.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
     <PackageVersion Include="Marten" Version="7.33.0" />

--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/AccessToken.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/AccessToken.cs
@@ -2,13 +2,13 @@ namespace StrawberryShake.Tools.OAuth;
 
 public class AccessToken
 {
-    public AccessToken(string token, string? scheme)
+    public AccessToken(string? token, string? scheme)
     {
         Token = token;
         Scheme = scheme;
     }
 
-    public string Token { get; }
+    public string? Token { get; }
 
     public string? Scheme { get; }
 }

--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/TokenClient.cs
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/OAuth/TokenClient.cs
@@ -1,10 +1,10 @@
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 
 namespace StrawberryShake.Tools.OAuth;
 
 public static class TokenClient
 {
-    public static async Task<string> GetTokenAsync(
+    public static async Task<string?> GetTokenAsync(
         string tokenEndpoint,
         string clientId,
         string clientSecret,

--- a/src/StrawberryShake/Tooling/src/dotnet-graphql/dotnet-graphql.csproj
+++ b/src/StrawberryShake/Tooling/src/dotnet-graphql/dotnet-graphql.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Duende.IdentityModel" />
     <PackageReference Include="Glob" />
-    <PackageReference Include="IdentityModel" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
   </ItemGroup>
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Replaced deprecated `IdentityModel` package with `Duende.IdentityModel`.