### PR TITLE
Fix #6300 empty MongoDB list filters causing invalid and queries

### DIFF
--- a/src/HotChocolate/MongoDb/src/Data/Filters/Handlers/List/MongoDbListOperationHandlerBase.cs
+++ b/src/HotChocolate/MongoDb/src/Data/Filters/Handlers/List/MongoDbListOperationHandlerBase.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using HotChocolate.Configuration;
+using HotChocolate.Data.MongoDb;
 using HotChocolate.Data.Filters;
 using HotChocolate.Language;
 using HotChocolate.Language.Visitors;
@@ -17,6 +18,8 @@ namespace HotChocolate.Data.MongoDb.Filters;
 public abstract class MongoDbListOperationHandlerBase
     : FilterFieldHandler<MongoDbFilterVisitorContext, MongoDbFilterDefinition>
 {
+    private static readonly MongoDbFilterCombinator s_combinator = new();
+
     /// <summary>
     /// Specifies the identifier of the operations that should be handled by this handler
     /// </summary>
@@ -113,6 +116,12 @@ public abstract class MongoDbListOperationHandlerBase
     protected static MongoDbFilterDefinition CombineOperationsOfScope(MongoDbFilterScope scope)
     {
         var level = scope.Level.Peek();
+
+        if (level.Count == 0)
+        {
+            throw ThrowHelper.Filtering_MongoDbCombinator_QueueEmpty(s_combinator);
+        }
+
         if (level.Count == 1)
         {
             return level.Peek();

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/Issue6300ReproTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/Issue6300ReproTests.cs
@@ -1,0 +1,89 @@
+using HotChocolate.Data.Filters;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson.Serialization.Attributes;
+using Squadron;
+
+namespace HotChocolate.Data.MongoDb.Filters;
+
+public class Issue6300ReproTests : IClassFixture<MongoResource>
+{
+    private readonly MongoResource _resource;
+
+    public Issue6300ReproTests(MongoResource resource)
+    {
+        _resource = resource;
+    }
+
+    [Fact]
+    public async Task Empty_List_Some_Filter_Should_Not_Reach_Mongo()
+    {
+        // arrange
+        var person = new Person
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            PetList =
+            [
+                new Animal { Name = "dog" }
+            ]
+        };
+
+        var collection = _resource.CreateCollection<Person>("data_" + Guid.NewGuid().ToString("N"));
+        collection.InsertOne(person);
+
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .ModifyRequestOptions(o => o.IncludeExceptionDetails = true)
+            .AddFiltering(x => x.AddMongoDbDefaults())
+            .AddQueryType(
+                c => c
+                    .Name("Query")
+                    .Field("userProfiles")
+                    .Type<ListType<ObjectType<Person>>>()
+                    .Resolve(async _ => await new ValueTask<IExecutable<Person>>(collection.AsExecutable()))
+                    .UseFiltering<FilterInputType<Person>>())
+            .BuildRequestExecutorAsync();
+
+        // act
+        var result = await executor.ExecuteAsync(
+            $$"""
+            {
+              userProfiles(
+                where: {
+                  id: { eq: "{{person.Id}}" }
+                  and: { petList: { some: {} } }
+                }) {
+                id
+              }
+            }
+            """);
+
+        // assert
+        var operationResult = result.ExpectOperationResult();
+        var error = Assert.Single(operationResult.Errors!);
+
+        Assert.NotNull(error.Exception);
+        Assert.Contains(
+            "could not combine expressions",
+            error.Exception!.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "Command find failed",
+            error.Exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public class Person
+    {
+        [BsonId]
+        public string Id { get; set; } = default!;
+
+        public List<Animal> PetList { get; set; } = [];
+    }
+
+    public class Animal
+    {
+        public string Name { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
## Summary
- add a regression test for `where: { ... and: { petList: { some: {} } } }` on MongoDB filters
- fail empty list operation scopes before query execution instead of emitting an empty `$and`
- preserve existing MongoDB filter combinator error semantics (`could not combine expressions`)

Fixes #6300

## Tests
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/HotChocolate.Data.MongoDb.Filters.Tests.csproj --filter "FullyQualifiedName~Issue6300ReproTests"`
  - Passed on `net8.0`, `net9.0`, `net10.0`
- `dotnet test src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/HotChocolate.Data.MongoDb.Filters.Tests.csproj --no-build`
  - Passed: `123` tests on each of `net8.0`, `net9.0`, `net10.0`
