### PR TITLE
Fix #7609 interface/object reuse with oneOf inputs

### DIFF
--- a/src/HotChocolate/Core/src/Types/Configuration/ExtendedTypeRefEqualityComparer.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/ExtendedTypeRefEqualityComparer.cs
@@ -19,9 +19,7 @@ internal sealed class ExtendedTypeRefEqualityComparer : IEqualityComparer<Extend
             return false;
         }
 
-        if (x.Context != y.Context
-            && x.Context != TypeContext.None
-            && y.Context != TypeContext.None)
+        if (x.Context != y.Context)
         {
             return false;
         }
@@ -54,10 +52,11 @@ internal sealed class ExtendedTypeRefEqualityComparer : IEqualityComparer<Extend
         unchecked
         {
             var hashCode = GetHashCode(obj.Type);
+            hashCode = (hashCode * 397) ^ obj.Context.GetHashCode();
 
             if (obj.Scope is not null)
             {
-                hashCode ^= obj.GetHashCode() * 397;
+                hashCode = (hashCode * 397) ^ StringComparer.Ordinal.GetHashCode(obj.Scope);
             }
 
             return hashCode;

--- a/src/HotChocolate/Core/src/Types/Configuration/TypeRegistry.cs
+++ b/src/HotChocolate/Core/src/Types/Configuration/TypeRegistry.cs
@@ -46,7 +46,7 @@ internal sealed class TypeRegistry
         }
 
         if (typeReference is ExtendedTypeReference extendedTypeRef
-            && _runtimeTypeRefs.TryGetValue(extendedTypeRef, out var reference))
+            && TryGetRuntimeTypeRefInternal(extendedTypeRef, out var reference))
         {
             return _typeRegister.ContainsKey(reference);
         }
@@ -61,7 +61,7 @@ internal sealed class TypeRegistry
         ArgumentNullException.ThrowIfNull(typeRef);
 
         if (typeRef is ExtendedTypeReference clrTypeRef
-            && _runtimeTypeRefs.TryGetValue(clrTypeRef, out var internalRef))
+            && TryGetRuntimeTypeRefInternal(clrTypeRef, out var internalRef))
         {
             typeRef = internalRef;
         }
@@ -75,14 +75,20 @@ internal sealed class TypeRegistry
     {
         ArgumentNullException.ThrowIfNull(runtimeTypeRef);
 
-        return _runtimeTypeRefs.TryGetValue(runtimeTypeRef, out typeRef);
+        return TryGetRuntimeTypeRefInternal(runtimeTypeRef, out typeRef);
     }
 
     public bool IsExplicitBinding(ExtendedTypeReference runtimeTypeRef)
     {
         ArgumentNullException.ThrowIfNull(runtimeTypeRef);
 
-        return _explicitRuntimeTypeRefs.Contains(runtimeTypeRef);
+        if (_explicitRuntimeTypeRefs.Contains(runtimeTypeRef))
+        {
+            return true;
+        }
+
+        return runtimeTypeRef.Context is not TypeContext.None
+            && _explicitRuntimeTypeRefs.Contains(runtimeTypeRef.WithContext());
     }
 
     public bool TryGetTypeRef(
@@ -101,6 +107,24 @@ internal sealed class TypeRegistry
     }
 
     public IEnumerable<TypeReference> GetTypeRefs() => _runtimeTypeRefs.Values;
+
+    private bool TryGetRuntimeTypeRefInternal(
+        ExtendedTypeReference runtimeTypeRef,
+        [NotNullWhen(true)] out TypeReference? typeRef)
+    {
+        if (_runtimeTypeRefs.TryGetValue(runtimeTypeRef, out typeRef))
+        {
+            return true;
+        }
+
+        if (runtimeTypeRef.Context is not TypeContext.None)
+        {
+            return _runtimeTypeRefs.TryGetValue(runtimeTypeRef.WithContext(), out typeRef);
+        }
+
+        typeRef = null;
+        return false;
+    }
 
     public void TryRegister(
         ExtendedTypeReference runtimeTypeRef,

--- a/src/HotChocolate/Core/test/Types.Tests/Regressions/Issue_7609.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Regressions/Issue_7609.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using HotChocolate.Execution;
+using HotChocolate.Types;
+
+namespace HotChocolate.Regressions;
+
+public class Issue_7609
+{
+    [Fact]
+    public async Task Query_Only_Reusing_Dtos_Works()
+    {
+        var schema = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddQueryType<Issue7609Query>()
+            .AddType<Issue7609Boat>()
+            .AddType<Issue7609Car>()
+            .BuildSchemaAsync();
+
+        Assert.NotNull(schema);
+    }
+
+    [Fact]
+    public async Task Interface_Output_And_OneOf_Input_Reusing_Dtos_Does_Not_Throw()
+    {
+        // Repro from #7609: reuse the same DTOs for interface output and oneOf input.
+        var schema = await new ServiceCollection()
+            .AddGraphQLServer()
+            .AddQueryType<Issue7609Query>()
+            .AddMutationType<Issue7609Mutation>()
+            .AddType<Issue7609Boat>()
+            .AddType<Issue7609Car>()
+            .AddType<Issue7609BoatInput>()
+            .AddType<Issue7609CarInput>()
+            .BuildSchemaAsync();
+
+        Assert.NotNull(schema);
+    }
+
+    public class Issue7609Query
+    {
+        public Issue7609BaseThing? GetThing(string? name) => name switch
+        {
+            "Car" => new Issue7609Car { Name = name, Make = "Toyota" },
+            "Boat" => new Issue7609Boat { Name = name, Make = "Yamaha", Length = 10 },
+            _ => null
+        };
+    }
+
+    [InterfaceType]
+    public interface Issue7609BaseThing
+    {
+        string? Name { get; }
+    }
+
+    [ObjectType]
+    public class Issue7609Car : Issue7609BaseThing
+    {
+        public required string Name { get; set; }
+
+        public required string Make { get; set; }
+    }
+
+    [ObjectType]
+    public class Issue7609Boat : Issue7609BaseThing
+    {
+        public required string Name { get; set; }
+
+        public required string Make { get; set; }
+
+        public int Length { get; set; }
+    }
+
+    public class Issue7609Mutation
+    {
+        public bool AddThingy(Issue7609CouldBeInputThingInput thing) => thing is not null;
+    }
+
+    [OneOf]
+    public class Issue7609CouldBeInputThingInput
+    {
+        public Issue7609Boat? Boat { get; set; }
+
+        public Issue7609Car? Car { get; set; }
+    }
+
+    public class Issue7609BoatInput : InputObjectType<Issue7609Boat>;
+
+    public class Issue7609CarInput : InputObjectType<Issue7609Car>;
+}


### PR DESCRIPTION
## Summary
- add regression coverage for reusing the same DTOs as interface output types and oneOf input members
- make runtime type reference matching context-exact (Input/Output/None)
- allow fallback from specific contexts to None during runtime type lookups without treating None as a wildcard during registration checks

Fixes #7609

## Validation
- Issue_7609 regression tests pass on net8/net9/net10
- TypeDiscovererTests and TypeInitializerTests pass on net8/net9/net10
