### PR TITLE
Fix #6694 avoid LISTEN initialization in send-only Postgres channel paths

### DIFF
--- a/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannel.cs
+++ b/src/HotChocolate/Core/src/Subscriptions.Postgres/PostgresChannel.cs
@@ -11,7 +11,8 @@ internal sealed class PostgresChannel : IAsyncDisposable
     private readonly ResilientNpgsqlConnection _connection;
     private readonly CopyOnWriteList<PostgresChannelObserver> _observers = new();
     private readonly PostgresChannelWriter _writer;
-    private bool _initialized;
+    private bool _channelInitialized;
+    private bool _writerInitialized;
     private ContinuousTask? _waitOnNotificationTask;
     private ChannelSubscription? _subscription;
 
@@ -31,12 +32,8 @@ internal sealed class PostgresChannel : IAsyncDisposable
 
     public async ValueTask EnsureInitialized(CancellationToken cancellationToken)
     {
-        if (!_initialized)
-        {
-            await _connection.Initialize(cancellationToken);
-            await _writer.Initialize(cancellationToken);
-            _initialized = true;
-        }
+        await EnsureChannelInitialized(cancellationToken);
+        await EnsureWriterInitialized(cancellationToken);
     }
 
     public IAsyncDisposable Subscribe(PostgresChannelObserver observer)
@@ -60,7 +57,7 @@ internal sealed class PostgresChannel : IAsyncDisposable
         PostgresMessageEnvelope message,
         CancellationToken cancellationToken)
     {
-        await EnsureInitialized(cancellationToken);
+        await EnsureWriterInitialized(cancellationToken);
 
         await _writer.SendAsync(message, cancellationToken);
     }
@@ -81,6 +78,28 @@ internal sealed class PostgresChannel : IAsyncDisposable
         _waitOnNotificationTask = new ContinuousTask(connection.WaitAsync, TimeProvider.System);
 
         _diagnosticEvents.ProviderInfo(PostgresChannel_ConnectionEstablished);
+    }
+
+    private async ValueTask EnsureChannelInitialized(CancellationToken cancellationToken)
+    {
+        if (_channelInitialized)
+        {
+            return;
+        }
+
+        await _connection.Initialize(cancellationToken);
+        _channelInitialized = true;
+    }
+
+    private async ValueTask EnsureWriterInitialized(CancellationToken cancellationToken)
+    {
+        if (_writerInitialized)
+        {
+            return;
+        }
+
+        await _writer.Initialize(cancellationToken);
+        _writerInitialized = true;
     }
 
     private async ValueTask OnDisconnect(CancellationToken cancellationToken = default)

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
@@ -385,6 +385,34 @@ public class PostgresChannelTests
         Assert.Single(receivedMessages);
     }
 
+    [Fact]
+    public async Task SendAsync_Should_Not_Initialize_ListenConnection_When_SendOnly()
+    {
+        // arrange
+        var createdConnections = new List<NpgsqlConnection>();
+        var options = new PostgresSubscriptionOptions
+        {
+            ConnectionFactory = async ct =>
+            {
+                var connection = await ConnectionFactory(ct);
+                createdConnections.Add(connection);
+                return connection;
+            },
+            ChannelName = _channelName
+        };
+        var channel = new PostgresChannel(_events, options);
+        var message =
+            PostgresMessageEnvelope.Create("test", "foobar", options.MaxMessagePayloadSize);
+
+        // act
+        await channel.SendAsync(message, CancellationToken.None);
+
+        // assert
+        Assert.Single(createdConnections);
+
+        await channel.DisposeAsync();
+    }
+
     private NpgsqlConnection SyncConnectionFactory()
     {
         var connection = _resource.GetConnection(_dbName);


### PR DESCRIPTION
## Summary
- add regression coverage proving `SendAsync` should not initialize the listen connection in send-only scenarios
- split `PostgresChannel` initialization tracking into channel-listener and writer initialization
- update `SendAsync` to initialize only the writer connection, avoiding `LISTEN` startup in non-GraphQL background sender processes

Fixes #6694

## Test Commands
- `dotnet test src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/HotChocolate.Subscriptions.Postgres.Tests.csproj --filter "FullyQualifiedName~SendAsync_Should_Not_Initialize_ListenConnection_When_SendOnly"`
  - Repro before fix: failed on net8/net9/net10 with `Assert.Single() Failure: The collection contained 2 items`
  - After fix: passed on net8/net9/net10
- `dotnet test src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/HotChocolate.Subscriptions.Postgres.Tests.csproj --no-build`
  - Passed on net8/net9/net10 (Failed: 0, Passed: 74, Skipped: 0)
