### PR TITLE
Fix #7024 variable coercion with custom interface-typed filter fields

### DIFF
--- a/src/HotChocolate/Core/src/Types/Utilities/DictionaryToObjectConverter.cs
+++ b/src/HotChocolate/Core/src/Types/Utilities/DictionaryToObjectConverter.cs
@@ -25,6 +25,13 @@ public sealed class DictionaryToObjectConverter(ITypeConverter converter)
         IReadOnlyDictionary<string, object> dictionary,
         ConverterContext context)
     {
+        // Interface targets cannot be instantiated; keep dictionary representation.
+        if (context.ClrType.IsInterface)
+        {
+            context.Object = dictionary;
+            return;
+        }
+
         if (!context.ClrType.IsValueType
             && context.ClrType != typeof(string))
         {

--- a/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/Issue7024Tests.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/Issue7024Tests.cs
@@ -1,0 +1,119 @@
+using HotChocolate.Execution;
+using HotChocolate.Types;
+
+namespace HotChocolate.Data.Filters;
+
+public class Issue7024Tests
+{
+    [Fact]
+    public async Task Variable_Filter_With_Custom_List_Field_Works()
+    {
+        var machineIdWithLock = Guid.NewGuid();
+        var machineIdWithoutLock = Guid.NewGuid();
+
+        Machine[] machines =
+        [
+            new()
+            {
+                Id = machineIdWithLock,
+                Locks = new HashSet<MachineLock>
+                {
+                    new(machineIdWithLock, LockType.Lock1)
+                }
+            },
+            new()
+            {
+                Id = machineIdWithoutLock,
+                Locks = new HashSet<MachineLock>()
+            }
+        ];
+
+        var executor = SchemaBuilder.New()
+            .AddFiltering()
+            .AddQueryType(
+                d => d
+                    .Name(OperationTypeNames.Query)
+                    .Field("machines")
+                    .Resolve(_ => machines.AsQueryable())
+                    .UseFiltering<MachineFilterType>())
+            .AddType<MachineType>()
+            .Create()
+            .MakeExecutable();
+
+        var inlineResult = await executor.ExecuteAsync(
+            """
+            {
+              machines(where: { locks: { any: true } }) {
+                id
+              }
+            }
+            """);
+
+        var variableResult = await executor.ExecuteAsync(
+            OperationRequestBuilder.New()
+                .SetDocument(
+                    """
+                    query($filter: MachineFilterInput) {
+                      machines(where: $filter) {
+                        id
+                      }
+                    }
+                    """)
+                .SetVariableValues(
+                    new Dictionary<string, object?>
+                    {
+                        ["filter"] = new Dictionary<string, object?>
+                        {
+                            ["locks"] = new Dictionary<string, object?>
+                            {
+                                ["any"] = true
+                            }
+                        }
+                    })
+                .Build());
+
+        var inlineOperation = inlineResult.ExpectOperationResult();
+        var variableOperation = variableResult.ExpectOperationResult();
+
+        Assert.Empty(inlineOperation.Errors ?? []);
+        Assert.Empty(variableOperation.Errors ?? []);
+
+        Assert.Equal(
+            inlineOperation.ToJson(),
+            variableOperation.ToJson());
+    }
+
+    public class Machine
+    {
+        public Guid Id { get; set; }
+
+        public ISet<MachineLock> Locks { get; set; } = new HashSet<MachineLock>();
+    }
+
+    public record MachineLock(Guid MachineId, LockType Lock);
+
+    public enum LockType
+    {
+        Lock1,
+        Lock2
+    }
+
+    public class MachineType : ObjectType<Machine>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Machine> descriptor)
+        {
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Id);
+        }
+    }
+
+    public class MachineFilterType : FilterInputType<Machine>
+    {
+        protected override void Configure(IFilterInputTypeDescriptor<Machine> descriptor)
+        {
+            descriptor.Name("MachineFilterInput");
+            descriptor.BindFieldsExplicitly();
+            descriptor.Field(x => x.Locks.Select(y => y.Lock)).Name("locks");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7024

## Summary
- adds a regression test reproducing the custom filter variable coercion scenario from the issue
- avoids interface instantiation in `DictionaryToObjectConverter` when the input value is a dictionary
- keeps dictionary representation for interface targets so variable-based filter input behaves like inline filter input

## Test Commands
- `dotnet test src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/HotChocolate.Data.Filters.InMemory.Tests.csproj --filter "FullyQualifiedName~Issue7024Tests" --nologo`
- `dotnet test src/HotChocolate/Data/test/Data.Filters.InMemory.Tests/HotChocolate.Data.Filters.InMemory.Tests.csproj --filter "FullyQualifiedName~QueryableFilterVisitorListTests|FullyQualifiedName~QueryableFilterVisitorVariablesTests|FullyQualifiedName~Issue7024Tests" --nologo`

## Results
- Passed on `net8.0`, `net9.0`, and `net10.0`.
