### PR TITLE
Fix #8714: @stream fails when list contains fewer items than initialCount

### DIFF
--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices;
 using HotChocolate.Execution.Internal;
 using HotChocolate.Types;
 using Microsoft.Extensions.DependencyInjection;
+using System.Runtime.InteropServices;
 
 namespace HotChocolate.Execution.Processing.Tasks;
 
@@ -185,7 +185,10 @@ internal sealed partial class ResolverTask
                 {
                     count++;
                     next = await enumerator.MoveNextAsync().ConfigureAwait(false);
-                    list.Add(enumerator.Current);
+                    if (next)
+                    {
+                        list.Add(enumerator.Current);
+                    }
 
                     if (count >= initialCount)
                     {

--- a/src/HotChocolate/Core/test/Execution.Tests/StreamTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/StreamTests.cs
@@ -77,6 +77,26 @@ public class StreamTests
     }
 
     [LocalFact]
+    public async Task Stream_InitialCount_Exceeds_Total_Count()
+    {
+        // arrange
+        var executor = await DeferAndStreamTestSchema.CreateAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            @"{
+                ... @defer {
+                    wait(m: 300)
+                }
+                persons @stream(initialCount: 7) {
+                    id
+                }
+            }");
+
+        Assert.IsType<ResponseStream>(result).MatchSnapshot();
+    }
+
+    [LocalFact]
     public async Task Stream_Label_Set_To_abc()
     {
         // arrange

--- a/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Exceeds_Total_Count.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/__snapshots__/StreamTests.Stream_InitialCount_Exceeds_Total_Count.snap
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "persons": [
+      {
+        "id": "UGVyc29uOjE="
+      },
+      {
+        "id": "UGVyc29uOjI="
+      },
+      {
+        "id": "UGVyc29uOjM="
+      },
+      {
+        "id": "UGVyc29uOjQ="
+      }
+    ],
+    "wait": true
+  }
+}


### PR DESCRIPTION
Test the return value from `enumerator.MoveNextAsync()`, and only add items to the list if the value is valid.

Closes #8714