### PR TITLE
Fix #5102 null navigation filtering for non-null leaf fields

### DIFF
--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableDefaultFieldHandler.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableDefaultFieldHandler.cs
@@ -137,13 +137,81 @@ public class QueryableDefaultFieldHandler
             && (previousRuntimeType.IsNullableValueType() || !previousRuntimeType.IsValueType()))
         {
             var peekedInstance = context.GetInstance();
-            condition = FilterExpressionBuilder.NotNullAndAlso(peekedInstance, condition);
+
+            if (!IsNullComparisonOnInstance(condition, peekedInstance))
+            {
+                condition = FilterExpressionBuilder.NotNullAndAlso(peekedInstance, condition);
+            }
         }
 
         context.GetLevel().Enqueue(condition);
         action = SyntaxVisitor.Continue;
 
         return true;
+    }
+
+    private static bool IsNullComparisonOnInstance(Expression condition, Expression instance)
+    {
+        if (condition is not BinaryExpression binary
+            || (binary.NodeType is not ExpressionType.Equal
+                && binary.NodeType is not ExpressionType.NotEqual))
+        {
+            return false;
+        }
+
+        return IsInstanceAndNull(binary.Left, binary.Right, instance)
+            || IsInstanceAndNull(binary.Right, binary.Left, instance);
+
+        static bool IsInstanceAndNull(
+            Expression candidateInstance,
+            Expression candidateNull,
+            Expression targetInstance)
+            => IsSameInstance(candidateInstance, targetInstance) && IsNull(candidateNull);
+
+        static bool IsSameInstance(Expression candidate, Expression target)
+        {
+            while (candidate is UnaryExpression
+                   {
+                       NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked,
+                       Operand: { } operand
+                   })
+            {
+                candidate = operand;
+            }
+
+            return ReferenceEquals(candidate, target);
+        }
+
+        static bool IsNull(Expression expression)
+        {
+            while (expression is UnaryExpression
+                   {
+                       NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked,
+                       Operand: { } operand
+                   })
+            {
+                expression = operand;
+            }
+
+            if (expression is ConstantExpression { Value: null })
+            {
+                return true;
+            }
+
+            if (expression is MemberExpression { Expression: ConstantExpression owner } member)
+            {
+                object? value = member.Member switch
+                {
+                    FieldInfo field => field.GetValue(owner.Value),
+                    PropertyInfo property => property.GetValue(owner.Value),
+                    _ => null
+                };
+
+                return value is null;
+            }
+
+            return false;
+        }
     }
 
     public static QueryableDefaultFieldHandler Create(FilterProviderContext context) => new();

--- a/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableOperationHandlerBase.cs
+++ b/src/HotChocolate/Data/src/Data/Filters/Expressions/Handlers/QueryableOperationHandlerBase.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
 using HotChocolate.Data.Filters.Internal;
 using HotChocolate.Language;
@@ -34,12 +35,28 @@ public abstract class QueryableOperationHandlerBase
 
         var parsedValue = InputParser.ParseLiteral(value, field, type);
 
-        if ((!runtimeType.IsNullable || !CanBeNull) && parsedValue is null)
+        if (parsedValue is null)
         {
-            var error = ErrorHelper.CreateNonNullError(field, value, context);
-            context.ReportError(error);
-            result = null!;
-            return false;
+            if (!CanBeNull)
+            {
+                var error = ErrorHelper.CreateNonNullError(field, value, context);
+                context.ReportError(error);
+                result = null!;
+                return false;
+            }
+
+            if (!runtimeType.IsNullable)
+            {
+                if (TryCreateNullNavigationExpression(context, field, out result))
+                {
+                    return true;
+                }
+
+                var error = ErrorHelper.CreateNonNullError(field, value, context);
+                context.ReportError(error);
+                result = null!;
+                return false;
+            }
         }
 
         if (!ValueNullabilityHelpers.IsListValueValid(field.Type, runtimeType, node.Value))
@@ -51,6 +68,38 @@ public abstract class QueryableOperationHandlerBase
         }
 
         result = HandleOperation(context, field, value, parsedValue);
+        return true;
+    }
+
+    private static bool TryCreateNullNavigationExpression(
+        QueryableFilterContext context,
+        IFilterOperationField field,
+        [NotNullWhen(true)] out Expression? result)
+    {
+        result = null;
+
+        if (field.Id is not (DefaultFilterOperations.Equals or DefaultFilterOperations.NotEquals))
+        {
+            return false;
+        }
+
+        if (context.RuntimeTypes.Count < 2 || context.Scopes.Count == 0)
+        {
+            return false;
+        }
+
+        var parentType = context.RuntimeTypes.Skip(1).FirstOrDefault();
+        var parentInstance = context.Scopes.Peek().Instance.Skip(1).FirstOrDefault();
+
+        if (parentType is null || !parentType.IsNullable || parentInstance is null)
+        {
+            return false;
+        }
+
+        result = field.Id == DefaultFilterOperations.Equals
+            ? FilterExpressionBuilder.Equals(parentInstance, null)
+            : FilterExpressionBuilder.NotEquals(parentInstance, null);
+
         return true;
     }
 

--- a/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.Tests/Expression/QueryableFilterVisitorObjectTests.cs
@@ -24,6 +24,44 @@ public class QueryableFilterVisitorObjectTests : FilterVisitorTestBase
     }
 
     [Fact]
+    public void Create_ObjectNonNullableShortEqualNull_Expression()
+    {
+        // arrange
+        var value = Utf8GraphQLParser.Syntax.ParseValueLiteral(
+            "{ foo: { barShort: { eq: null }}}");
+        var tester = CreateProviderTester(new BarFilterInput());
+
+        // act
+        var func = tester.Build<Bar>(value);
+
+        // assert
+        var a = new Bar { Foo = null };
+        Assert.True(func(a));
+
+        var b = new Bar { Foo = new Foo { BarShort = 12 } };
+        Assert.False(func(b));
+    }
+
+    [Fact]
+    public void Create_ObjectNonNullableShortNotEqualNull_Expression()
+    {
+        // arrange
+        var value = Utf8GraphQLParser.Syntax.ParseValueLiteral(
+            "{ foo: { barShort: { neq: null }}}");
+        var tester = CreateProviderTester(new BarFilterInput());
+
+        // act
+        var func = tester.Build<Bar>(value);
+
+        // assert
+        var a = new Bar { Foo = null };
+        Assert.False(func(a));
+
+        var b = new Bar { Foo = new Foo { BarShort = 12 } };
+        Assert.True(func(b));
+    }
+
+    [Fact]
     public void Create_ObjectShortIn_Expression()
     {
         // arrange

--- a/src/HotChocolate/Data/test/Data.Tests/Issue5102VerificationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/Issue5102VerificationTests.cs
@@ -1,0 +1,55 @@
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Data;
+
+public class Issue5102VerificationTests
+{
+    [Fact]
+    public async Task Can_Filter_Null_Object_Field_Through_Nested_NonNull_Id()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddFiltering()
+            .AddQueryType<Issue5102Query>()
+            .BuildRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              devices(where: { site: { id: { eq: null } } }) {
+                id
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+        Assert.Empty(operationResult.Errors ?? []);
+        var json = result.ToJson();
+        Assert.Contains("\"id\": 1", json);
+        Assert.DoesNotContain("\"id\": 2", json);
+    }
+
+    public class Issue5102Query
+    {
+        [UseFiltering]
+        public IQueryable<Issue5102Device> GetDevices()
+            => new[]
+            {
+                new Issue5102Device { Id = 1, Site = null },
+                new Issue5102Device { Id = 2, Site = new Issue5102Site { Id = 7 } }
+            }.AsQueryable();
+    }
+
+    public class Issue5102Device
+    {
+        public int Id { get; set; }
+
+        public Issue5102Site? Site { get; set; }
+    }
+
+    public class Issue5102Site
+    {
+        public int Id { get; set; }
+    }
+}


### PR DESCRIPTION
## What
- allow `eq/neq null` on non-null leaf fields when accessed through a nullable navigation path
- translate these cases to a null check on the parent navigation for queryable filters
- preserve in-memory null-guard behavior while avoiding incorrect guard wrapping for explicit null comparisons
- add regression coverage for object-filter expression handling and an end-to-end verification for #5102

## Why
`where: { site: { id: { eq: null } } }` failed when `id` was non-nullable, even though the nullable navigation (`site`) should make this a valid null-navigation filter scenario.

## Verification
- `dotnet test src/HotChocolate/Data/test/Data.Filters.Tests/ -f net10.0`
- `dotnet test src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/ --filter FullyQualifiedName~QueryableFilterVisitorObjectTests -f net10.0`
- `dotnet test src/HotChocolate/Data/test/Data.Tests/ --filter FullyQualifiedName~Issue5102VerificationTests.Can_Filter_Null_Object_Field_Through_Nested_NonNull_Id -f net10.0`
- `dotnet test src/HotChocolate/Data/test/Data.Tests/ --filter FullyQualifiedName~IntegrationTests -f net10.0`

Fixes #5102
