### PR TITLE
Fix #6487 constructor-based projections for record types

### DIFF
--- a/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
+++ b/src/HotChocolate/Data/src/Data/Projections/Expressions/QueryableProjectionScopeExtensions.cs
@@ -44,8 +44,7 @@ public static class QueryableProjectionScopeExtensions
 
             foreach (var val in scope.GetAbstractTypes())
             {
-                var ctor = Expression.New(val.Key);
-                Expression memberInit = Expression.MemberInit(ctor, val.Value);
+                var memberInit = CreateProjectedInstance(val.Key, val.Value);
 
                 lastValue = Expression.Condition(
                     Expression.TypeIs(scope.Instance.Peek(), val.Key),
@@ -57,8 +56,7 @@ public static class QueryableProjectionScopeExtensions
         }
         else
         {
-            var ctor = Expression.New(scope.RuntimeType);
-            return Expression.MemberInit(ctor, scope.Level.Peek());
+            return CreateProjectedInstance(scope.RuntimeType, scope.Level.Peek());
         }
     }
 
@@ -66,6 +64,190 @@ public static class QueryableProjectionScopeExtensions
         => type.GetConstructor(Type.EmptyTypes) is not null
             && type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
                 .Any(t => t.GetParameters().Length > 0);
+
+    private static Expression CreateProjectedInstance(
+        Type runtimeType,
+        IEnumerable<MemberAssignment> assignments)
+    {
+        var bindings = assignments.ToArray();
+
+        if (runtimeType.GetConstructor(Type.EmptyTypes) is { } parameterlessCtor)
+        {
+            return Expression.MemberInit(Expression.New(parameterlessCtor), bindings);
+        }
+
+        ConstructorProjection? best = null;
+        foreach (var constructor in runtimeType.GetConstructors())
+        {
+            if (!TryCreateProjection(constructor, bindings, out var projection))
+            {
+                continue;
+            }
+
+            if (best is null
+                || projection.MatchedParameterCount > best.MatchedParameterCount
+                || (projection.MatchedParameterCount == best.MatchedParameterCount
+                    && projection.UnmatchedBindingCount < best.UnmatchedBindingCount)
+                || (projection.MatchedParameterCount == best.MatchedParameterCount
+                    && projection.UnmatchedBindingCount == best.UnmatchedBindingCount
+                    && projection.ParameterCount < best.ParameterCount))
+            {
+                best = projection;
+            }
+        }
+
+        if (best is not null)
+        {
+            return best.Expression;
+        }
+
+        // Preserve the existing exception shape if no suitable constructor exists.
+        return Expression.MemberInit(Expression.New(runtimeType), bindings);
+    }
+
+    private static bool TryCreateProjection(
+        ConstructorInfo constructor,
+        MemberAssignment[] bindings,
+        [NotNullWhen(true)] out ConstructorProjection? projection)
+    {
+        var parameters = constructor.GetParameters();
+        var arguments = new Expression[parameters.Length];
+        var consumed = new bool[bindings.Length];
+        var matched = 0;
+
+        for (var parameterIndex = 0; parameterIndex < parameters.Length; parameterIndex++)
+        {
+            var parameter = parameters[parameterIndex];
+            var bindingIndex = FindMatchingBinding(parameter, bindings, consumed);
+
+            if (bindingIndex >= 0)
+            {
+                consumed[bindingIndex] = true;
+                matched++;
+                arguments[parameterIndex] = CastIfNeeded(
+                    bindings[bindingIndex].Expression,
+                    parameter.ParameterType);
+            }
+            else if (parameter.HasDefaultValue)
+            {
+                arguments[parameterIndex] = CreateDefaultValueExpression(parameter);
+            }
+            else
+            {
+                arguments[parameterIndex] = Expression.Default(parameter.ParameterType);
+            }
+        }
+
+        List<MemberAssignment>? unmatchedBindings = null;
+        var unmatchedCount = 0;
+        for (var bindingIndex = 0; bindingIndex < bindings.Length; bindingIndex++)
+        {
+            if (consumed[bindingIndex])
+            {
+                continue;
+            }
+
+            if (!CanAssign(bindings[bindingIndex].Member))
+            {
+                projection = null;
+                return false;
+            }
+
+            unmatchedBindings ??= [];
+            unmatchedBindings.Add(bindings[bindingIndex]);
+            unmatchedCount++;
+        }
+
+        var constructorExpression = Expression.New(constructor, arguments);
+        Expression expression =
+            unmatchedBindings is null
+                ? constructorExpression
+                : Expression.MemberInit(constructorExpression, unmatchedBindings);
+
+        projection = new ConstructorProjection(
+            expression,
+            matched,
+            unmatchedCount,
+            parameters.Length);
+
+        return true;
+    }
+
+    private static int FindMatchingBinding(
+        ParameterInfo parameter,
+        MemberAssignment[] bindings,
+        bool[] consumed)
+    {
+        for (var bindingIndex = 0; bindingIndex < bindings.Length; bindingIndex++)
+        {
+            if (consumed[bindingIndex])
+            {
+                continue;
+            }
+
+            var binding = bindings[bindingIndex];
+            if (!string.Equals(binding.Member.Name, parameter.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (IsCompatibleType(binding.Expression.Type, parameter.ParameterType))
+            {
+                return bindingIndex;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsCompatibleType(Type sourceType, Type targetType)
+    {
+        if (targetType.IsAssignableFrom(sourceType))
+        {
+            return true;
+        }
+
+        try
+        {
+            _ = Expression.Convert(Expression.Default(sourceType), targetType);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static Expression CreateDefaultValueExpression(ParameterInfo parameter)
+    {
+        if (parameter.DefaultValue is null)
+        {
+            return Expression.Default(parameter.ParameterType);
+        }
+
+        var defaultValue = parameter.DefaultValue;
+        var constant = Expression.Constant(defaultValue, defaultValue.GetType());
+        return CastIfNeeded(constant, parameter.ParameterType);
+    }
+
+    private static Expression CastIfNeeded(Expression source, Type targetType)
+        => source.Type == targetType
+            ? source
+            : Expression.Convert(source, targetType);
+
+    private static bool CanAssign(MemberInfo member)
+        => member switch
+        {
+            PropertyInfo { CanWrite: true } => true,
+            FieldInfo { IsInitOnly: false } => true,
+            _ => false
+        };
+
+    private sealed record ConstructorProjection(
+        Expression Expression,
+        int MatchedParameterCount,
+        int UnmatchedBindingCount,
+        int ParameterCount);
 
     public static Expression CreateMemberInitLambda(this QueryableProjectionScope scope)
         => Expression.Lambda(scope.CreateMemberInit(), scope.Parameter);

--- a/src/HotChocolate/Data/test/Data.Projections.Tests/Issue6487ReproTests.cs
+++ b/src/HotChocolate/Data/test/Data.Projections.Tests/Issue6487ReproTests.cs
@@ -1,0 +1,46 @@
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Data;
+
+public class Issue6487ReproTests
+{
+    [Fact]
+    public async Task Projection_On_Record_Type_Does_Not_Throw_Default_Constructor_Error()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Query>()
+            .AddProjections()
+            .BuildRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync(
+            """
+            {
+              products {
+                id
+                price {
+                  amount
+                }
+              }
+            }
+            """);
+
+        var operationResult = result.ExpectOperationResult();
+        Assert.Empty(operationResult.Errors ?? []);
+    }
+
+    public class Query
+    {
+        [UseProjection]
+        public IQueryable<Product> Products
+            => new[]
+            {
+                new Product(1, new PriceData(12.34m, "USD"))
+            }.AsQueryable();
+    }
+
+    public record Product(int Id, PriceData Price);
+
+    public record PriceData(decimal Amount, string Currency);
+}


### PR DESCRIPTION
Fixes #6487

## Summary
- add regression test that reproduces projection failure with positional record types (`Type ... does not have a default constructor`)
- update `QueryableProjectionScopeExtensions.CreateMemberInit` to support constructor-based projection object creation when no parameterless constructor exists
- keep existing parameterless-constructor path and EF injected-constructor instance reuse behavior

## Tests
- `dotnet test src/HotChocolate/Data/test/Data.Projections.Tests/HotChocolate.Data.Projections.Tests.csproj --filter "FullyQualifiedName~Issue6487ReproTests"`
  - Passed on net8.0/net9.0/net10.0
- `dotnet test src/HotChocolate/Data/test/Data.Projections.Tests/HotChocolate.Data.Projections.Tests.csproj --no-build`
  - Passed: 33 tests on net8.0/net9.0/net10.0
- `dotnet test src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/HotChocolate.Data.Projections.SqlServer.Tests.csproj --filter "FullyQualifiedName~QueryableProjectionVisitorScalarTests.Create_ProjectsOneProperty_Expression"`
  - Passed on net8.0/net9.0/net10.0
