### PR TITLE
Fix #7074 report a single field error from aggregate resolver exceptions

### DIFF
--- a/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Global.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Processing/MiddlewareContext.Global.cs
@@ -60,16 +60,16 @@ internal partial class MiddlewareContext : IMiddlewareContext
 
         if (exception is GraphQLException ex)
         {
-            foreach (var error in ex.Errors)
+            if (ex.Errors.Count > 0)
             {
-                ReportError(error);
+                ReportError(ex.Errors[0]);
             }
         }
         else if (exception is AggregateException aggregateException)
         {
-            foreach (var innerException in aggregateException.InnerExceptions)
+            if (aggregateException.InnerExceptions.Count > 0)
             {
-                ReportError(innerException);
+                ReportError(aggregateException.InnerExceptions[0]);
             }
         }
         else

--- a/src/HotChocolate/Core/test/Execution.Tests/Errors/Issue7074ReproTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Errors/Issue7074ReproTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Execution.Errors;
+
+public class Issue7074ReproTests
+{
+    [Fact]
+    public async Task Aggregate_GraphQLException_Produces_Only_One_Field_Error()
+    {
+        var executor = await new ServiceCollection()
+            .AddGraphQL()
+            .AddQueryType<Query>()
+            .BuildRequestExecutorAsync();
+
+        var result = await executor.ExecuteAsync("{ test }");
+        var json = result.ToJson();
+
+        Assert.Contains("Test1", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("Test2", json, StringComparison.Ordinal);
+    }
+
+    public class Query
+    {
+        public string Test()
+            => throw new AggregateException(
+                new GraphQLException("Test1"),
+                new GraphQLException("Test2"));
+    }
+}


### PR DESCRIPTION
Fixes #7074

## Summary
- Added a regression test that reproduces throwing an `AggregateException` with multiple `GraphQLException` inner exceptions from a single field resolver.
- Updated resolver error reporting in `MiddlewareContext` to only surface the first field error for `GraphQLException` and `AggregateException` containers.
- This aligns field-error behavior with one-error-per-field expectations.

## Test Commands
- `dotnet test src/HotChocolate/Core/test/Execution.Tests/HotChocolate.Execution.Tests.csproj --filter "FullyQualifiedName~Issue7074ReproTests" --nologo`
- `dotnet test src/HotChocolate/Core/test/Types.Mutations.Tests/HotChocolate.Types.Mutations.Tests.csproj --filter "FullyQualifiedName~ErrorMiddleware_Should_MapAggregateException_WhenRegistered" --nologo`

## Results
- Both commands passed on `net8.0`, `net9.0`, and `net10.0`.
