### PR TITLE
[Fusion] Add support for directives in schema composition fusion-v2

### DIFF
--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/DirectiveTests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/DirectiveTests.cs
@@ -1,0 +1,117 @@
+using HotChocolate.Transport.Http;
+using HotChocolate.Types;
+using HotChocolate.Types.Composite;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Fusion;
+
+public class DirectiveTests : FusionTestBase
+{
+    [Fact]
+    public async Task Custom_Directive_Is_Composed()
+    {
+        // arrange
+        using var server1 = CreateSourceSchema(
+            "A",
+            """
+            directive @customAuth(
+              role: String!
+              permission: String = "read"
+            ) on FIELD_DEFINITION | OBJECT
+
+            type Query {
+              publicField: String
+              protectedField: String @customAuth(role: "admin", permission: "write")
+            }
+            """);
+
+        using var server2 = CreateSourceSchema(
+            "B",
+            """
+            directive @customAuth(
+              role: String!
+              permission: String = "read"
+            ) on FIELD_DEFINITION | OBJECT
+
+            type Query {
+              otherField: String @customAuth(role: "user")
+            }
+            """);
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", server1),
+            ("B", server2)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        var request = new Transport.OperationRequest(
+            """
+            query CustomDirectiveIntrospection {
+              __schema {
+                directives {
+                  name
+                  description
+                  locations
+                  args {
+                    name
+                    description
+                    defaultValue
+                    type {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        using var result = await client.PostAsync(
+            request,
+            new Uri("http://localhost:5000/graphql"));
+
+        // assert
+        await MatchSnapshotAsync(gateway, request, result);
+    }
+
+    [Fact]
+    public async Task Can_Execute_Operation_With_Custom_Directive_On_Field()
+    {
+        // arrange: define a custom directive usable in operations (FIELD location)
+        using var server = CreateSourceSchema(
+            "A",
+            """
+            directive @flag(note: String) on FIELD
+            type Query { a: String b: String }
+            """);
+
+        using var gateway = await CreateCompositeSchemaAsync([
+            ("A", server)
+        ]);
+
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        var request = new Transport.OperationRequest(
+            """
+            query CustomDirectiveUsage {
+              first: a @flag(note: "one")
+              second: b @flag
+            }
+            """);
+
+        // act
+        using var result = await client.PostAsync(
+            request,
+            new Uri("http://localhost:5000/graphql"));
+
+        // assert
+        await MatchSnapshotAsync(gateway, request, result);
+    }
+}

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/DirectiveTests.Can_Execute_Operation_With_Custom_Directive_On_Field.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/DirectiveTests.Can_Execute_Operation_With_Custom_Directive_On_Field.yaml
@@ -1,0 +1,63 @@
+title: Can_Execute_Operation_With_Custom_Directive_On_Field
+request:
+  document: |
+    query CustomDirectiveUsage {
+      first: a @flag(note: "one")
+      second: b @flag
+    }
+response:
+  body: |
+    {
+      "data": {
+        "first": "Query",
+        "second": "Query"
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+      
+      type Query {
+        a: String
+        b: String
+      }
+      
+      directive @flag(note: String) on FIELD
+    interactions:
+      - request:
+          document: |
+            query CustomDirectiveUsage_4b77c3a7_1 {
+              first: a @flag(note: "one")
+              second: b @flag
+            }
+        response:
+          results:
+            - |
+              {
+                "data": {
+                  "first": "Query",
+                  "second": "Query"
+                }
+              }
+operationPlan:
+  operation:
+    - document: |
+        query CustomDirectiveUsage {
+          first: a @flag(note: "one")
+          second: b @flag
+        }
+      name: CustomDirectiveUsage
+      hash: 4b77c3a71bdbe7389cf71a918fbbc229
+      searchSpace: 1
+  nodes:
+    - id: 1
+      type: Operation
+      schema: A
+      operation: |
+        query CustomDirectiveUsage_4b77c3a7_1 {
+          first: a @flag(note: "one")
+          second: b @flag
+        }

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/DirectiveTests.Custom_Directive_Is_Composed.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/DirectiveTests.Custom_Directive_Is_Composed.yaml
@@ -1,0 +1,172 @@
+title: Custom_Directive_Is_Composed
+request:
+  document: |
+    query CustomDirectiveIntrospection {
+      __schema {
+        directives {
+          name
+          description
+          locations
+          args {
+            name
+            description
+            defaultValue
+            type {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+response:
+  body: |
+    {
+      "data": {
+        "__schema": {
+          "directives": [
+            {
+              "name": "customAuth",
+              "description": null,
+              "locations": [
+                "OBJECT",
+                "FIELD_DEFINITION"
+              ],
+              "args": [
+                {
+                  "name": "permission",
+                  "description": null,
+                  "defaultValue": "\u0022read\u0022",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "name": "role",
+                  "description": null,
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ]
+            },
+            {
+              "name": "skip",
+              "description": "Directs the executor to skip this field or fragment when the \u0060if\u0060 argument is true.",
+              "locations": [
+                "FIELD",
+                "FRAGMENT_SPREAD",
+                "INLINE_FRAGMENT"
+              ],
+              "args": [
+                {
+                  "name": "if",
+                  "description": "Skips this field or fragment when the condition is true.",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "include",
+              "description": "Directs the executor to include this field or fragment when the \u0060if\u0060 argument is true.",
+              "locations": [
+                "FIELD",
+                "FRAGMENT_SPREAD",
+                "INLINE_FRAGMENT"
+              ],
+              "args": [
+                {
+                  "name": "if",
+                  "description": "Includes this field or fragment when the condition is true.",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+sourceSchemas:
+  - name: A
+    schema: |
+      schema {
+        query: Query
+      }
+      
+      type Query {
+        publicField: String
+        protectedField: String @customAuth(role: "admin", permission: "write")
+      }
+      
+      directive @customAuth(role: String! permission: String = "read") on OBJECT | FIELD_DEFINITION
+  - name: B
+    schema: |
+      schema {
+        query: Query
+      }
+      
+      type Query {
+        otherField: String @customAuth(role: "user")
+      }
+      
+      directive @customAuth(role: String! permission: String = "read") on OBJECT | FIELD_DEFINITION
+operationPlan:
+  operation:
+    - document: |
+        query CustomDirectiveIntrospection {
+          __schema {
+            directives {
+              name
+              description
+              locations
+              args {
+                name
+                description
+                defaultValue
+                type {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      name: CustomDirectiveIntrospection
+      hash: 8ec8f6c3e13c33db296def51ea176d73
+      searchSpace: 1
+  nodes:
+    - id: 1
+      type: Introspection
+      selections:
+        - id: 1
+          responseName: __schema
+          fieldName: __schema

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_IntrospectionQuery.yaml
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/__snapshots__/IntrospectionTests.IntrospectionQueries_IntrospectionQuery.yaml
@@ -1639,6 +1639,46 @@ response:
           ],
           "directives": [
             {
+              "name": "test",
+              "description": "Directive description",
+              "isRepeatable": true,
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "Directive argument description",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": "\u0022default\u0022",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "locations": [
+                "QUERY",
+                "MUTATION",
+                "SUBSCRIPTION",
+                "FIELD",
+                "FRAGMENT_DEFINITION",
+                "FRAGMENT_SPREAD",
+                "INLINE_FRAGMENT",
+                "VARIABLE_DEFINITION",
+                "SCHEMA",
+                "SCALAR",
+                "OBJECT",
+                "FIELD_DEFINITION",
+                "ARGUMENT_DEFINITION",
+                "INTERFACE",
+                "UNION",
+                "ENUM",
+                "ENUM_VALUE",
+                "INPUT_OBJECT",
+                "INPUT_FIELD_DEFINITION"
+              ]
+            },
+            {
               "name": "skip",
               "description": "Directs the executor to skip this field or fragment when the \u0060if\u0060 argument is true.",
               "isRepeatable": false,


### PR DESCRIPTION
Add support for merging directives in Fusion-v2 schemas

Took a first stab at handling directives in the SchemaMerger. Not sure if this is the final behavior (might not even be fully specified yet), but thought it could serve as a reference point.  

@tobias-tengler  feel free to close if this doesn’t fit or if I’ve missed something. This is my first dive into the SchemaMerger, so I might have overlooked a few bits.