### PR TITLE
Fix introspection of `@deprecated(reason: null)`

### DIFF
--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionFormatter.cs
@@ -329,7 +329,7 @@ internal static class IntrospectionFormatter
                     new ArgumentNode
                     (
                         WellKnownDirectives.DeprecationReasonArgument,
-                        new StringValueNode(deprecationReason)
+                        deprecationReason is not null ? new StringValueNode(deprecationReason) : NullValueNode.Default
                     )
                 )
             };

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__resources__/StarWarsIntrospectionResult.json
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__resources__/StarWarsIntrospectionResult.json
@@ -1087,6 +1087,43 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "someDeprecatedField",
+              "description": null,
+              "args": [
+                {
+                  "name": "deprecatedArg",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": "null",
+                  "isDeprecated": true,
+                  "deprecationReason": "use something else"
+                },
+                {
+                  "name": "deprecatedWithNullReason",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": "null",
+                  "isDeprecated": true,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "use something else"
             }
           ],
           "inputFields": null,

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionFormatterTests.DeserializeStarWarsIntrospectionResult.snap
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionFormatterTests.DeserializeStarWarsIntrospectionResult.snap
@@ -164,6 +164,7 @@ type Query {
   human(id: ID!): Human
   droid(id: ID!): Droid
   search(text: String): [SearchResult]
+  someDeprecatedField(deprecatedArg: String @deprecated(reason: "use something else") deprecatedWithNullReason: String @deprecated(reason: null)): String @deprecated(reason: "use something else")
 }
 
 type Mutation {


### PR DESCRIPTION
Fixes introspection of deprecated fields with null deprecation reason.

IntrospectionFormatter assumed that the `deprecationReason` for a deprecated field will always be a non-null string even though a `null` deprecation reason should also be valid according to the [GraphQL spec](https://spec.graphql.org/October2021/#sec--deprecated) which defines it as a nullable `String`:
```graphql
directive @deprecated(
  reason: String = "No longer supported"
) on FIELD_DEFINITION | ENUM_VALUE
```

I tried to add some tests for the introspection of deprecated fields by manually editing the source JSON and the schema snapshots. I am not entirely sure if this is the correct approach but the test seems to pass. I can redo them properly if you assist me with the correct way of generating the JSONs and snapshots :)

Closes #8720
