### PR TITLE
Increased timeouts in Send_Connect_Accept_Ping test

### DIFF
--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
@@ -74,8 +74,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                         {
                             Sockets =
                             {
-                                ConnectionInitializationTimeout =
-                                    TimeSpan.FromMilliseconds(1000),
+                                ConnectionInitializationTimeout = TimeSpan.FromMilliseconds(5000),
                                 KeepAliveInterval = TimeSpan.FromMilliseconds(150)
                             }
                         }));

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/GraphQLOverWebSocket/WebSocketProtocolTests.cs
@@ -89,7 +89,7 @@ public class WebSocketProtocolTests(TestServerFactory serverFactory, ITestOutput
                 var message = await WaitForMessage(
                     webSocket,
                     Messages.Ping,
-                    TimeSpan.FromSeconds(5),
+                    TimeSpan.FromSeconds(10),
                     ct);
                 Assert.NotNull(message);
                 Assert.Equal(Messages.Ping, message[MessageProperties.Type]);


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Increased connection initialization timeout in test.