### PR TITLE
Fix #5924 directive middleware variable argument parsing

### DIFF
--- a/src/HotChocolate/Core/src/Types/Execution/Processing/OperationCompiler.CompileResolver.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/OperationCompiler.CompileResolver.cs
@@ -72,26 +72,141 @@ public sealed partial class OperationCompiler
             if (schema.DirectiveTypes.TryGetDirective(directiveNode.Name.Value, out var directiveType)
                 && directiveType.Middleware is not null)
             {
-                Directive directive;
-                try
-                {
-                    directive = new Directive(
-                        directiveType,
-                        directiveNode,
-                        directiveType.Parse(directiveNode));
-                }
-                catch (LeafCoercionException ex)
-                {
-                    throw new LeafCoercionException(
-                        ErrorBuilder.FromError(ex.Errors[0])
-                            .TryAddLocation(directiveNode)
-                            .Build(),
-                        ex.Type);
-                }
-
                 var directiveMiddleware = directiveType.Middleware;
-                pipelineComponents.Add(next => directiveMiddleware(next, directive));
+
+                if (ContainsVariable(directiveNode))
+                {
+                    pipelineComponents.Add(
+                        next => context =>
+                        {
+                            var rewrittenDirectiveNode =
+                                RewriteDirectiveNode(directiveType, directiveNode, context.Variables);
+
+                            var directive = CreateDirective(
+                                directiveType,
+                                rewrittenDirectiveNode,
+                                directiveNode);
+
+                            return directiveMiddleware(next, directive)(context);
+                        });
+                }
+                else
+                {
+                    var directive = CreateDirective(directiveType, directiveNode);
+                    pipelineComponents.Add(next => directiveMiddleware(next, directive));
+                }
             }
         }
+    }
+
+    private static Directive CreateDirective(
+        DirectiveType directiveType,
+        DirectiveNode directiveNode,
+        DirectiveNode? errorLocationNode = null)
+    {
+        try
+        {
+            return new Directive(
+                directiveType,
+                directiveNode,
+                directiveType.Parse(directiveNode));
+        }
+        catch (LeafCoercionException ex)
+        {
+            throw new LeafCoercionException(
+                ErrorBuilder.FromError(ex.Errors[0])
+                    .TryAddLocation(errorLocationNode ?? directiveNode)
+                    .Build(),
+                ex.Type);
+        }
+    }
+
+    private static DirectiveNode RewriteDirectiveNode(
+        DirectiveType directiveType,
+        DirectiveNode directiveNode,
+        IVariableValueCollection variableValues)
+    {
+        if (directiveNode.Arguments.Count == 0)
+        {
+            return directiveNode;
+        }
+
+        var hasChanges = false;
+        var rewrittenArguments = new ArgumentNode[directiveNode.Arguments.Count];
+
+        for (var i = 0; i < directiveNode.Arguments.Count; i++)
+        {
+            var argumentNode = directiveNode.Arguments[i];
+            var rewrittenValue = argumentNode.Value;
+
+            if (directiveType.Arguments.TryGetField(argumentNode.Name.Value, out var argument))
+            {
+                rewrittenValue = VariableRewriter.Rewrite(
+                    argumentNode.Value,
+                    argument.Type,
+                    argument.DefaultValue,
+                    variableValues);
+            }
+
+            if (!ReferenceEquals(rewrittenValue, argumentNode.Value))
+            {
+                rewrittenArguments[i] = argumentNode.WithValue(rewrittenValue);
+                hasChanges = true;
+            }
+            else
+            {
+                rewrittenArguments[i] = argumentNode;
+            }
+        }
+
+        return hasChanges
+            ? directiveNode.WithArguments(rewrittenArguments)
+            : directiveNode;
+    }
+
+    private static bool ContainsVariable(DirectiveNode directiveNode)
+    {
+        for (var i = 0; i < directiveNode.Arguments.Count; i++)
+        {
+            if (ContainsVariable(directiveNode.Arguments[i].Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsVariable(IValueNode value)
+    {
+        switch (value.Kind)
+        {
+            case SyntaxKind.Variable:
+                return true;
+
+            case SyntaxKind.ListValue:
+                var list = (ListValueNode)value;
+                for (var i = 0; i < list.Items.Count; i++)
+                {
+                    if (ContainsVariable(list.Items[i]))
+                    {
+                        return true;
+                    }
+                }
+                break;
+
+            case SyntaxKind.ObjectValue:
+                var obj = (ObjectValueNode)value;
+                for (var i = 0; i < obj.Fields.Count; i++)
+                {
+                    if (ContainsVariable(obj.Fields[i].Value))
+                    {
+                        return true;
+                    }
+                }
+                break;
+        }
+
+        return false;
     }
 }

--- a/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveTypeTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Types/DirectiveTypeTests.cs
@@ -338,6 +338,50 @@ public class DirectiveTypeTests : TypeTestBase
     }
 
     [Fact]
+    public async Task Use_DirectiveMiddleware_With_Variable_Argument()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType(
+                descriptor =>
+                {
+                    descriptor.Name("Query");
+                    descriptor.Field("foo").Type<IntType>().Resolve(123);
+                })
+            .AddDirectiveType(
+                new DirectiveType<DefaultCountDirective>(
+                    descriptor => descriptor
+                        .Name("defaultCount")
+                        .Location(DirectiveLocation.Field)
+                        .Use((HotChocolate.Resolvers.DirectiveMiddleware)((next, _) => next))))
+            .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            OperationRequestBuilder
+                .New()
+                .SetDocument(
+                    """
+                    query Test($totalCount: Int) {
+                      foo @defaultCount(value: $totalCount)
+                    }
+                    """)
+                .SetVariableValues(new Dictionary<string, object?> { { "totalCount", 10 } })
+                .Build());
+
+        // assert
+        result.ToJson().MatchInlineSnapshot(
+            """
+            {
+              "data": {
+                "foo": 123
+              }
+            }
+            """);
+    }
+
+    [Fact]
     public void Use_ClassMiddleware()
     {
         // arrange
@@ -990,6 +1034,11 @@ public class DirectiveTypeTests : TypeTestBase
         [DefaultValue("abc")] public required string Argument1 { get; set; }
 
         public string? Argument2 { get; set; }
+    }
+
+    public class DefaultCountDirective
+    {
+        public int? Value { get; set; }
     }
 
     [DirectiveType("anno", DirectiveLocation.FieldDefinition)]


### PR DESCRIPTION
Fixes #5924

## Summary
- add a regression test for executable directives with middleware using variable arguments
- defer executable directive argument parsing when the directive arguments contain variables
- rewrite directive argument nodes with request variable values before parsing inside the middleware pipeline

## Test Commands
- `dotnet test src/HotChocolate/Core/test/Types.Tests/HotChocolate.Types.Tests.csproj -f net10.0 --filter "FullyQualifiedName~DirectiveTypeTests.Use_DirectiveMiddleware_With_Variable_Argument" --nologo`
  - Passed: 1, Failed: 0
- `dotnet test src/HotChocolate/Core/test/Types.Tests/HotChocolate.Types.Tests.csproj -f net10.0 --filter "FullyQualifiedName~DirectiveTypeTests" --nologo`
  - Passed: 44, Failed: 0