### PR TITLE
[Fusion] Update introspection directive to use 'args' and add corresp…

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Introspection/__Directive.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Introspection/__Directive.cs
@@ -27,7 +27,7 @@ internal sealed class __Directive : ITypeResolverInterceptor
             case "locations":
                 features.Set(new ResolveFieldValue(Locations));
                 break;
-            case "arguments":
+            case "args":
                 features.Set(new ResolveFieldValue(Arguments));
                 break;
         }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.Directives_Should_Include_Args_SkipIncludeDirectiveArgs.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.Directives_Should_Include_Args_SkipIncludeDirectiveArgs.yaml
@@ -1,0 +1,200 @@
+title: Directives_Should_Include_Args
+request:
+  document: |
+    query SkipIncludeDirectiveArgs {
+      __schema {
+        directives {
+          name
+          args {
+            name
+            defaultValue
+            type {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+response:
+  body: |
+    {
+      "data": {
+        "__schema": {
+          "directives": [
+            {
+              "name": "skip",
+              "args": [
+                {
+                  "name": "if",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "include",
+              "args": [
+                {
+                  "name": "if",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+      
+      type Author {
+        id: Int!
+      }
+      
+      type Book {
+        id: Int!
+        title: String!
+        author: Author!
+      }
+      
+      "A connection to a list of items."
+      type BooksConnection {
+        "Information to aid in pagination."
+        pageInfo: PageInfo!
+        "A list of edges."
+        edges: [BooksEdge!]
+        "A flattened list of the nodes."
+        nodes: [Book!]
+      }
+      
+      "An edge in a connection."
+      type BooksEdge {
+        "A cursor for use in pagination."
+        cursor: String!
+        "The item at the end of the edge."
+        node: Book!
+      }
+      
+      "Information about pagination in a connection."
+      type PageInfo {
+        "Indicates whether more edges exist following the set defined by the clients arguments."
+        hasNextPage: Boolean!
+        "Indicates whether more edges exist prior the set defined by the clients arguments."
+        hasPreviousPage: Boolean!
+        "When paginating backwards, the cursor to continue."
+        startCursor: String
+        "When paginating forwards, the cursor to continue."
+        endCursor: String
+      }
+      
+      type Query {
+        bookById(id: Int!): Book! @lookup
+        books("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): BooksConnection
+      }
+  - name: B
+    schema: |
+      schema {
+        query: Query
+      }
+      
+      type Author {
+        books: [Book!]!
+        id: Int!
+        name: String!
+      }
+      
+      "A connection to a list of items."
+      type AuthorsConnection {
+        "Information to aid in pagination."
+        pageInfo: PageInfo!
+        "A list of edges."
+        edges: [AuthorsEdge!]
+        "A flattened list of the nodes."
+        nodes: [Author!]
+      }
+      
+      "An edge in a connection."
+      type AuthorsEdge {
+        "A cursor for use in pagination."
+        cursor: String!
+        "The item at the end of the edge."
+        node: Author!
+      }
+      
+      type Book {
+        id: Int!
+        author: Author!
+      }
+      
+      "Information about pagination in a connection."
+      type PageInfo {
+        "Indicates whether more edges exist following the set defined by the clients arguments."
+        hasNextPage: Boolean!
+        "Indicates whether more edges exist prior the set defined by the clients arguments."
+        hasPreviousPage: Boolean!
+        "When paginating backwards, the cursor to continue."
+        startCursor: String
+        "When paginating forwards, the cursor to continue."
+        endCursor: String
+      }
+      
+      type Query {
+        authorById(id: Int!): Author! @internal @lookup
+        authors("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String): AuthorsConnection
+      }
+operationPlan:
+  operation:
+    - document: |
+        query SkipIncludeDirectiveArgs {
+          __schema {
+            directives {
+              name
+              args {
+                name
+                defaultValue
+                type {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      name: SkipIncludeDirectiveArgs
+      hash: 9aae2e030d16332696dbc628c2dda22a
+      searchSpace: 1
+  nodes:
+    - id: 1
+      type: Introspection
+      selections:
+        - id: 1
+          responseName: __schema
+          fieldName: __schema


### PR DESCRIPTION
**Introspection logic update:**

* Changed the resolver in `__Directive.cs` to use `"args"` instead of `"arguments"` when setting directive arguments, ensuring compatibility with the GraphQL introspection query format.

**Testing and verification:**

* Added a new test `Directives_Should_Include_Args` in `IntrospectionTests.cs` to confirm that the introspection query returns directive arguments as expected.
* Introduced a snapshot file `IntrospectionTests.Directives_Should_Include_Args_SkipIncludeDirectiveArgs.yaml` to capture and validate the expected response for the new test case.
