### PR TITLE
Fix inferred paging connection name collisions for UsePaging

### DIFF
--- a/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
@@ -4,6 +4,7 @@ using HotChocolate.Language;
 using HotChocolate.Types.Descriptors;
 using HotChocolate.Types.Descriptors.Configurations;
 using HotChocolate.Types.Pagination;
+using HotChocolate.Features;
 using HotChocolate.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using static HotChocolate.Types.Pagination.CursorPagingArgumentNames;
@@ -129,16 +130,18 @@ public static class PagingObjectFieldDescriptorExtensions
                 var backward = pagingOptions.AllowBackwardPagination ?? AllowBackwardPagination;
                 d.Features.Set(pagingOptions);
                 d.Flags |= CoreFieldFlags.Connection;
+                var inferConnectionNameFromField = false;
 
                 CreatePagingArguments(d.Arguments, backward);
 
                 if (string.IsNullOrEmpty(connectionName))
                 {
-                    connectionName =
-                        pagingOptions.InferConnectionNameFromField ??
-                        InferConnectionNameFromField
-                            ? EnsureConnectionNameCasing(d.Name)
-                            : null;
+                    inferConnectionNameFromField =
+                        pagingOptions.InferConnectionNameFromField ?? InferConnectionNameFromField;
+
+                    connectionName = inferConnectionNameFromField
+                        ? EnsureConnectionNameCasing(d.Name)
+                        : null;
                 }
 
                 TypeReference? typeRef = nodeType is not null
@@ -166,6 +169,12 @@ public static class PagingObjectFieldDescriptorExtensions
                         => TypeReference.Create(elementType, TypeContext.Output),
                     _ => typeRef
                 };
+
+                connectionName = EnsureConnectionNameUniqueness(
+                    c,
+                    connectionName,
+                    typeRef,
+                    inferConnectionNameFromField);
 
                 var resolverMember = d.ResolverMember ?? d.Member;
                 d.Type = CreateConnectionTypeRef(c, resolverMember, connectionName, typeRef, options);
@@ -219,16 +228,18 @@ public static class PagingObjectFieldDescriptorExtensions
                 var backward = pagingOptions.AllowBackwardPagination ?? AllowBackwardPagination;
                 d.Features.Set(pagingOptions);
                 d.Flags |= CoreFieldFlags.Connection;
+                var inferConnectionNameFromField = false;
 
                 CreatePagingArguments(d.Arguments, backward);
 
                 if (string.IsNullOrEmpty(connectionName))
                 {
-                    connectionName =
-                        pagingOptions.InferConnectionNameFromField ??
-                        InferConnectionNameFromField
-                            ? EnsureConnectionNameCasing(d.Name)
-                            : null;
+                    inferConnectionNameFromField =
+                        pagingOptions.InferConnectionNameFromField ?? InferConnectionNameFromField;
+
+                    connectionName = inferConnectionNameFromField
+                        ? EnsureConnectionNameCasing(d.Name)
+                        : null;
                 }
 
                 TypeReference? typeRef = nodeType is not null
@@ -256,6 +267,12 @@ public static class PagingObjectFieldDescriptorExtensions
                         => TypeReference.Create(elementType, TypeContext.Output),
                     _ => typeRef
                 };
+
+                connectionName = EnsureConnectionNameUniqueness(
+                    c,
+                    connectionName,
+                    typeRef,
+                    inferConnectionNameFromField);
 
                 d.Type = CreateConnectionTypeRef(c, d.Member, connectionName, typeRef, options);
             });
@@ -450,4 +467,162 @@ public static class PagingObjectFieldDescriptorExtensions
         => char.IsUpper(connectionName[0])
             ? connectionName
             : string.Concat(char.ToUpperInvariant(connectionName[0]), connectionName[1..]);
+
+    private static string? EnsureConnectionNameUniqueness(
+        IDescriptorContext context,
+        string? connectionName,
+        TypeReference? nodeType,
+        bool inferConnectionNameFromField)
+    {
+        if (!inferConnectionNameFromField || connectionName is null || nodeType is null)
+        {
+            return connectionName;
+        }
+
+        var lookup = context.Features.GetOrSet<InferredConnectionNameLookup>();
+
+        if (lookup.Value.TryGetValue(connectionName, out var otherType))
+        {
+            return AreEquivalentNodeTypes(otherType, nodeType)
+                ? connectionName
+                : null;
+        }
+
+        lookup.Value[connectionName] = nodeType;
+        return connectionName;
+    }
+
+    private static bool AreEquivalentNodeTypes(TypeReference left, TypeReference right)
+    {
+        var leftIdentity = GetNodeTypeIdentity(left);
+        var rightIdentity = GetNodeTypeIdentity(right);
+
+        if (leftIdentity is not null && rightIdentity is not null)
+        {
+            return leftIdentity.Equals(rightIdentity, StringComparison.Ordinal);
+        }
+
+        return left.Equals(right);
+    }
+
+    private static string? GetNodeTypeIdentity(TypeReference nodeType)
+        => nodeType switch
+        {
+            SyntaxTypeReference syntax => syntax.Type.NamedType().Name.Value,
+            FactoryTypeReference factory => factory.TypeStructure.NamedType().Name.Value,
+            ExtendedTypeReference extended => GetNodeTypeIdentity(extended.Type.Type),
+            _ => null
+        };
+
+    private static string GetNodeTypeIdentity(Type type)
+    {
+        var namedType = GetNamedType(type);
+
+        if (TryGetBuiltInScalarName(namedType, out var scalarName))
+        {
+            return scalarName;
+        }
+
+        if (TryGetRuntimeTypeFromSchemaType(namedType, out var runtimeType))
+        {
+            return runtimeType.Name;
+        }
+
+        return StripGenericSuffix(namedType.Name);
+    }
+
+    private static Type GetNamedType(Type type)
+    {
+        while (type.IsGenericType)
+        {
+            var typeDefinition = type.GetGenericTypeDefinition();
+
+            if (typeDefinition == typeof(NonNullType<>)
+                || typeDefinition == typeof(ListType<>)
+                || typeDefinition == typeof(NamedRuntimeType<>))
+            {
+                type = type.GetGenericArguments()[0];
+                continue;
+            }
+
+            break;
+        }
+
+        return type;
+    }
+
+    private static bool TryGetRuntimeTypeFromSchemaType(Type type, out Type runtimeType)
+    {
+        var current = type;
+
+        while (current is not null && current != typeof(object))
+        {
+            if (current.IsGenericType)
+            {
+                var definition = current.GetGenericTypeDefinition();
+
+                if (definition == typeof(ObjectType<>)
+                    || definition == typeof(InterfaceType<>)
+                    || definition == typeof(EnumType<>)
+                    || definition == typeof(UnionType<>)
+                    || definition == typeof(InputObjectType<>))
+                {
+                    runtimeType = current.GetGenericArguments()[0];
+                    return true;
+                }
+            }
+
+            current = current.BaseType;
+        }
+
+        runtimeType = null!;
+        return false;
+    }
+
+    private static bool TryGetBuiltInScalarName(Type type, out string scalarName)
+    {
+        if (type == typeof(BooleanType) || type == typeof(bool))
+        {
+            scalarName = ScalarNames.Boolean;
+            return true;
+        }
+
+        if (type == typeof(IntType) || type == typeof(int))
+        {
+            scalarName = ScalarNames.Int;
+            return true;
+        }
+
+        if (type == typeof(FloatType) || type == typeof(float) || type == typeof(double))
+        {
+            scalarName = ScalarNames.Float;
+            return true;
+        }
+
+        if (type == typeof(StringType) || type == typeof(string))
+        {
+            scalarName = ScalarNames.String;
+            return true;
+        }
+
+        if (type == typeof(IdType))
+        {
+            scalarName = ScalarNames.ID;
+            return true;
+        }
+
+        scalarName = default!;
+        return false;
+    }
+
+    private static string StripGenericSuffix(string name)
+    {
+        var index = name.IndexOf('`', StringComparison.Ordinal);
+        return index > -1 ? name[..index] : name;
+    }
+
+    private sealed class InferredConnectionNameLookup
+    {
+        public Dictionary<string, TypeReference> Value { get; } = new(StringComparer.Ordinal);
+    }
 }

--- a/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/Extensions/PagingObjectFieldDescriptorExtensions.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 using HotChocolate.Internal;
 using HotChocolate.Language;
+using HotChocolate.Features;
 using HotChocolate.Types.Descriptors;
 using HotChocolate.Types.Descriptors.Configurations;
 using HotChocolate.Types.Pagination;
-using HotChocolate.Features;
 using HotChocolate.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using static HotChocolate.Types.Pagination.CursorPagingArgumentNames;
@@ -130,19 +130,8 @@ public static class PagingObjectFieldDescriptorExtensions
                 var backward = pagingOptions.AllowBackwardPagination ?? AllowBackwardPagination;
                 d.Features.Set(pagingOptions);
                 d.Flags |= CoreFieldFlags.Connection;
-                var inferConnectionNameFromField = false;
 
                 CreatePagingArguments(d.Arguments, backward);
-
-                if (string.IsNullOrEmpty(connectionName))
-                {
-                    inferConnectionNameFromField =
-                        pagingOptions.InferConnectionNameFromField ?? InferConnectionNameFromField;
-
-                    connectionName = inferConnectionNameFromField
-                        ? EnsureConnectionNameCasing(d.Name)
-                        : null;
-                }
 
                 TypeReference? typeRef = nodeType is not null
                     ? c.TypeInspector.GetTypeRef(nodeType)
@@ -170,11 +159,16 @@ public static class PagingObjectFieldDescriptorExtensions
                     _ => typeRef
                 };
 
-                connectionName = EnsureConnectionNameUniqueness(
-                    c,
-                    connectionName,
-                    typeRef,
-                    inferConnectionNameFromField);
+                if (string.IsNullOrEmpty(connectionName))
+                {
+                    var inferConnectionNameFromField =
+                        pagingOptions.InferConnectionNameFromField ??
+                        InferConnectionNameFromField;
+
+                    connectionName = inferConnectionNameFromField
+                        ? InferConnectionName(c, d.Name, typeRef, enableCollisionFallback: true)
+                        : null;
+                }
 
                 var resolverMember = d.ResolverMember ?? d.Member;
                 d.Type = CreateConnectionTypeRef(c, resolverMember, connectionName, typeRef, options);
@@ -228,19 +222,8 @@ public static class PagingObjectFieldDescriptorExtensions
                 var backward = pagingOptions.AllowBackwardPagination ?? AllowBackwardPagination;
                 d.Features.Set(pagingOptions);
                 d.Flags |= CoreFieldFlags.Connection;
-                var inferConnectionNameFromField = false;
 
                 CreatePagingArguments(d.Arguments, backward);
-
-                if (string.IsNullOrEmpty(connectionName))
-                {
-                    inferConnectionNameFromField =
-                        pagingOptions.InferConnectionNameFromField ?? InferConnectionNameFromField;
-
-                    connectionName = inferConnectionNameFromField
-                        ? EnsureConnectionNameCasing(d.Name)
-                        : null;
-                }
 
                 TypeReference? typeRef = nodeType is not null
                     ? c.TypeInspector.GetTypeRef(nodeType)
@@ -268,11 +251,16 @@ public static class PagingObjectFieldDescriptorExtensions
                     _ => typeRef
                 };
 
-                connectionName = EnsureConnectionNameUniqueness(
-                    c,
-                    connectionName,
-                    typeRef,
-                    inferConnectionNameFromField);
+                if (string.IsNullOrEmpty(connectionName))
+                {
+                    var inferConnectionNameFromField =
+                        pagingOptions.InferConnectionNameFromField ??
+                        InferConnectionNameFromField;
+
+                    connectionName = inferConnectionNameFromField
+                        ? InferConnectionName(c, d.Name, typeRef, enableCollisionFallback: false)
+                        : null;
+                }
 
                 d.Type = CreateConnectionTypeRef(c, d.Member, connectionName, typeRef, options);
             });
@@ -468,161 +456,116 @@ public static class PagingObjectFieldDescriptorExtensions
             ? connectionName
             : string.Concat(char.ToUpperInvariant(connectionName[0]), connectionName[1..]);
 
-    private static string? EnsureConnectionNameUniqueness(
+    private static string? InferConnectionName(
         IDescriptorContext context,
-        string? connectionName,
+        string fieldName,
         TypeReference? nodeType,
-        bool inferConnectionNameFromField)
+        bool enableCollisionFallback)
     {
-        if (!inferConnectionNameFromField || connectionName is null || nodeType is null)
+        var inferredConnectionName = EnsureConnectionNameCasing(fieldName);
+
+        if (!enableCollisionFallback || nodeType is null)
         {
-            return connectionName;
+            return inferredConnectionName;
         }
 
-        var lookup = context.Features.GetOrSet<InferredConnectionNameLookup>();
+        var feature = context.Features.GetOrSet<ConnectionNameLookupFeature>();
 
-        if (lookup.Value.TryGetValue(connectionName, out var otherType))
+        if (!feature.NodeTypesByConnectionName.TryGetValue(inferredConnectionName, out var existingNodeType))
         {
-            return AreEquivalentNodeTypes(otherType, nodeType)
-                ? connectionName
-                : null;
+            feature.NodeTypesByConnectionName[inferredConnectionName] = nodeType;
+            return inferredConnectionName;
         }
 
-        lookup.Value[connectionName] = nodeType;
-        return connectionName;
+        if (ConnectionNodeTypeComparer.Default.Equals(existingNodeType, nodeType))
+        {
+            return inferredConnectionName;
+        }
+
+        // If another field with the same inferred name uses a different node type,
+        // we let the connection type infer its name from the node type.
+        return null;
     }
 
-    private static bool AreEquivalentNodeTypes(TypeReference left, TypeReference right)
+    private sealed class ConnectionNameLookupFeature
     {
-        var leftIdentity = GetNodeTypeIdentity(left);
-        var rightIdentity = GetNodeTypeIdentity(right);
-
-        if (leftIdentity is not null && rightIdentity is not null)
-        {
-            return leftIdentity.Equals(rightIdentity, StringComparison.Ordinal);
-        }
-
-        return left.Equals(right);
+        public Dictionary<string, TypeReference> NodeTypesByConnectionName { get; } =
+            new(StringComparer.Ordinal);
     }
 
-    private static string? GetNodeTypeIdentity(TypeReference nodeType)
-        => nodeType switch
-        {
-            SyntaxTypeReference syntax => syntax.Type.NamedType().Name.Value,
-            FactoryTypeReference factory => factory.TypeStructure.NamedType().Name.Value,
-            ExtendedTypeReference extended => GetNodeTypeIdentity(extended.Type.Type),
-            _ => null
-        };
-
-    private static string GetNodeTypeIdentity(Type type)
+    private sealed class ConnectionNodeTypeComparer
+        : IEqualityComparer<TypeReference>
     {
-        var namedType = GetNamedType(type);
-
-        if (TryGetBuiltInScalarName(namedType, out var scalarName))
+        public bool Equals(TypeReference? x, TypeReference? y)
         {
-            return scalarName;
-        }
-
-        if (TryGetRuntimeTypeFromSchemaType(namedType, out var runtimeType))
-        {
-            return runtimeType.Name;
-        }
-
-        return StripGenericSuffix(namedType.Name);
-    }
-
-    private static Type GetNamedType(Type type)
-    {
-        while (type.IsGenericType)
-        {
-            var typeDefinition = type.GetGenericTypeDefinition();
-
-            if (typeDefinition == typeof(NonNullType<>)
-                || typeDefinition == typeof(ListType<>)
-                || typeDefinition == typeof(NamedRuntimeType<>))
+            if (ReferenceEquals(x, y))
             {
-                type = type.GetGenericArguments()[0];
-                continue;
+                return true;
             }
 
-            break;
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+            {
+                return false;
+            }
+
+            if (x.Context != y.Context
+                && x.Context != TypeContext.None
+                && y.Context != TypeContext.None)
+            {
+                return false;
+            }
+
+            if (!string.Equals(x.Scope, y.Scope, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (x is SchemaTypeReference xSchemaType
+                && y is ExtendedTypeReference yExtendedTypeReference)
+            {
+                return CompareSchemaAndExtendedTypeRef(xSchemaType, yExtendedTypeReference);
+            }
+
+            if (y is SchemaTypeReference ySchemaType
+                && x is ExtendedTypeReference xExtendedTypeReference)
+            {
+                return CompareSchemaAndExtendedTypeRef(ySchemaType, xExtendedTypeReference);
+            }
+
+            return x.Equals(y);
         }
 
-        return type;
-    }
-
-    private static bool TryGetRuntimeTypeFromSchemaType(Type type, out Type runtimeType)
-    {
-        var current = type;
-
-        while (current is not null && current != typeof(object))
+        public int GetHashCode(TypeReference obj)
         {
-            if (current.IsGenericType)
+            unchecked
             {
-                var definition = current.GetGenericTypeDefinition();
+                var hashCode = obj.Context.GetHashCode();
 
-                if (definition == typeof(ObjectType<>)
-                    || definition == typeof(InterfaceType<>)
-                    || definition == typeof(EnumType<>)
-                    || definition == typeof(UnionType<>)
-                    || definition == typeof(InputObjectType<>))
+                if (obj.Scope is not null)
                 {
-                    runtimeType = current.GetGenericArguments()[0];
-                    return true;
+                    hashCode ^= obj.GetHashCode() * 397;
                 }
+
+                if (obj is SchemaTypeReference schemaTypeReference)
+                {
+                    hashCode ^= schemaTypeReference.Type.GetType().GetHashCode() * 397;
+                }
+
+                if (obj is ExtendedTypeReference extendedTypeReference)
+                {
+                    hashCode ^= extendedTypeReference.Type.Source.GetHashCode() * 397;
+                }
+
+                return hashCode;
             }
-
-            current = current.BaseType;
         }
 
-        runtimeType = null!;
-        return false;
-    }
+        private static bool CompareSchemaAndExtendedTypeRef(
+            SchemaTypeReference schemaTypeReference,
+            ExtendedTypeReference extendedTypeReference) =>
+            schemaTypeReference.Type.GetType() == extendedTypeReference.Type.Source;
 
-    private static bool TryGetBuiltInScalarName(Type type, out string scalarName)
-    {
-        if (type == typeof(BooleanType) || type == typeof(bool))
-        {
-            scalarName = ScalarNames.Boolean;
-            return true;
-        }
-
-        if (type == typeof(IntType) || type == typeof(int))
-        {
-            scalarName = ScalarNames.Int;
-            return true;
-        }
-
-        if (type == typeof(FloatType) || type == typeof(float) || type == typeof(double))
-        {
-            scalarName = ScalarNames.Float;
-            return true;
-        }
-
-        if (type == typeof(StringType) || type == typeof(string))
-        {
-            scalarName = ScalarNames.String;
-            return true;
-        }
-
-        if (type == typeof(IdType))
-        {
-            scalarName = ScalarNames.ID;
-            return true;
-        }
-
-        scalarName = default!;
-        return false;
-    }
-
-    private static string StripGenericSuffix(string name)
-    {
-        var index = name.IndexOf('`', StringComparison.Ordinal);
-        return index > -1 ? name[..index] : name;
-    }
-
-    private sealed class InferredConnectionNameLookup
-    {
-        public Dictionary<string, TypeReference> Value { get; } = new(StringComparer.Ordinal);
+        public static readonly IEqualityComparer<TypeReference> Default =
+            new ConnectionNodeTypeComparer();
     }
 }

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/IntegrationTests.cs
@@ -878,6 +878,29 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task ConnectionName_Inference_Does_Not_Leak_Between_Types_With_Same_Field_Name()
+    {
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Issue4790Query>()
+            .AddType<Issue4790FooType>()
+            .AddType<Issue4790BarType>()
+            .BuildSchemaAsync();
+
+        var schemaText = schema.ToString();
+
+        Assert.Matches(
+            @"type Issue4790Foo \{[\s\S]*bazzes\([^)]*\): BazzesConnection",
+            schemaText);
+        Assert.Matches(
+            @"type Issue4790Bar \{[\s\S]*bazzes\([^)]*\): Issue4790BazzSummaryConnection",
+            schemaText);
+        Assert.Matches(
+            @"type Issue4790Bar \{[\s\S]*bazzSummaries\([^)]*\): BazzSummariesConnection",
+            schemaText);
+    }
+
+    [Fact]
     public async Task SelectProviderByName()
     {
         var executor =
@@ -1259,6 +1282,57 @@ public class IntegrationTests
 
         [UsePaging]
         public string[] Ghi => throw new NotImplementedException();
+    }
+
+    public class Issue4790Query
+    {
+        public Issue4790Foo Foo() => new();
+
+        public Issue4790Bar Bar() => new();
+    }
+
+    public class Issue4790FooType : ObjectType<Issue4790Foo>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Issue4790Foo> descriptor)
+        {
+            descriptor.Name("Issue4790Foo");
+            descriptor.Field("bazzes")
+                .UsePaging<ObjectType<Issue4790Bazz>>()
+                .Resolve(_ => new[] { new Issue4790Bazz(), new Issue4790Bazz() }.AsQueryable());
+        }
+    }
+
+    public class Issue4790BarType : ObjectType<Issue4790Bar>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Issue4790Bar> descriptor)
+        {
+            descriptor.Name("Issue4790Bar");
+            descriptor.Field("bazzes")
+                .UsePaging<ObjectType<Issue4790BazzSummary>>()
+                .Resolve(
+                    _ => new[] { new Issue4790BazzSummary(), new Issue4790BazzSummary() }.AsQueryable());
+
+            descriptor.Field("bazzSummaries")
+                .UsePaging<ObjectType<Issue4790BazzSummary>>()
+                .Resolve(
+                    _ => new[] { new Issue4790BazzSummary(), new Issue4790BazzSummary() }.AsQueryable());
+        }
+    }
+
+    public class Issue4790Foo;
+
+    public class Issue4790Bar;
+
+    public class Issue4790Bazz
+    {
+        public string? Field1 { get; set; }
+
+        public string? ExpensiveField2 { get; set; }
+    }
+
+    public class Issue4790BazzSummary
+    {
+        public string? Field1 { get; set; }
     }
 
     public class ProviderByName

--- a/src/HotChocolate/Core/test/Types.CursorPagination.Tests/Issue4790Tests.cs
+++ b/src/HotChocolate/Core/test/Types.CursorPagination.Tests/Issue4790Tests.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.DependencyInjection;
+using HotChocolate.Execution;
+
+namespace HotChocolate.Types.Pagination;
+
+public class Issue4790Tests
+{
+    [Fact]
+    public async Task UsePaging_With_Same_Field_Name_On_Different_Parents_Uses_Correct_Connection_Type()
+    {
+        // arrange
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Issue4790Query>()
+            .AddType<Issue4790FooType>()
+            .AddType<Issue4790BarType>()
+            .Services
+            .BuildServiceProvider()
+            .GetSchemaAsync();
+
+        // act
+        var fooType = schema.Types.GetType<ObjectType>("Foo");
+        var barType = schema.Types.GetType<ObjectType>("Bar");
+
+        var fooBazzesConnection = fooType.Fields["bazzes"].Type.NamedType().Name;
+        var barBazzesConnection = barType.Fields["bazzes"].Type.NamedType().Name;
+        // assert
+        Assert.Equal("BazzesConnection", fooBazzesConnection);
+        Assert.NotEqual(fooBazzesConnection, barBazzesConnection);
+        Assert.Equal("Issue4790BazzSummaryConnection", barBazzesConnection);
+    }
+
+    public sealed class Issue4790Query
+    {
+        public Issue4790Foo Foo() => new();
+
+        public Issue4790Bar Bar() => new();
+    }
+
+    public sealed class Issue4790Foo;
+
+    public sealed class Issue4790Bar
+    {
+        public string? Qux { get; set; }
+    }
+
+    public sealed class Issue4790Bazz
+    {
+        public string? Field1 { get; set; }
+
+        public string? ExpensiveField2 { get; set; }
+    }
+
+    public sealed class Issue4790BazzSummary
+    {
+        public string? Field1 { get; set; }
+    }
+
+    public sealed class Issue4790FooType : ObjectType<Issue4790Foo>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Issue4790Foo> descriptor)
+        {
+            descriptor.Name("Foo");
+
+            descriptor
+                .Field("bazzes")
+                .UsePaging<ObjectType<Issue4790Bazz>>()
+                .Resolve(_ =>
+                    new[]
+                    {
+                        new Issue4790Bazz(),
+                        new Issue4790Bazz()
+                    }.AsQueryable());
+        }
+    }
+
+    public sealed class Issue4790BarType : ObjectType<Issue4790Bar>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Issue4790Bar> descriptor)
+        {
+            descriptor.Name("Bar");
+
+            descriptor
+                .Field("bazzes")
+                .UsePaging<ObjectType<Issue4790BazzSummary>>()
+                .Resolve(_ =>
+                    new[]
+                    {
+                        new Issue4790BazzSummary(),
+                        new Issue4790BazzSummary()
+                    }.AsQueryable());
+
+            descriptor
+                .Field("bazzSummaries")
+                .UsePaging<ObjectType<Issue4790BazzSummary>>()
+                .Resolve(_ =>
+                    new[]
+                    {
+                        new Issue4790BazzSummary(),
+                        new Issue4790BazzSummary()
+                    }.AsQueryable());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prevent inferred connection-name reuse when fields share a name but have different node types
- keep existing behavior for equivalent node types (for example `StringType!` and inferred `String!`)
- add a regression test for issue #4790 (`ConnectionName_Inference_Does_Not_Leak_Between_Types_With_Same_Field_Name`)

## Validation
- `dotnet test src/HotChocolate/Core/test/Types.CursorPagination.Tests/HotChocolate.Types.CursorPagination.Tests.csproj --filter "FullyQualifiedName~Interface_With_Paging_Field|FullyQualifiedName~Deactivate_BackwardPagination_Interface|FullyQualifiedName~ConnectionName_Inference_Does_Not_Leak_Between_Types_With_Same_Field_Name"`
- `dotnet test src/HotChocolate/Core/test/Types.CursorPagination.Tests/HotChocolate.Types.CursorPagination.Tests.csproj --no-build`
