### PR TITLE
Retain original location of variable on value node rewrite

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/FileReferenceNode.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/FileReferenceNode.cs
@@ -66,6 +66,9 @@ public sealed class FileReferenceNode
 
     string IValueNode<string>.Value => Value.FileName;
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location) => this;
+
     /// <summary>
     /// Gets the children of this node.
     /// </summary>

--- a/src/HotChocolate/Core/src/Execution/Processing/VariableRewriter.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/VariableRewriter.cs
@@ -223,32 +223,20 @@ public static class VariableRewriter
         {
             case SyntaxKind.Variable:
                 rewritten = Rewrite((VariableNode)original, defaultValue, variableValues);
-                return true;
+                break;
 
             case SyntaxKind.ObjectValue when type.Kind == TypeKind.InputObject:
                 rewritten = Rewrite(
                     (ObjectValueNode)original,
                     (InputObjectType)type,
                     variableValues);
-
-                if (ReferenceEquals(rewritten, original))
-                {
-                    rewritten = null;
-                    return false;
-                }
-                return true;
+                break;
 
             case SyntaxKind.ObjectValue when type.Kind == TypeKind.List:
                 rewritten = Rewrite(
                     (ObjectValueNode)original,
                     (ListType)type,
                     variableValues);
-
-                if (ReferenceEquals(rewritten, original))
-                {
-                    rewritten = null;
-                    return false;
-                }
                 return true;
 
             case SyntaxKind.ListValue when type.Kind == TypeKind.List:
@@ -256,18 +244,21 @@ public static class VariableRewriter
                     (ListValueNode)original,
                     (ListType)type,
                     variableValues);
-
-                if (ReferenceEquals(rewritten, original))
-                {
-                    rewritten = null;
-                    return false;
-                }
-                return true;
+                break;
 
             default:
                 rewritten = null;
                 return false;
         }
+
+        if (ReferenceEquals(rewritten, original))
+        {
+            rewritten = null;
+            return false;
+        }
+
+        rewritten = rewritten.WithLocation(original.Location);
+        return true;
     }
 
     private static IValueNode Rewrite(

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_NestedVariableInput.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_NestedVariableInput.snap
@@ -5,7 +5,7 @@
       "locations": [
         {
           "line": 1,
-          "column": 57
+          "column": 72
         }
       ],
       "path": [

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_WithMutationConventions_NestedVariableInput.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_WithMutationConventions_NestedVariableInput.snap
@@ -5,7 +5,7 @@
       "locations": [
         {
           "line": 1,
-          "column": 59
+          "column": 81
         }
       ],
       "path": [

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_WithMutationConventions_VariableInput.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_Mutation_WithMutationConventions_VariableInput.snap
@@ -5,7 +5,7 @@
       "locations": [
         {
           "line": 1,
-          "column": 53
+          "column": 60
         }
       ],
       "path": [

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_NestedVariableInput.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/TypeConverter/__snapshots__/TypeConverterTests.Exception_IsAvailableInErrorFilter_NestedVariableInput.snap
@@ -5,7 +5,7 @@
       "locations": [
         {
           "line": 1,
-          "column": 54
+          "column": 69
         }
       ],
       "path": [

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/__snapshots__/AnyTypeTests.Input_Value_ObjectDict_As_Variable.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/__snapshots__/AnyTypeTests.Input_Value_ObjectDict_As_Variable.snap
@@ -1,8 +1,13 @@
-﻿{
+{
   "data": {
     "foo": {
       "kind": "ObjectValue",
-      "location": null,
+      "location": {
+        "start": 31,
+        "end": 36,
+        "line": 1,
+        "column": 32
+      },
       "fields": [
         {
           "kind": "ObjectField",

--- a/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/__snapshots__/AnyTypeTests.Input_Value_Object_As_Variable.snap
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/Scalars/__snapshots__/AnyTypeTests.Input_Value_Object_As_Variable.snap
@@ -1,8 +1,13 @@
-﻿{
+{
   "data": {
     "foo": {
       "kind": "ObjectValue",
-      "location": null,
+      "location": {
+        "start": 31,
+        "end": 36,
+        "line": 1,
+        "column": 32
+      },
       "fields": [
         {
           "kind": "ObjectField",

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/BooleanValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/BooleanValueNode.cs
@@ -90,6 +90,10 @@ public sealed class BooleanValueNode : IValueNode<bool>
     public BooleanValueNode WithLocation(Location? location)
         => new(location, Value);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Value" /> with <paramref name="value" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Contracts/IValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Contracts/IValueNode.cs
@@ -9,4 +9,16 @@ public interface IValueNode : ISyntaxNode
     /// Gets the value.
     /// </summary>
     object? Value { get; }
+
+    /// <summary>
+    /// Creates a new node from the current instance and replaces the
+    /// <see cref="Location" /> with <paramref name="location" />.
+    /// </summary>
+    /// <param name="location">
+    /// The location that shall be used to replace the current location.
+    /// </param>
+    /// <returns>
+    /// Returns the new node with the new <paramref name="location" />.
+    /// </returns>
+    IValueNode WithLocation(Location? location);
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/EnumValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/EnumValueNode.cs
@@ -187,6 +187,10 @@ public sealed class EnumValueNode : IValueNode<string>
     public EnumValueNode WithLocation(Location? location)
         => new(location, Value);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Value" /> with <paramref name="value" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FloatValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FloatValueNode.cs
@@ -363,6 +363,10 @@ public sealed class FloatValueNode : IValueNode<string>, IFloatValueLiteral
     public FloatValueNode WithLocation(Location? location)
         => new(location, Format) { _memorySegment = _memorySegment, _value = _value };
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Value" /> with <paramref name="value" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/IntValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/IntValueNode.cs
@@ -958,6 +958,10 @@ public sealed class IntValueNode : IValueNode<string>, IIntValueLiteral
     public IntValueNode WithLocation(Location? location)
         => new(location) { _memorySegment = _memorySegment, _value = _value };
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Value" /> with <paramref name="value" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/ListValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/ListValueNode.cs
@@ -138,6 +138,10 @@ public sealed class ListValueNode : IValueNode<IReadOnlyList<IValueNode>>
     /// </returns>
     public ListValueNode WithLocation(Location? location) => new(location, Items);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Items" /> with <paramref name="items" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/NullValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/NullValueNode.cs
@@ -151,6 +151,10 @@ public sealed class NullValueNode
     /// </returns>
     public NullValueNode WithLocation(Location? location) => new(location);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Gets the default null value instance.
     /// </summary>

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/ObjectValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/ObjectValueNode.cs
@@ -105,6 +105,10 @@ public sealed class ObjectValueNode : IValueNode<IReadOnlyList<ObjectFieldNode>>
     public ObjectValueNode WithLocation(Location? location)
         => new(location, Fields);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="Fields" /> with <paramref name="fields" />.

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/StringValueNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/StringValueNode.cs
@@ -176,6 +176,10 @@ public sealed class StringValueNode : IValueNode<string>, IHasSpan
     public StringValueNode WithLocation(Location? location)
         => new(location, Value, Block);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     public StringValueNode WithValue(string value)
         => new(Location, value, false);
 

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/VariableNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/VariableNode.cs
@@ -100,6 +100,10 @@ public sealed class VariableNode : IValueNode<string>
     /// </returns>
     public VariableNode WithLocation(Location? location) => new(location, Name);
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location)
+        => WithLocation(location);
+
     /// <summary>
     /// Creates a new node from the current instance and replaces the
     /// <see cref="NamedSyntaxNode.Name" /> with <paramref name="name" />.

--- a/src/HotChocolate/Primitives/src/Primitives/Types/FileValueNode.cs
+++ b/src/HotChocolate/Primitives/src/Primitives/Types/FileValueNode.cs
@@ -37,6 +37,9 @@ public class FileValueNode
 
     string IValueNode<string>.Value => Value.Name;
 
+    /// <inheritdoc />
+    IValueNode IValueNode.WithLocation(Location? location) => this;
+
     /// <summary>
     /// Determines whether the specified <see cref="FileValueNode"/>
     /// is equal to the current <see cref="FileValueNode"/>.


### PR DESCRIPTION
This is a follow-up of #8677 Summary of the changes (Less than 80 chars)

- Retain location of the original VariableNode during rewrite
- Detail 2

Closes #bugnumber (in this specific format)

This is a follow-up of #8677 and resolves the issue [discussed during review](https://github.com/ChilliCream/graphql-platform/pull/8677#discussion_r2377125094) with @tobias-tengler that for variables, the location always points to the outermost argument. 

For example in

query($v: String!) { fieldWithNestedObjectInput(arg: { inner: { id: $v }  }  }
the location points to arg: { inner: { id: $v } }.

With this PR, the location of the original VariableNode is retained when rewriting it to the corresponding ValueNode, solving the issue so that the example above will correctly point to $v.

I am not sure whether it is acceptable to introduce a new method into such a central interface like IValueNode; alternatively, it could be extracted into a separate interface (e.g., ILocationAdjustable).