### PR TITLE
Sockets client: add OperationResult.Incremental

### DIFF
--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/OperationResult.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/OperationResult.cs
@@ -30,6 +30,10 @@ public sealed class OperationResult : IDisposable
     /// A <see cref="JsonElement"/> object representing any extensions returned by the
     /// operation.
     /// </param>
+    /// <param name="incremental">
+    /// A <see cref="JsonElement"/> object representing the incremental result returned by the
+    /// operation.
+    /// </param>
     /// <param name="requestIndex">
     /// The request index of this result. This is only set if the result is part of a batched operation.
     /// </param>
@@ -41,6 +45,7 @@ public sealed class OperationResult : IDisposable
         JsonElement data = default,
         JsonElement errors = default,
         JsonElement extensions = default,
+        JsonElement incremental = default,
         int? requestIndex = null,
         int? variableIndex = null)
     {
@@ -48,6 +53,7 @@ public sealed class OperationResult : IDisposable
         Data = data;
         Errors = errors;
         Extensions = extensions;
+        Incremental = incremental;
         RequestIndex = requestIndex;
         VariableIndex = variableIndex;
     }
@@ -81,6 +87,12 @@ public sealed class OperationResult : IDisposable
     public JsonElement Extensions { get; }
 
     /// <summary>
+    /// Gets the <see cref="JsonElement"/> object representing the incremental result returned
+    /// by the operation.
+    /// </summary>
+    public JsonElement Incremental { get; }
+
+    /// <summary>
     /// Releases all resources used by the <see cref="OperationResult"/> object.
     /// </summary>
     public void Dispose()
@@ -90,13 +102,16 @@ public sealed class OperationResult : IDisposable
     {
         ArgumentNullException.ThrowIfNull(documentOwner);
 
-        var root = documentOwner.Document.RootElement;
+        return Parse(documentOwner.Document.RootElement, documentOwner);
+    }
 
-        return new OperationResult(
-            documentOwner,
+    public static OperationResult Parse(JsonElement root, IDisposable? memoryOwner = null)
+    {
+        return new OperationResult(memoryOwner,
             root.TryGetProperty(DataProp, out var data) ? data : default,
             root.TryGetProperty(ErrorsProp, out var errors) ? errors : default,
             root.TryGetProperty(ExtensionsProp, out var extensions) ? extensions : default,
+            root.TryGetProperty(IncrementalProp, out var incremental) ? incremental : default,
             root.TryGetProperty(RequestIndexProp, out var requestIndex) ? requestIndex.GetInt32() : null,
             root.TryGetProperty(VariableIndexProp, out var variableIndex) ? variableIndex.GetInt32() : null);
     }
@@ -105,15 +120,7 @@ public sealed class OperationResult : IDisposable
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        var root = document.RootElement;
-
-        return new OperationResult(
-            document,
-            root.TryGetProperty(DataProp, out var data) ? data : default,
-            root.TryGetProperty(ErrorsProp, out var errors) ? errors : default,
-            root.TryGetProperty(ExtensionsProp, out var extensions) ? extensions : default,
-            root.TryGetProperty(RequestIndexProp, out var requestIndex) ? requestIndex.GetInt32() : null,
-            root.TryGetProperty(VariableIndexProp, out var variableIndex) ? variableIndex.GetInt32() : null);
+        return Parse(document.RootElement, document);
     }
 
     public static OperationResult Parse(ReadOnlySpan<byte> span)
@@ -129,18 +136,7 @@ public sealed class OperationResult : IDisposable
         var bufferSpan = buffer.GetSpan(span.Length);
         span.CopyTo(bufferSpan);
         buffer.Advance(span.Length);
-
-        var document = JsonDocument.Parse(buffer.WrittenMemory);
-        var root = document.RootElement;
-        var documentOwner = new JsonDocumentOwner(document, buffer);
-
-        return new OperationResult(
-            documentOwner,
-            root.TryGetProperty(DataProp, out var data) ? data : default,
-            root.TryGetProperty(ErrorsProp, out var errors) ? errors : default,
-            root.TryGetProperty(ExtensionsProp, out var extensions) ? extensions : default,
-            root.TryGetProperty(RequestIndexProp, out var requestIndex) ? requestIndex.GetInt32() : null,
-            root.TryGetProperty(VariableIndexProp, out var variableIndex) ? variableIndex.GetInt32() : null);
+        return Parse(buffer);
     }
 
     public static OperationResult Parse(PooledArrayWriter buffer)
@@ -153,15 +149,8 @@ public sealed class OperationResult : IDisposable
         }
 
         var document = JsonDocument.Parse(buffer.WrittenMemory);
-        var root = document.RootElement;
         var documentOwner = new JsonDocumentOwner(document, buffer);
 
-        return new OperationResult(
-            documentOwner,
-            root.TryGetProperty(DataProp, out var data) ? data : default,
-            root.TryGetProperty(ErrorsProp, out var errors) ? errors : default,
-            root.TryGetProperty(ExtensionsProp, out var extensions) ? extensions : default,
-            root.TryGetProperty(RequestIndexProp, out var requestIndex) ? requestIndex.GetInt32() : null,
-            root.TryGetProperty(VariableIndexProp, out var variableIndex) ? variableIndex.GetInt32() : null);
+        return Parse(document.RootElement, documentOwner);
     }
 }

--- a/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8GraphQLResultProperties.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Abstractions/Serialization/Utf8GraphQLResultProperties.cs
@@ -25,6 +25,11 @@ internal static class Utf8GraphQLResultProperties
     public static ReadOnlySpan<byte> ExtensionsProp => "extensions"u8;
 
     /// <summary>
+    /// Gets the incremental property name.
+    /// </summary>
+    public static ReadOnlySpan<byte> IncrementalProp => "incremental"u8;
+
+    /// <summary>
     /// Gets the request index property name.
     /// </summary>
     public static ReadOnlySpan<byte> RequestIndexProp => "requestIndex"u8;

--- a/src/HotChocolate/AspNetCore/src/Transport.Sockets.Client/Protocols/GraphQLOverWebSocket/Messages/NextMessage.cs
+++ b/src/HotChocolate/AspNetCore/src/Transport.Sockets.Client/Protocols/GraphQLOverWebSocket/Messages/NextMessage.cs
@@ -36,24 +36,8 @@ internal sealed class NextMessage : IDataMessage
         var id = root.GetProperty(Utf8MessageProperties.IdProp).GetString()!;
         var payload = root.GetProperty(Utf8MessageProperties.PayloadProp);
 
-        var result = new OperationResult(
-            documentOwner,
-            TryGetProperty(payload, Utf8MessageProperties.DataProp),
-            TryGetProperty(payload, Utf8MessageProperties.ErrorsProp),
-            TryGetProperty(payload, Utf8MessageProperties.ExtensionsProp),
-            TryGetInt32Property(payload, Utf8MessageProperties.RequestIndexProp),
-            TryGetInt32Property(payload, Utf8MessageProperties.VariableIndexProp));
+        var result = OperationResult.Parse(payload, documentOwner);
 
         return new NextMessage(id, result);
     }
-
-    private static JsonElement TryGetProperty(JsonElement element, ReadOnlySpan<byte> name)
-        => element.TryGetProperty(name, out var property)
-            ? property
-            : default;
-
-    private static int? TryGetInt32Property(JsonElement element, ReadOnlySpan<byte> name)
-        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.Number
-            ? property.GetInt32()
-            : null;
 }


### PR DESCRIPTION
`Transport.Sockets.Client` can subscribe to results of GraphQL queries which return incremental results (`@defer`/`@stream`), but there is no way to obtain the results as the payload's `incremental` property is not parsed and the payload's root JSON element is not accessible. This small PR parses the `incremental` property out of the payload.