### PR TITLE
Hotfix: Use ClaimsPrincipal global prefix when generating resolver.

### DIFF
--- a/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
@@ -645,7 +645,7 @@ public abstract class TypeFileBuilderBase(StringBuilder sb)
 
                 case ResolverParameterKind.ClaimsPrincipal:
                     Writer.WriteIndentedLine(
-                        "var args{0} = context.GetGlobalState<{1}>(\"ClaimsPrincipal\");",
+                        "var args{0} = context.GetGlobalState<global::{1}>(\"ClaimsPrincipal\");",
                         i,
                         WellKnownTypes.ClaimsPrincipal);
                     break;


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Added missing `global::` prefix for ClaimsPrincipal type.

