### PR TITLE
Fix: Enum-deserialization from _Any-type with ReferenceResolver

### DIFF
--- a/src/HotChocolate/ApolloFederation/src/ApolloFederation/Resolvers/ArgumentParser.cs
+++ b/src/HotChocolate/ApolloFederation/src/ApolloFederation/Resolvers/ArgumentParser.cs
@@ -64,8 +64,14 @@ internal static class ArgumentParser
             case SyntaxKind.IntValue:
             case SyntaxKind.FloatValue:
             case SyntaxKind.BooleanValue:
-                if (type.NamedType() is not ScalarType scalarType)
+                var namedType = type.NamedType();
+                if (namedType is not ScalarType scalarType)
                 {
+                    if (namedType is EnumType)
+                    {
+                        goto case SyntaxKind.EnumValue;
+                    }
+
                     break;
                 }
 

--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/_AnyTypeTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/_AnyTypeTests.cs
@@ -25,7 +25,8 @@ public class _AnyTypeTests
         var serialized = new ObjectValueNode(
             new ObjectFieldNode(AnyType.TypeNameField, "test"),
             new ObjectFieldNode("faa", "foo"),
-            new ObjectFieldNode("foo", "bar")
+            new ObjectFieldNode("foo", "bar"),
+            new ObjectFieldNode("fooEnum", new EnumValueNode("enum"))
         );
 
         // act
@@ -64,6 +65,16 @@ public class _AnyTypeTests
 
                 Assert.Equal(
                     "bar",
+                    node.Value.Value);
+            },
+            node =>
+            {
+                Assert.Equal(
+                    "fooEnum",
+                    node.Name.Value);
+
+                Assert.Equal(
+                    "enum",
                     node.Value.Value);
             }
         );


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Enums can appear as `StringValue` in `_Any`, this was not considered in the `ArgumentParser`
- Detail 2

Closes #bugnumber (in this specific format)
