### PR TITLE
Fix #5228 nested MongoDB child collection filtering

### DIFF
--- a/src/HotChocolate/MongoDb/src/Data/Filters/MongoDbFilterProvider.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Filters/MongoDbFilterProvider.cs
@@ -1,6 +1,9 @@
+using System.Text.RegularExpressions;
 using HotChocolate.Data.Filters;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using static HotChocolate.Data.MongoDb.MongoDbContextData;
 
@@ -31,7 +34,7 @@ public class MongoDbFilterProvider : FilterProvider<MongoDbFilterVisitorContext>
         new(new MongoDbFilterCombinator());
 
     public override IQueryBuilder CreateBuilder<TEntityType>(string argumentName)
-        => new MongoDbQueryBuilder(CreateFilterDefinition(argumentName));
+        => new MongoDbQueryBuilder<TEntityType>(CreateFilterDefinition(argumentName));
 
     private Func<IMiddlewareContext, MongoDbFilterDefinition?> CreateFilterDefinition(string argumentName)
         => context =>
@@ -64,7 +67,7 @@ public class MongoDbFilterProvider : FilterProvider<MongoDbFilterVisitorContext>
                 visitorContext.Errors.Select(e => e.WithPath(context.Path)).ToArray());
         };
 
-    private sealed class MongoDbQueryBuilder(
+    private sealed class MongoDbQueryBuilder<TEntityType>(
         Func<IMiddlewareContext, MongoDbFilterDefinition?> createFilterDef)
         : IQueryBuilder
     {
@@ -76,11 +79,6 @@ public class MongoDbFilterProvider : FilterProvider<MongoDbFilterVisitorContext>
 
         public void Apply(IMiddlewareContext context)
         {
-            if (context.Result is not IMongoDbExecutable executable)
-            {
-                return;
-            }
-
             var filterDef = context.GetLocalStateOrDefault<MongoDbFilterDefinition>(FilterDefinitionKey);
 
             if (filterDef is null)
@@ -88,7 +86,402 @@ public class MongoDbFilterProvider : FilterProvider<MongoDbFilterVisitorContext>
                 return;
             }
 
-            context.Result = executable.WithFiltering(filterDef);
+            if (context.Result is IMongoDbExecutable executable)
+            {
+                context.Result = executable.WithFiltering(filterDef);
+                return;
+            }
+
+            if (TryApplyInMemoryFiltering<TEntityType>(context.Result, filterDef, out var filtered))
+            {
+                context.Result = filtered;
+            }
         }
+    }
+
+    private static bool TryApplyInMemoryFiltering<TEntityType>(
+        object? source,
+        MongoDbFilterDefinition filterDef,
+        out object? filtered)
+    {
+        filtered = null;
+
+        IEnumerable<TEntityType>? enumerable = source switch
+        {
+            IQueryableExecutable<TEntityType> q => q.Source,
+            IQueryable<TEntityType> q => q,
+            IEnumerable<TEntityType> q => q,
+            _ => null
+        };
+
+        if (enumerable is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var serializer = BsonSerializer.SerializerRegistry.GetSerializer<TEntityType>();
+            var renderedFilter = filterDef.ToFilterDefinition<TEntityType>().Render(
+                new RenderArgs<TEntityType>(serializer, BsonSerializer.SerializerRegistry));
+
+            List<TEntityType> result = [];
+
+            foreach (var item in enumerable)
+            {
+                if (item is null)
+                {
+                    continue;
+                }
+
+                var document = item.ToBsonDocument();
+
+                if (!TryMatchesDocument(document, renderedFilter, out var isMatch))
+                {
+                    return false;
+                }
+
+                if (isMatch)
+                {
+                    result.Add(item);
+                }
+            }
+
+            filtered = source switch
+            {
+                IQueryableExecutable<TEntityType> q => q.WithSource(result.AsQueryable()),
+                IQueryable<TEntityType> => result.AsQueryable(),
+                IEnumerable<TEntityType> => result,
+                _ => null
+            };
+
+            return filtered is not null;
+        }
+        catch
+        {
+            filtered = null;
+            return false;
+        }
+    }
+
+    private static bool TryMatchesDocument(
+        BsonValue document,
+        BsonDocument filter,
+        out bool isMatch)
+    {
+        foreach (var element in filter)
+        {
+            if (!TryMatchesElement(document, element, out var elementMatches))
+            {
+                isMatch = false;
+                return false;
+            }
+
+            if (!elementMatches)
+            {
+                isMatch = false;
+                return true;
+            }
+        }
+
+        isMatch = true;
+        return true;
+    }
+
+    private static bool TryMatchesElement(
+        BsonValue document,
+        BsonElement element,
+        out bool isMatch)
+    {
+        switch (element.Name)
+        {
+            case "$and":
+                if (element.Value is not BsonArray andConditions)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                foreach (var condition in andConditions)
+                {
+                    if (condition is not BsonDocument conditionDocument
+                        || !TryMatchesDocument(document, conditionDocument, out var conditionMatches))
+                    {
+                        isMatch = false;
+                        return false;
+                    }
+
+                    if (!conditionMatches)
+                    {
+                        isMatch = false;
+                        return true;
+                    }
+                }
+
+                isMatch = true;
+                return true;
+
+            case "$or":
+                if (element.Value is not BsonArray orConditions)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                foreach (var condition in orConditions)
+                {
+                    if (condition is not BsonDocument conditionDocument
+                        || !TryMatchesDocument(document, conditionDocument, out var conditionMatches))
+                    {
+                        isMatch = false;
+                        return false;
+                    }
+
+                    if (conditionMatches)
+                    {
+                        isMatch = true;
+                        return true;
+                    }
+                }
+
+                isMatch = false;
+                return true;
+
+            case "$nor":
+                if (element.Value is not BsonArray norConditions)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                foreach (var condition in norConditions)
+                {
+                    if (condition is not BsonDocument conditionDocument
+                        || !TryMatchesDocument(document, conditionDocument, out var conditionMatches))
+                    {
+                        isMatch = false;
+                        return false;
+                    }
+
+                    if (conditionMatches)
+                    {
+                        isMatch = false;
+                        return true;
+                    }
+                }
+
+                isMatch = true;
+                return true;
+
+            default:
+                return TryMatchesField(document, element.Name, element.Value, out isMatch);
+        }
+    }
+
+    private static bool TryMatchesField(
+        BsonValue document,
+        string path,
+        BsonValue condition,
+        out bool isMatch)
+    {
+        var exists = TryResolvePath(document, path, out var fieldValue);
+
+        if (condition is not BsonDocument conditionDocument
+            || conditionDocument.ElementCount == 0
+            || !conditionDocument.Names.All(name => name.StartsWith("$", StringComparison.Ordinal)))
+        {
+            isMatch = exists && BsonValuesEqual(fieldValue, condition);
+            return true;
+        }
+
+        foreach (var operation in conditionDocument)
+        {
+            if (!TryApplyOperation(exists, fieldValue, operation, out var operationMatch))
+            {
+                isMatch = false;
+                return false;
+            }
+
+            if (!operationMatch)
+            {
+                isMatch = false;
+                return true;
+            }
+        }
+
+        isMatch = true;
+        return true;
+    }
+
+    private static bool TryApplyOperation(
+        bool exists,
+        BsonValue fieldValue,
+        BsonElement operation,
+        out bool isMatch)
+    {
+        switch (operation.Name)
+        {
+            case "$eq":
+                isMatch = exists && BsonValuesEqual(fieldValue, operation.Value);
+                return true;
+
+            case "$ne":
+                isMatch = !exists || !BsonValuesEqual(fieldValue, operation.Value);
+                return true;
+
+            case "$gt":
+                isMatch = exists && fieldValue.CompareTo(operation.Value) > 0;
+                return true;
+
+            case "$gte":
+                isMatch = exists && fieldValue.CompareTo(operation.Value) >= 0;
+                return true;
+
+            case "$lt":
+                isMatch = exists && fieldValue.CompareTo(operation.Value) < 0;
+                return true;
+
+            case "$lte":
+                isMatch = exists && fieldValue.CompareTo(operation.Value) <= 0;
+                return true;
+
+            case "$in":
+                if (operation.Value is not BsonArray inArray)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                isMatch = exists && inArray.Any(value => BsonValuesEqual(fieldValue, value));
+                return true;
+
+            case "$nin":
+                if (operation.Value is not BsonArray ninArray)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                isMatch = !exists || !ninArray.Any(value => BsonValuesEqual(fieldValue, value));
+                return true;
+
+            case "$exists":
+                isMatch = exists == operation.Value.ToBoolean();
+                return true;
+
+            case "$regex":
+                if (!exists)
+                {
+                    isMatch = false;
+                    return true;
+                }
+
+                if (operation.Value is not BsonRegularExpression regex)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                var regexOptions = ParseRegexOptions(regex.Options);
+                isMatch = Regex.IsMatch(fieldValue.AsString, regex.Pattern, regexOptions);
+                return true;
+
+            case "$not":
+                if (!exists || operation.Value is not BsonDocument notCondition)
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                if (!TryMatchesField(
+                        new BsonDocument("value", fieldValue),
+                        "value",
+                        notCondition,
+                        out var notMatch))
+                {
+                    isMatch = false;
+                    return false;
+                }
+
+                isMatch = !notMatch;
+                return true;
+
+            case "$elemMatch":
+                if (!exists || fieldValue is not BsonArray elements || operation.Value is not BsonDocument elementFilter)
+                {
+                    isMatch = false;
+                    return true;
+                }
+
+                foreach (var element in elements)
+                {
+                    if (element is not BsonDocument elementDocument
+                        || !TryMatchesDocument(elementDocument, elementFilter, out var elementMatch))
+                    {
+                        isMatch = false;
+                        return false;
+                    }
+
+                    if (elementMatch)
+                    {
+                        isMatch = true;
+                        return true;
+                    }
+                }
+
+                isMatch = false;
+                return true;
+
+            default:
+                isMatch = false;
+                return false;
+        }
+    }
+
+    private static bool TryResolvePath(BsonValue document, string path, out BsonValue value)
+    {
+        value = document;
+
+        foreach (var segment in path.Split('.', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (value is BsonDocument doc && doc.TryGetValue(segment, out var next))
+            {
+                value = next;
+                continue;
+            }
+
+            value = BsonNull.Value;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool BsonValuesEqual(BsonValue left, BsonValue right)
+    {
+        if (left.IsBsonNull && right.IsBsonNull)
+        {
+            return true;
+        }
+
+        return left.Equals(right);
+    }
+
+    private static RegexOptions ParseRegexOptions(string options)
+    {
+        var regexOptions = RegexOptions.None;
+
+        foreach (var option in options)
+        {
+            regexOptions |= option switch
+            {
+                'i' => RegexOptions.IgnoreCase,
+                'm' => RegexOptions.Multiline,
+                's' => RegexOptions.Singleline,
+                _ => RegexOptions.None
+            };
+        }
+
+        return regexOptions;
     }
 }

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/Issue5228Tests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/Issue5228Tests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using HotChocolate.Execution;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using Squadron;
+
+namespace HotChocolate.Data.MongoDb.Projections;
+
+public class Issue5228Tests(MongoResource resource) : ProjectionVisitorTestBase, IClassFixture<MongoResource>
+{
+    [Fact]
+    public async Task Nested_Collection_Filter_Should_Filter_Child_Items()
+    {
+        var matchingId = Guid.Parse("f00554bc-fcef-417c-baee-9234534cb6bd");
+        var nonMatchingId = Guid.Parse("f00554bc-fcef-417c-baee-9234534cb6be");
+
+        var executor = CreateSchema(
+            entities:
+            [
+                new GatewayDefinition
+                {
+                    Name = "Test",
+                    ModelReferences =
+                    [
+                        new ModelReference
+                        {
+                            Id = matchingId,
+                            DomainModelId = Guid.NewGuid(),
+                            Depth = 2
+                        }
+                    ]
+                }
+            ],
+            mongoResource: resource,
+            useOffsetPaging: true);
+
+        var result = await executor.ExecuteAsync(
+            $$"""
+            {
+              root {
+                items {
+                  name
+                  modelReferences(where: { id: { eq: "{{nonMatchingId}}" } }) {
+                    id
+                  }
+                }
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+        Assert.Empty(operationResult.Errors ?? []);
+
+        using var json = JsonDocument.Parse(result.ToJson());
+        var modelReferences = json.RootElement
+            .GetProperty("data")
+            .GetProperty("root")
+            .GetProperty("items")[0]
+            .GetProperty("modelReferences");
+
+        Assert.Equal(0, modelReferences.GetArrayLength());
+    }
+
+    public class GatewayDefinition
+    {
+        [BsonId]
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public string Name { get; set; } = string.Empty;
+
+        [UseFiltering]
+        [UseSorting]
+        public List<ModelReference> ModelReferences { get; set; } = [];
+    }
+
+    public class ModelReference
+    {
+        [BsonId]
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
+        public Guid DomainModelId { get; set; }
+
+        public int Depth { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- reproduce #5228 with a MongoDB regression test covering `UseProjection + UseOffsetPaging + UseFiltering` on a nested collection field
- update `MongoDbFilterProvider` to apply in-memory filtering when a field uses Mongo filtering but returns a non-`IMongoDbExecutable` result (for example, nested collection properties)
- keep existing Mongo executable behavior unchanged; fallback only runs for enumerable/queryable results

## Verification
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/HotChocolate.Data.MongoDb.Projections.Tests.csproj --filter FullyQualifiedName~Issue5228Tests.Nested_Collection_Filter_Should_Filter_Child_Items`
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/HotChocolate.Data.MongoDb.Projections.Tests.csproj --filter FullyQualifiedName~Issue5228Tests.Nested_Collection_Filter_Should_Filter_Child_Items -f net10.0`
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/HotChocolate.Data.MongoDb.Projections.Tests.csproj -f net10.0`
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/HotChocolate.Data.MongoDb.Filters.Tests.csproj -f net10.0`

Fixes #5228
