### PR TITLE
Fix #6752 preserve shared entity on subgraph transport failure

### DIFF
--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Results/ValueCompletion.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Execution/Results/ValueCompletion.cs
@@ -387,9 +387,10 @@ TryCompleteList_MoveNext:
     {
         AssertDepthAllowed(ref depth);
 
-        // if the property value is yet undefined we need to initialize it
-        // with the current selection set.
-        if (target.ValueKind is JsonValueKind.Undefined)
+        // If the target is undefined we need to initialize it with the current
+        // selection set. We also rehydrate null values so shared field results
+        // from another subgraph can still populate the object.
+        if (target.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
         {
             var operation = parentSelection.DeclaringSelectionSet.DeclaringOperation;
             var selectionSet = operation.GetSelectionSet(parentSelection, objectType);

--- a/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Planning/OperationPlanner.cs
+++ b/src/HotChocolate/Fusion-vnext/src/Fusion.Execution/Planning/OperationPlanner.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using HotChocolate.Fusion.Execution.Nodes;
 using HotChocolate.Fusion.Planning.Partitioners;
 using HotChocolate.Fusion.Rewriters;
@@ -625,18 +626,31 @@ public sealed partial class OperationPlanner
         Backlog backlog,
         PlanQueue possiblePlans)
     {
-        current = InlineLookupRequirements(
-            workItem.SelectionSet,
-            current,
-            lookup,
-            workItem.EstimatedDepth,
-            backlog);
+        IReadOnlyDictionary<string, IValueNode>? lookupArguments = null;
+        var nextBacklog = backlog;
+
+        if (!TryGetRootLookupArguments(
+                current.InternalOperationDefinition,
+                workItem.SelectionSet.Path,
+                lookup,
+                out lookupArguments))
+        {
+            current = InlineLookupRequirements(
+                workItem.SelectionSet,
+                current,
+                lookup,
+                workItem.EstimatedDepth,
+                backlog);
+            nextBacklog = current.Backlog;
+        }
+
         PlanSelections(
             workItem,
             current,
             lookup,
-            current.Backlog,
-            possiblePlans);
+            nextBacklog,
+            possiblePlans,
+            lookupArguments);
     }
 
     private void PlanSelections(
@@ -644,7 +658,8 @@ public sealed partial class OperationPlanner
         PlanNode current,
         Lookup? lookup,
         Backlog backlog,
-        PlanQueue possiblePlans)
+        PlanQueue possiblePlans,
+        IReadOnlyDictionary<string, IValueNode>? lookupArgumentValues = null)
     {
         var stepId = current.Steps.NextId();
         var stepDepth = workItem.EstimatedDepth;
@@ -687,28 +702,51 @@ public sealed partial class OperationPlanner
 
         if (lookup is not null)
         {
-            lastRequirementId++;
-            var requirementKey = $"__fusion_{lastRequirementId}";
+            string? requirementKey = null;
+            var arguments = new List<ArgumentNode>(lookup.Arguments.Length);
 
             for (var i = 0; i < lookup.Arguments.Length; i++)
             {
                 var argument = lookup.Arguments[i];
-                var fieldSelectionMap = lookup.Fields[i];
+
+                if (lookupArgumentValues?.TryGetValue(argument.Name, out var argumentValue) == true)
+                {
+                    arguments.Add(new ArgumentNode(new NameNode(argument.Name), argumentValue));
+                    continue;
+                }
+
+                if (requirementKey is null)
+                {
+                    lastRequirementId++;
+                    requirementKey = $"__fusion_{lastRequirementId}";
+                }
 
                 var argumentRequirementKey = $"{requirementKey}_{argument.Name}";
+                arguments.Add(
+                    new ArgumentNode(
+                        new NameNode(argument.Name),
+                        new VariableNode(new NameNode(argumentRequirementKey))));
+
                 var operationRequirement = new OperationRequirement(
                     argumentRequirementKey,
                     argument.Type,
                     workItem.SelectionSet.Path,
-                    fieldSelectionMap);
+                    lookup.Fields[i]);
 
                 requirements = requirements.Add(argumentRequirementKey, operationRequirement);
             }
 
-            operationBuilder.SetLookup(lookup, GetLookupArguments(lookup, requirementKey), workItem.SelectionSet.Type);
+            operationBuilder.SetLookup(lookup, arguments, workItem.SelectionSet.Type);
         }
 
         (var definition, index, var source) = operationBuilder.Build(index);
+
+        if (lookup is not null
+            && requirements.IsEmpty
+            && lookupArgumentValues is not null)
+        {
+            source = SelectionPath.Root;
+        }
 
         var step = new OperationPlanStep
         {
@@ -1517,6 +1555,52 @@ public sealed partial class OperationPlanner
         }
 
         return conditions;
+    }
+
+    private static bool TryGetRootLookupArguments(
+        OperationDefinitionNode operationDefinition,
+        SelectionPath targetPath,
+        Lookup lookup,
+        [NotNullWhen(true)] out IReadOnlyDictionary<string, IValueNode>? lookupArguments)
+    {
+        lookupArguments = null;
+
+        if (targetPath.Segments.Length != 1
+            || targetPath.Segments[0].Kind != SelectionPathSegmentKind.Field)
+        {
+            return false;
+        }
+
+        var rootResponseName = targetPath.Segments[0].Name;
+        var rootField = operationDefinition.SelectionSet.Selections
+            .OfType<FieldNode>()
+            .FirstOrDefault(
+                field =>
+                    field.Alias?.Value == rootResponseName
+                    || field.Name.Value == rootResponseName);
+
+        if (rootField is null)
+        {
+            return false;
+        }
+
+        var arguments = new Dictionary<string, IValueNode>(StringComparer.Ordinal);
+
+        foreach (var lookupArgument in lookup.Arguments)
+        {
+            var argument = rootField.Arguments
+                .FirstOrDefault(a => a.Name.Value == lookupArgument.Name);
+
+            if (argument is null)
+            {
+                return false;
+            }
+
+            arguments[lookupArgument.Name] = argument.Value;
+        }
+
+        lookupArguments = arguments;
+        return true;
     }
 
     private static List<ArgumentNode> GetLookupArguments(Lookup lookup, string requirementKey)

--- a/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/Issue6752Tests.cs
+++ b/src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/Issue6752Tests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using HotChocolate.Transport.Http;
+using HotChocolate.Types.Composite;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Fusion;
+
+public sealed class Issue6752Tests : FusionTestBase
+{
+    [Fact]
+    public async Task Shared_Entity_Transport_Failure_Does_Not_Null_Entire_Entity()
+    {
+        // arrange
+        using var subgraphA = CreateSourceSchema(
+            "A",
+            b => b.AddQueryType<SourceSchemaA.Query>());
+
+        using var subgraphB = CreateSourceSchema(
+            "B",
+            b => b.AddQueryType<SourceSchemaB.Query>(),
+            isOffline: true);
+
+        using var gateway = await CreateCompositeSchemaAsync(
+        [
+            ("A", subgraphA),
+            ("B", subgraphB)
+        ]);
+
+        // act
+        using var client = GraphQLHttpClient.Create(gateway.CreateClient());
+
+        using var result = await client.PostAsync(
+            """
+            query {
+              productById(id: 1) {
+                name
+                reviews {
+                  body
+                }
+              }
+            }
+            """,
+            new Uri("http://localhost:5000/graphql"));
+
+        using var response = await result.ReadAsResultAsync();
+
+        // assert
+        Assert.Equal(JsonValueKind.Array, response.Errors.ValueKind);
+        Assert.Equal(JsonValueKind.Object, response.Data.ValueKind);
+        var product = response.Data.GetProperty("productById");
+        Assert.Equal(JsonValueKind.Object, product.ValueKind);
+
+        Assert.Equal("Product 1", product.GetProperty("name").GetString());
+        Assert.Equal(JsonValueKind.Null, product.GetProperty("reviews").ValueKind);
+    }
+
+    public static class SourceSchemaA
+    {
+        public sealed class Query
+        {
+            [Shareable]
+            [Lookup]
+            public Product? GetProductById(int id) => new(id);
+        }
+
+        public sealed record Product(int Id)
+        {
+            public string Name => $"Product {Id}";
+        }
+    }
+
+    public static class SourceSchemaB
+    {
+        public sealed class Query
+        {
+            [Shareable]
+            [Lookup]
+            public Product? GetProductById(int id) => new(id);
+        }
+
+        public sealed record Product(int Id)
+        {
+            public IReadOnlyList<Review>? Reviews =>
+            [
+                new("Review 1"),
+                new("Review 2")
+            ];
+        }
+
+        public sealed record Review(string Body);
+    }
+}


### PR DESCRIPTION
## Overview

Fixes #6752

This change addresses shared top-level entity lookups when one subgraph fails with a transport error.

### What changed

- Added a regression test (`Issue6752Tests`) that reproduces a shared `productById` query where one subgraph is offline and verifies:
  - `data.productById` stays an object
  - fields from the failing subgraph are `null`
  - fields from the healthy subgraph are still returned
- Updated Fusion planner lookup argument handling for shared root lookups:
  - Reuses root field arguments directly from the original operation when available.
  - Avoids creating unnecessary lookup requirements/dependencies for that case.
  - Normalizes source extraction to root for this no-requirements lookup path.
- Updated value completion for object fields to rehydrate `null` targets when later shared-source object data arrives.

## Test commands

- `dotnet test src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/HotChocolate.Fusion.AspNetCore.Tests.csproj --filter "FullyQualifiedName~Issue6752Tests"`
  - Passed on `net8.0`, `net9.0`, `net10.0`.

- `dotnet test src/HotChocolate/Fusion-vnext/test/Fusion.AspNetCore.Tests/HotChocolate.Fusion.AspNetCore.Tests.csproj --filter "FullyQualifiedName~Issue6752Tests|FullyQualifiedName~SourceSchema_Request_Fails_For_Lookup"`
  - Passed on `net8.0`, `net9.0`, `net10.0`.
