### PR TITLE
fix(PageConnection): fallback to 0, not -1 on empty pages

### DIFF
--- a/src/GreenDonut/src/GreenDonut.Data.Primitives/ValueCursorPage.cs
+++ b/src/GreenDonut/src/GreenDonut.Data.Primitives/ValueCursorPage.cs
@@ -45,7 +45,7 @@ internal sealed class ValueCursorPage<T> : Page<T>
     /// <summary>
     /// An empty page.
     /// </summary>
-    public static new ValueCursorPage<T> Empty { get; } = new([], false, false, _ => string.Empty);
+    public static new ValueCursorPage<T> Empty { get; } = new([], false, false, _ => string.Empty, 0);
 
     protected override string CreateCursor(int index, int offset, int pageIndex, int totalCount)
         => _createCursor(new EdgeEntry<T>(Entries[index].Item, offset, pageIndex, totalCount));

--- a/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
@@ -76,5 +76,5 @@ public class PageConnection<TNode> : ConnectionBase<TNode, PageEdge<TNode>, Page
     /// Identifies the total count of items in the connection.
     /// </summary>
     [GraphQLDescription("Identifies the total count of items in the connection.")]
-    public int TotalCount => _page.TotalCount ?? -1;
+    public int TotalCount => _page.TotalCount ?? 0;
 }

--- a/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
@@ -76,5 +76,6 @@ public class PageConnection<TNode> : ConnectionBase<TNode, PageEdge<TNode>, Page
     /// Identifies the total count of items in the connection.
     /// </summary>
     [GraphQLDescription("Identifies the total count of items in the connection.")]
-    public int TotalCount => _page.TotalCount ?? _page.Count;
+    public int TotalCount =>
+        _page.TotalCount ?? throw new GraphQLException("Total count is not available for this connection.");
 }

--- a/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination.Extensions/PageConnection.cs
@@ -76,5 +76,5 @@ public class PageConnection<TNode> : ConnectionBase<TNode, PageEdge<TNode>, Page
     /// Identifies the total count of items in the connection.
     /// </summary>
     [GraphQLDescription("Identifies the total count of items in the connection.")]
-    public int TotalCount => _page.TotalCount ?? 0;
+    public int TotalCount => _page.TotalCount ?? _page.Count;
 }


### PR DESCRIPTION
This pull request makes a minor change to the default value for the `TotalCount` property in the `PageConnection` class. The default value is now `0` instead of `-1` when the total count is not available.
