### PR TITLE
Projections: Support selecting only __typename on union types

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
@@ -35,12 +35,25 @@ public static class QueryableProjectionScopeExtensions
 
             foreach (var val in scope.GetAbstractTypes())
             {
-                var ctor = Expression.New(val.Key);
-                Expression memberInit = Expression.MemberInit(ctor, val.Value);
+                var instance = scope.Instance.Peek();
+                Expression baseExpression;
+                if (val.Value.Count == 0)
+                {
+                    // No field has been selected for this type
+                    // -> Since we need to select something, select all(!) fields
+                    baseExpression = instance;
+                }
+                else
+                {
+                    // One or more fields have been selected for this type
+                    // -> Select only the requested fields.
+                    var ctor = Expression.New(val.Key);
+                    baseExpression = Expression.MemberInit(ctor, val.Value);
+                }
 
                 lastValue = Expression.Condition(
-                    Expression.TypeIs(scope.Instance.Peek(), val.Key),
-                    Expression.Convert(memberInit, scope.RuntimeType),
+                    Expression.TypeIs(instance, val.Key),
+                    Expression.Convert(baseExpression, scope.RuntimeType),
                     lastValue);
             }
 

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionUnionTypeTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/QueryableProjectionUnionTypeTests.cs
@@ -214,6 +214,61 @@ public class QueryableProjectionUnionTypeTests
             .MatchAsync();
     }
 
+    [Fact]
+    public async Task Create_Union_Typename_Only()
+    {
+        // arrange
+        var tester =
+            _cache.CreateSchema(s_barEntities, OnModelCreating, configure: ConfigureSchema);
+
+        // act
+        var res1 = await tester.ExecuteAsync(
+            OperationRequestBuilder.New()
+                .SetDocument(
+                    @"
+                        {
+                            root {
+                                __typename
+                            }
+                        }")
+                .Build());
+
+        // assert
+        await Snapshot
+            .Create()
+            .AddResult(res1)
+            .MatchAsync();
+    }
+
+    [Fact]
+    public async Task Create_Union_Typename_Concrete_Mixed()
+    {
+        // arrange
+        var tester =
+            _cache.CreateSchema(s_barEntities, OnModelCreating, configure: ConfigureSchema);
+
+        // act
+        var res1 = await tester.ExecuteAsync(
+            OperationRequestBuilder.New()
+                .SetDocument(
+                    @"
+                        {
+                            root {
+                                __typename
+                                ... on Foo {
+                                    fooProp
+                                }
+                            }
+                        }")
+                .Build());
+
+        // assert
+        await Snapshot
+            .Create()
+            .AddResult(res1)
+            .MatchAsync();
+    }
+
     private static void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AbstractType>()

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Typename_Concrete_Mixed.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Typename_Concrete_Mixed.snap
@@ -1,0 +1,22 @@
+Result:
+---------------
+{
+  "data": {
+    "root": [
+      {
+        "__typename": "Bar"
+      },
+      {
+        "__typename": "Foo",
+        "fooProp": "FooProp"
+      }
+    ]
+  }
+}
+---------------
+
+SQL:
+---------------
+SELECT "d"."d" = 'bar', "d"."Id", "d"."Name", "d"."d", "d"."BarProp", "d"."FooProp", "d"."d" = 'foo'
+FROM "Data" AS "d"
+---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Typename_Only.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionUnionTypeTests.Create_Union_Typename_Only.snap
@@ -1,0 +1,21 @@
+Result:
+---------------
+{
+  "data": {
+    "root": [
+      {
+        "__typename": "Bar"
+      },
+      {
+        "__typename": "Foo"
+      }
+    ]
+  }
+}
+---------------
+
+SQL:
+---------------
+SELECT "d"."d" = 'bar', "d"."Id", "d"."Name", "d"."d", "d"."BarProp", "d"."FooProp", "d"."d" = 'foo'
+FROM "Data" AS "d"
+---------------


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Support selecting only __typename (without any other 'real' members) on union type

Closes #8252  (in this specific format)

Background:

If no 'real' member of an entity was requested as part of the selection set, like in

```graphql
{
  foo {
    items { # This is a union of ConcreteType1|ConcreteType2
      __typename 
      ... on ConcreteType2 {
          foo
       }
    }
  }
}
```

the projected query currenty looks like this:

```csharp
repository.Select(_s1 => (_s1 is ConcreteType1) ? new ConcreteType1 {}
                : (_s1 is ConcreteType2) ? (ConcreteType2)new ConcreteType2 { Foo = ((ConcreteType2)_s1).Foo }
                : default(BaseType));
```

However, `new ConcreteType1 {}` cannot be translated to SQL, which leads to the following exception:

>The client projection contains a reference to a constant expression of 'ConcreteType1'. This could potentially cause a memory leak; consider assigning this constant to a local variable and using the variable in the query instead.

I fixed this by transforming the query into:

```csharp
repository.Select(_s1 => (_s1 is ConcreteType1) ? (BaseType)_s1
                : (_s1 is ConcreteType2) ? (ConcreteType2)new ConcreteType2 { Foo = ((ConcreteType2)_s1).Foo }
                : default(BaseType));
```

This approach selects the entire record, so it indeed overfetches. Anyways, it seems to be the simplest solution that works in all cases.

I considered selecting just one property instead, but that seems to be hacky and tricky since we cant know for sure whether a property is actually part of the table or just a calculated helper property. Because we’re only selecting the values of the base type and also do not eager load navigation properties, I believe the performance penalty from this overfetching is negligible compared to correctness. Also this seems to be a rare edge case.

However, if another approach is preferred - like the one with just selecting one property-, please let me know and I can reevaluate this.