### PR TITLE
Migration guide: Cost analysis for AutomaticPersistedOperations-pipeline

### DIFF
--- a/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
+++ b/website/src/docs/hotchocolate/v16/migrating/migrate-from-15-to-16.md
@@ -809,6 +809,12 @@ There is no 1:1 mapping for all old methods. In most cases:
 
 Also note that `SubscriptionTransportError(...)` is no longer exposed separately in the fusion diagnostics API; use `SourceSchemaTransportError(...)`. -->
 
+## Cost validation now active for `AutomaticPersistedOperations`-pipeline
+
+If you are using Automatic Persisted Queries (APQ), cost analysis is now validated correctly.
+In v15, cost was not applied when the `AutomaticPersistedOperations`-pipeline was used, allowing queries to bypass cost limits.
+After upgrading, queries that previously executed successfully may now be rejected due to their configured cost.
+
 # Deprecations
 
 Things that will continue to function this release, but we encourage you to move away from.


### PR DESCRIPTION
Added section for now active cost analysis within the APQ-pipeline.

Not sure whether this should even be mentioned, since APQ is probably not very widely used. However, it would have saved me half a day since it was tricky to find. I first suspected that the cost analysis itself had changed (assuming it was already active in v15, which it was not) and therefore looked in the wrong places.

See slack: https://hotchocolategraphql.slack.com/archives/C01EZSSF6NS/p1773649798490099?thread_ts=1772536564.803119&cid=C01EZSSF6NS 