### PR TITLE
Fix #4429 jsonb projection translation failures

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionFieldHandler.cs
@@ -23,6 +23,13 @@ public class QueryableProjectionFieldHandler
 
         if (field.Member is PropertyInfo { CanWrite: true } propertyInfo)
         {
+            if (QueryableProjectionJsonbDetector.IsJsonbMappedProperty(context, propertyInfo))
+            {
+                action = SelectionVisitor.SkipAndLeave;
+
+                return true;
+            }
+
             memberType = propertyInfo.PropertyType;
             nestedProperty = Expression.Property(context.GetInstance(), propertyInfo);
         }
@@ -52,11 +59,32 @@ public class QueryableProjectionFieldHandler
     {
         var field = selection.Field;
 
-        if (field.Member is null)
+        if (field.Member is not PropertyInfo propertyInfo)
         {
             action = null;
 
             return false;
+        }
+
+        if (QueryableProjectionJsonbDetector.IsJsonbMappedProperty(context, propertyInfo))
+        {
+            if (context.Scopes.Count > 0
+                && context.Scopes.Peek() is QueryableProjectionScope closure)
+            {
+                var instance = closure.Instance.Peek();
+
+                closure.Level
+                    .Peek()
+                    .Enqueue(Expression.Bind(propertyInfo, Expression.Property(instance, propertyInfo)));
+
+                action = SelectionVisitor.Continue;
+
+                return true;
+            }
+
+            action = SelectionVisitor.Skip;
+
+            return true;
         }
 
         // Dequeue last
@@ -75,16 +103,7 @@ public class QueryableProjectionFieldHandler
         }
 
         Expression nestedProperty;
-        if (field.Member is PropertyInfo propertyInfo)
-        {
-            nestedProperty = Expression.Property(context.GetInstance(), propertyInfo);
-        }
-        else
-        {
-            action = SelectionVisitor.Skip;
-
-            return true;
-        }
+        nestedProperty = Expression.Property(context.GetInstance(), propertyInfo);
 
         // If the nested scope has no projectable members we keep the original value.
         // This happens for members like JsonDocument where selected subfields are read-only.
@@ -92,7 +111,7 @@ public class QueryableProjectionFieldHandler
         {
             parentScope.Level
                 .Peek()
-                .Enqueue(Expression.Bind(field.Member, nestedProperty));
+                .Enqueue(Expression.Bind(propertyInfo, nestedProperty));
 
             action = SelectionVisitor.Continue;
 
@@ -105,13 +124,13 @@ public class QueryableProjectionFieldHandler
         {
             parentScope.Level
                 .Peek()
-                .Enqueue(Expression.Bind(field.Member, NotNullAndAlso(nestedProperty, memberInit)));
+                .Enqueue(Expression.Bind(propertyInfo, NotNullAndAlso(nestedProperty, memberInit)));
         }
         else
         {
             parentScope.Level
                 .Peek()
-                .Enqueue(Expression.Bind(field.Member, memberInit));
+                .Enqueue(Expression.Bind(propertyInfo, memberInit));
         }
 
         action = SelectionVisitor.Continue;

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionJsonbDetector.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionJsonbDetector.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+
+namespace HotChocolate.Data.Projections.Expressions.Handlers;
+
+internal static class QueryableProjectionJsonbDetector
+{
+    private const string DbContextTypeName = "Microsoft.EntityFrameworkCore.DbContext";
+    private const string RelationalColumnType = "Relational:ColumnType";
+
+    public static bool IsJsonbMappedProperty(
+        QueryableProjectionContext context,
+        PropertyInfo propertyInfo)
+        => IsJsonbFromColumnAttribute(propertyInfo)
+            || IsJsonbFromEntityFrameworkModel(context, propertyInfo);
+
+    private static bool IsJsonbFromColumnAttribute(PropertyInfo propertyInfo)
+        => propertyInfo
+            .GetCustomAttribute<ColumnAttribute>(inherit: true)?
+            .TypeName
+            ?.Equals("jsonb", StringComparison.OrdinalIgnoreCase)
+            ?? false;
+
+    private static bool IsJsonbFromEntityFrameworkModel(
+        QueryableProjectionContext context,
+        PropertyInfo propertyInfo)
+    {
+        if (context.ResolverContext.Selection.Field.Member is not MethodInfo resolverMethod)
+        {
+            return false;
+        }
+
+        foreach (var parameter in resolverMethod.GetParameters())
+        {
+            if (!IsDbContextType(parameter.ParameterType))
+            {
+                continue;
+            }
+
+            var dbContext = context.ResolverContext.Services.GetService(parameter.ParameterType);
+            if (dbContext is null)
+            {
+                continue;
+            }
+
+            if (TryGetColumnType(dbContext, propertyInfo, out var columnType)
+                && columnType.Equals("jsonb", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsDbContextType(Type type)
+    {
+        Type? current = type;
+
+        while (current is not null)
+        {
+            if (current.FullName == DbContextTypeName)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetColumnType(
+        object dbContext,
+        PropertyInfo propertyInfo,
+        out string columnType)
+    {
+        columnType = string.Empty;
+
+        if (propertyInfo.DeclaringType is null
+            || TryGetModel(dbContext) is not { } model)
+        {
+            return false;
+        }
+
+        var currentType = propertyInfo.DeclaringType;
+        while (currentType is not null)
+        {
+            if (TryGetEntityType(model, currentType) is { } entityType
+                && TryGetProperty(entityType, propertyInfo) is { } efProperty
+                && TryGetColumnTypeAnnotation(efProperty) is { } annotation
+                && TryGetAnnotationValue(annotation) is { } annotationValue)
+            {
+                columnType = annotationValue;
+                return true;
+            }
+
+            currentType = currentType.BaseType;
+        }
+
+        return false;
+    }
+
+    private static object? TryGetModel(object dbContext)
+        => dbContext.GetType().GetProperty("Model")?.GetValue(dbContext);
+
+    private static object? TryGetEntityType(object model, Type clrType)
+        => InvokeMethod(model, "FindEntityType", [typeof(Type)], [clrType])
+            ?? InvokeMethod(model, "FindEntityType", [typeof(string)], [clrType.FullName!]);
+
+    private static object? TryGetProperty(object entityType, PropertyInfo propertyInfo)
+        => InvokeMethod(entityType, "FindProperty", [typeof(string)], [propertyInfo.Name])
+            ?? InvokeMethod(entityType, "FindProperty", [typeof(MemberInfo)], [propertyInfo]);
+
+    private static object? TryGetColumnTypeAnnotation(object property)
+        => InvokeMethod(property, "FindAnnotation", [typeof(string)], [RelationalColumnType]);
+
+    private static string? TryGetAnnotationValue(object annotation)
+        => annotation.GetType().GetProperty("Value")?.GetValue(annotation) as string;
+
+    private static object? InvokeMethod(
+        object instance,
+        string methodName,
+        Type[] parameterTypes,
+        object?[] arguments)
+    {
+        var instanceType = instance.GetType();
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var method = instanceType.GetMethod(methodName, flags, null, parameterTypes, null);
+
+        if (method is not null)
+        {
+            return method.Invoke(instance, arguments);
+        }
+
+        foreach (var @interface in instanceType.GetInterfaces())
+        {
+            method = @interface.GetMethod(methodName, parameterTypes);
+            if (method is not null)
+            {
+                return method.Invoke(instance, arguments);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/Handlers/QueryableProjectionListHandler.cs
@@ -18,7 +18,8 @@ public class QueryableProjectionListHandler
         Selection selection)
     {
         var field = selection.Field;
-        if (field.Member is PropertyInfo { CanWrite: true })
+        if (field.Member is PropertyInfo { CanWrite: true } propertyInfo
+            && !QueryableProjectionJsonbDetector.IsJsonbMappedProperty(context, propertyInfo))
         {
             var next = context.GetInstance().Append(field.Member);
 
@@ -35,9 +36,16 @@ public class QueryableProjectionListHandler
     {
         var field = selection.Field;
 
-        if (field.Member is not PropertyInfo { CanWrite: true })
+        if (field.Member is not PropertyInfo { CanWrite: true } propertyInfo)
         {
             action = SelectionVisitor.Skip;
+
+            return true;
+        }
+
+        if (QueryableProjectionJsonbDetector.IsJsonbMappedProperty(context, propertyInfo))
+        {
+            action = SelectionVisitor.SkipAndLeave;
 
             return true;
         }
@@ -63,11 +71,32 @@ public class QueryableProjectionListHandler
     {
         var field = selection.Field;
 
-        if (field.Member is null)
+        if (field.Member is not PropertyInfo propertyInfo)
         {
             action = null;
 
             return false;
+        }
+
+        if (QueryableProjectionJsonbDetector.IsJsonbMappedProperty(context, propertyInfo))
+        {
+            if (context.Scopes.Count > 0
+                && context.Scopes.Peek() is QueryableProjectionScope closure)
+            {
+                var instance = closure.Instance.Peek();
+
+                closure.Level
+                    .Peek()
+                    .Enqueue(Expression.Bind(propertyInfo, Expression.Property(instance, propertyInfo)));
+
+                action = SelectionVisitor.Continue;
+
+                return true;
+            }
+
+            action = SelectionVisitor.Skip;
+
+            return true;
         }
 
         var scope = context.PopScope();

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Issue4429ReproTests.cs
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/Issue4429ReproTests.cs
@@ -1,0 +1,132 @@
+using HotChocolate.Execution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Squadron;
+
+namespace HotChocolate.Data;
+
+[Collection(PostgresCacheCollectionFixture.DefinitionName)]
+public sealed class Issue4429ReproTests(PostgreSqlResource resource)
+{
+    [Fact]
+    public async Task Projection_On_Jsonb_Array_And_Object_Does_Not_Throw()
+    {
+        var db = "db_" + Guid.NewGuid().ToString("N");
+        var connectionString = resource.GetConnectionString(db);
+
+        await using var services = CreateServer(connectionString);
+        await using var scope = services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<Issue4429Context>();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        dbContext.Companies.Add(
+            new Issue4429Company
+            {
+                Id = 1,
+                Name = "Company 1",
+                Details = new Issue4429CompanyDetails
+                {
+                    Detail1 = "Content1",
+                    Detail2 = "Content2",
+                    Detail3 = "Content3"
+                },
+                Tags =
+                [
+                    new Issue4429Tag
+                    {
+                        Name = "Tag 1"
+                    }
+                ]
+            });
+
+        await dbContext.SaveChangesAsync();
+
+        var executor = await services.GetRequiredService<IRequestExecutorProvider>().GetExecutorAsync();
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              companies {
+                id
+                name
+                details {
+                  detail1
+                  detail2
+                  detail3
+                }
+                tags {
+                  name
+                }
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+        Assert.Empty(operationResult.Errors ?? []);
+    }
+
+    private static ServiceProvider CreateServer(string connectionString)
+    {
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+        dataSourceBuilder.EnableDynamicJson();
+        var dataSource = dataSourceBuilder.Build();
+
+        return new ServiceCollection()
+            .AddSingleton(dataSource)
+            .AddDbContext<Issue4429Context>(c => c.UseNpgsql(dataSource))
+            .AddGraphQLServer()
+            .AddProjections()
+            .AddQueryType<Issue4429Query>()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .Services
+            .BuildServiceProvider();
+    }
+
+    public sealed class Issue4429Context(DbContextOptions<Issue4429Context> options)
+        : DbContext(options)
+    {
+        public DbSet<Issue4429Company> Companies => Set<Issue4429Company>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Issue4429Company>(entity =>
+            {
+                entity.HasKey(t => t.Id);
+                entity.Property(t => t.Details).HasColumnType("jsonb");
+                entity.Property(t => t.Tags).HasColumnType("jsonb");
+            });
+        }
+    }
+
+    public sealed class Issue4429Query
+    {
+        [UseProjection]
+        public IQueryable<Issue4429Company> GetCompanies(Issue4429Context dbContext)
+            => dbContext.Companies;
+    }
+
+    public sealed class Issue4429Company
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public List<Issue4429Tag> Tags { get; set; } = [];
+
+        public Issue4429CompanyDetails Details { get; set; } = new();
+    }
+
+    public sealed class Issue4429Tag
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class Issue4429CompanyDetails
+    {
+        public string Detail1 { get; set; } = string.Empty;
+
+        public string Detail2 { get; set; } = string.Empty;
+
+        public string Detail3 { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## What
- fixes `#4429` by preventing nested projection rewriting for members mapped to PostgreSQL `jsonb`
- adds a PostgreSQL integration repro test that covers both `jsonb` object and `jsonb` array selections

## Why
`UseProjection` currently rewrites nested object/list selections into expression trees. For `jsonb` members this can generate list projections (`Select` over JSON arrays) that Npgsql/EF cannot translate, causing runtime errors like:

`The LINQ expression 'p1 => new Tag { Name = p1.Name }' could not be translated`

## How
- introduced `QueryableProjectionJsonbDetector` to detect `jsonb` members via:
  - `[Column(TypeName = "jsonb")]`
  - EF model metadata (`Relational:ColumnType`) for fluent `HasColumnType("jsonb")` configuration
- updated `QueryableProjectionFieldHandler` and `QueryableProjectionListHandler` to treat detected `jsonb` members as scalar projection boundaries (`SkipAndLeave` + bind original member)

## Validation
- `dotnet test src/HotChocolate/Data/test/Data.PostgreSQL.Tests/ --filter FullyQualifiedName~Issue4429ReproTests.Projection_On_Jsonb_Array_And_Object_Does_Not_Throw -f net10.0`
- `dotnet test src/HotChocolate/Data/test/Data.Projections.Tests/ -f net10.0`
- `dotnet test src/HotChocolate/Data/test/Data.Tests/ --filter FullyQualifiedName~QueryContextUnionProjectionTests -f net10.0`

Fixes #4429
