### PR TITLE
Fix #6252 async descriptor resolver sorting inference

### DIFF
--- a/src/HotChocolate/Data/src/Data/Sorting/Extensions/SortingObjectFieldDescriptorExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Sorting/Extensions/SortingObjectFieldDescriptorExtensions.cs
@@ -209,9 +209,7 @@ public static class SortingObjectFieldDescriptorExtensions
                     {
                         var convention = c.GetSortConvention(scope);
 
-                        if (definition.ResultType is null
-                            || definition.ResultType == typeof(object)
-                            || !c.TypeInspector.TryCreateTypeInfo(definition.ResultType, out var typeInfo))
+                        if (!TryGetTypeInfo(c, definition, out var typeInfo))
                         {
                             throw new ArgumentException(
                                 SortObjectFieldDescriptorExtensions_UseSorting_CannotHandleType,
@@ -270,6 +268,92 @@ public static class SortingObjectFieldDescriptorExtensions
                 });
 
         return descriptor;
+    }
+
+    private static bool TryGetTypeInfo(
+        IDescriptorContext context,
+        ObjectFieldConfiguration definition,
+        [NotNullWhen(true)]
+        out ITypeInfo? typeInfo)
+    {
+        if (definition.ResultType is not null
+            && definition.ResultType != typeof(object)
+            && context.TypeInspector.TryCreateTypeInfo(definition.ResultType, out typeInfo))
+        {
+            return true;
+        }
+
+        if (definition.Type is ExtendedTypeReference typeRef
+            && TryResolveRuntimeType(typeRef.Type, out var runtimeType)
+            && context.TypeInspector.TryCreateTypeInfo(runtimeType, out typeInfo))
+        {
+            return true;
+        }
+
+        if (definition.Member is not null
+            && context.TypeInspector.TryCreateTypeInfo(
+                context.TypeInspector.GetReturnType(definition.Member),
+                out typeInfo))
+        {
+            return true;
+        }
+
+        typeInfo = null;
+        return false;
+    }
+
+    private static bool TryResolveRuntimeType(
+        IExtendedType type,
+        [NotNullWhen(true)] out Type? runtimeType)
+    {
+        var current = type;
+
+        while (current.IsArrayOrList && current.ElementType is not null)
+        {
+            current = current.ElementType;
+        }
+
+        if (current.IsSchemaType)
+        {
+            return TryResolveRuntimeTypeFromSchemaType(current.Source, out runtimeType)
+                || TryResolveRuntimeTypeFromSchemaType(current.Type, out runtimeType);
+        }
+
+        runtimeType = current.Source;
+        return true;
+    }
+
+    private static bool TryResolveRuntimeTypeFromSchemaType(
+        Type schemaType,
+        [NotNullWhen(true)] out Type? runtimeType)
+    {
+        var current = schemaType;
+
+        while (current is not null && current != typeof(object))
+        {
+            if (current.IsGenericType)
+            {
+                var definition = current.GetGenericTypeDefinition();
+                if (definition == typeof(ObjectType<>)
+                    || definition == typeof(ObjectTypeExtension<>)
+                    || definition == typeof(InterfaceType<>)
+                    || definition == typeof(InputObjectType<>)
+                    || definition == typeof(UnionType<>)
+                    || definition == typeof(DirectiveType<>)
+                    || definition == typeof(EnumType<>)
+                    || definition == typeof(ScalarType<>)
+                    || definition == typeof(ScalarType<,>))
+                {
+                    runtimeType = current.GetGenericArguments()[0];
+                    return true;
+                }
+            }
+
+            current = current.BaseType;
+        }
+
+        runtimeType = null;
+        return false;
     }
 
     private static bool TryGetTypeInfo(

--- a/src/HotChocolate/Data/test/Data.Sorting.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/Data/test/Data.Sorting.Tests/IntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GreenDonut.Data;
 using HotChocolate.Execution;
 using HotChocolate.Types;
@@ -58,6 +59,53 @@ public class IntegrationTests
 
         // assert
         result.MatchSnapshot();
+    }
+
+    [Fact]
+    public async Task Sorting_Should_Work_When_UsedOnAsyncResolver()
+    {
+        // arrange
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType(
+                d => d
+                    .Name(OperationTypeNames.Query)
+                    .Field("foos")
+                        .Type(typeof(List<Foo>))
+                        .Resolve(async _ => await Task.FromResult(new List<Foo>(
+                            [
+                                new Foo { CreatedUtc = new DateTime(2000, 1, 1, 1, 1, 1) },
+                                new Foo { CreatedUtc = new DateTime(2010, 1, 1, 1, 1, 1) },
+                                new Foo { CreatedUtc = new DateTime(2020, 1, 1, 1, 1, 1) }
+                            ])))
+                        .UseSorting())
+            .AddSorting()
+            .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            """
+            {
+                foos(order: { createdUtc: DESC }) {
+                    createdUtc
+                }
+            }
+            """);
+
+        // assert
+        using var document = JsonDocument.Parse(result.ToJson());
+        Assert.False(
+            document.RootElement.TryGetProperty("errors", out _),
+            result.ToJson());
+
+        var values = document.RootElement
+            .GetProperty("data")
+            .GetProperty("foos")
+            .EnumerateArray()
+            .Select(t => DateTime.Parse(t.GetProperty("createdUtc").GetString()!))
+            .ToArray();
+
+        Assert.Equal(values.OrderByDescending(t => t).ToArray(), values);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a regression test for `descriptor.Field(...).Resolve(async ...).UseSorting()`
- infer sorting field type from the configured field type when async resolver metadata leaves `ResultType` as `object`
- resolve schema wrappers like `ObjectType<T>` back to runtime `T` during inference

Fixes #6252

## Tests
- `dotnet test src/HotChocolate/Data/test/Data.Sorting.Tests/HotChocolate.Data.Sorting.Tests.csproj --filter "FullyQualifiedName~Sorting_Should_Work_When_UsedOnAsyncResolver"`
  - Passed on `net8.0`, `net9.0`, `net10.0` (1/1 each)
- `dotnet test src/HotChocolate/Data/test/Data.Sorting.Tests/HotChocolate.Data.Sorting.Tests.csproj`
  - Passed on `net8.0`, `net9.0`, `net10.0` (181/181 each)
