### PR TITLE
Fix [UseConnection] source generation for resolvers returning Connection<T>

### DIFF
--- a/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/FileBuilders/TypeFileBuilderBase.cs
@@ -2042,6 +2042,29 @@ public abstract class TypeFileBuilderBase(StringBuilder sb)
                 }
                 break;
 
+            case SchemaTypeReferenceKind.ConnectionTypeReference:
+                Writer.WriteIndentedLine(
+                    "{0} = global::{1}.CreateConnectionTypeReference(",
+                    propertyName,
+                    WellKnownTypes.ConnectionTypeHelper);
+                using (Writer.IncreaseIndent())
+                {
+                    Writer.WriteIndentedLine("field.Context,");
+                    Writer.WriteIndentedLine(
+                        "\"{0}\",",
+                        GeneratorUtils.EscapeForStringLiteral(typeReference.TypeStructure));
+                    Writer.WriteIndentedLine(
+                        "typeInspector.GetTypeRef(typeof({0}), {1}.{2}),",
+                        typeReference.TypeString,
+                        WellKnownTypes.TypeContext,
+                        context);
+                    Writer.WriteIndentedLine(
+                        "nonNull: {0}){1}",
+                        typeReference.NonNull ? "true" : "false",
+                        lineEnd);
+                }
+                break;
+
             default:
                 throw new NotSupportedException();
         }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Helpers/CompilationExtensions.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Helpers/CompilationExtensions.cs
@@ -189,14 +189,14 @@ public static class CompilationExtensions
         return null;
     }
 
-    public static INamedTypeSymbol? GetConnectionBaseSymbol(this GeneratorSyntaxContext context)
-        => context.SemanticModel.Compilation.GetConnectionBaseSymbol();
-
     public static INamedTypeSymbol? GetFieldResultInterface(this Compilation compilation)
         => compilation.GetTypeByMetadataName("HotChocolate.IFieldResult");
 
-    public static INamedTypeSymbol? GetConnectionBaseSymbol(this Compilation compilation)
-        => compilation.GetTypeByMetadataName("HotChocolate.Types.Pagination.ConnectionBase`3");
+    public static INamedTypeSymbol? GetConnectionInterfaceSymbol(this Compilation compilation)
+        => compilation.GetTypeByMetadataName("HotChocolate.Types.Pagination.IConnection`1");
+
+    public static INamedTypeSymbol? GetConnectionClassSymbol(this Compilation compilation)
+        => compilation.GetTypeByMetadataName("HotChocolate.Types.Pagination.Connection`1");
 
     public static INamedTypeSymbol? GetEdgeInterfaceSymbol(this Compilation compilation)
         => compilation.GetTypeByMetadataName("HotChocolate.Types.Pagination.IEdge`1");
@@ -250,7 +250,7 @@ public static class CompilationExtensions
             return false;
         }
 
-        return IsDerivedFromGenericBase(namedType, compilation.GetConnectionBaseSymbol());
+        return IsDerivedFromGenericBase(namedType, compilation.GetConnectionInterfaceSymbol());
     }
 
     public static bool IsEdgeType(this Compilation compilation, ITypeSymbol possibleEdgeType)

--- a/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/ConnectionTypeTransformer.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Inspectors/ConnectionTypeTransformer.cs
@@ -63,6 +63,31 @@ public class ConnectionTypeTransformer : IPostCollectSyntaxTransformer
                 var owner = item.Value;
 #endif
                 var connectionType = GetConnectionType(compilation, connectionResolver.Member.GetReturnType());
+
+                // Connection<T>/IConnection<T> use the shared runtime connection type, so no
+                // connection or edge types are generated here. The name is left out of
+                // connectionNameLookup on purpose; a clash with a generated connection type
+                // surfaces later as a duplicate type name error at schema build time.
+                if (IsRuntimeConnectionType(compilation, connectionType))
+                {
+                    if (!compilation.TryGetConnectionNameFromResolver(
+                        connectionResolver.Member,
+                        out var runtimeConnectionName))
+                    {
+                        runtimeConnectionName = connectionType.TypeArguments[0].Name;
+                    }
+
+                    owner.ReplaceResolver(
+                        connectionResolver,
+                        connectionResolver.WithSchemaTypeName(
+                            new SchemaTypeReference(
+                                SchemaTypeReferenceKind.ConnectionTypeReference,
+                                connectionType.TypeArguments[0].ToFullyQualified(),
+                                typeStructure: runtimeConnectionName,
+                                nonNull: !connectionResolver.ReturnType.IsNullableType())));
+                    continue;
+                }
+
                 ConnectionTypeInfo connectionTypeInfo;
                 ConnectionClassInfo? connectionClass;
                 EdgeTypeInfo? edgeTypeInfo;
@@ -301,6 +326,21 @@ public class ConnectionTypeTransformer : IPostCollectSyntaxTransformer
 
         [DoesNotReturn]
         static void Throw() => throw new InvalidOperationException("Could not resolve connection base type.");
+    }
+
+    private static bool IsRuntimeConnectionType(
+        Compilation compilation,
+        INamedTypeSymbol connectionType)
+    {
+        if (!connectionType.IsGenericType || connectionType.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        var definition = connectionType.OriginalDefinition;
+
+        return SymbolEqualityComparer.Default.Equals(definition, compilation.GetConnectionClassSymbol())
+            || SymbolEqualityComparer.Default.Equals(definition, compilation.GetConnectionInterfaceSymbol());
     }
 
     private static string GetTypeLookupKey(IOutputTypeInfo typeInfo)

--- a/src/HotChocolate/Core/src/Types.Analyzers/Models/ConnectionClassInfo.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Models/ConnectionClassInfo.cs
@@ -80,7 +80,7 @@ public sealed class ConnectionClassInfo : SyntaxInfo, IEquatable<ConnectionClass
         {
             switch (member)
             {
-                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                case IMethodSymbol { MethodKind: MethodKind.Ordinary, ReturnsVoid: false } method:
                     resolvers.Add(ObjectTypeInspector.CreateResolver(compilation, runtimeType, method, name));
                     break;
 

--- a/src/HotChocolate/Core/src/Types.Analyzers/Models/ConnectionTypeInfo.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Models/ConnectionTypeInfo.cs
@@ -152,7 +152,7 @@ public sealed class ConnectionTypeInfo
         {
             switch (member)
             {
-                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                case IMethodSymbol { MethodKind: MethodKind.Ordinary, ReturnsVoid: false } method:
                     resolvers.Add(CreateResolver(compilation, runtimeType, method, connectionName));
                     break;
 

--- a/src/HotChocolate/Core/src/Types.Analyzers/Models/EdgeTypeInfo.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Models/EdgeTypeInfo.cs
@@ -160,7 +160,7 @@ public sealed class EdgeTypeInfo
         {
             switch (member)
             {
-                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                case IMethodSymbol { MethodKind: MethodKind.Ordinary, ReturnsVoid: false } method:
                     resolvers.Add(ObjectTypeInspector.CreateResolver(compilation, runtimeType, method, edgeName));
                     break;
 

--- a/src/HotChocolate/Core/src/Types.Analyzers/Models/SchemaTypeReference.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Models/SchemaTypeReference.cs
@@ -6,12 +6,14 @@ public readonly struct SchemaTypeReference
         SchemaTypeReferenceKind kind,
         string typeString,
         string? typeStructure = null,
-        string? nullability = null)
+        string? nullability = null,
+        bool nonNull = false)
     {
         Kind = kind;
         TypeString = typeString;
         TypeStructure = typeStructure;
         Nullability = nullability;
+        NonNull = nonNull;
     }
 
     public SchemaTypeReferenceKind Kind { get; }
@@ -21,4 +23,6 @@ public readonly struct SchemaTypeReference
     public string? TypeStructure { get; }
 
     public string? Nullability { get; }
+
+    public bool NonNull { get; }
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/Models/SchemaTypeReferenceKind.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/Models/SchemaTypeReferenceKind.cs
@@ -4,5 +4,6 @@ public enum SchemaTypeReferenceKind
 {
     ExtendedTypeReference = 0,
     SyntaxTypeReference = 1,
-    FactoryTypeReference = 2
+    FactoryTypeReference = 2,
+    ConnectionTypeReference = 3
 }

--- a/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
+++ b/src/HotChocolate/Core/src/Types.Analyzers/WellKnownTypes.cs
@@ -96,6 +96,7 @@ public static class WellKnownTypes
     public const string ListType = "HotChocolate.Types.ListType";
     public const string ConnectionFlags = "HotChocolate.Types.Pagination.ConnectionFlags";
     public const string ConnectionFlagsHelper = "HotChocolate.Types.Pagination.ConnectionFlagsHelper";
+    public const string ConnectionTypeHelper = "HotChocolate.Types.Pagination.ConnectionTypeHelper";
     public const string Shareable = "HotChocolate.Types.Composite.Shareable";
     public const string Inaccessible = "HotChocolate.Types.Composite.Inaccessible";
     public const string ArgumentConfiguration = "HotChocolate.Types.Descriptors.Configurations.ArgumentConfiguration";

--- a/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionTypeHelper.cs
+++ b/src/HotChocolate/Core/src/Types.CursorPagination/ConnectionTypeHelper.cs
@@ -1,0 +1,54 @@
+using HotChocolate.Types.Descriptors;
+
+namespace HotChocolate.Types.Pagination;
+
+/// <summary>
+/// Provides helpers to create type references for connection types.
+/// The helpers are used by source-generated type initialization code.
+/// </summary>
+public static class ConnectionTypeHelper
+{
+    /// <summary>
+    /// Creates a type reference for a field that returns
+    /// <see cref="Connection{T}"/> or <see cref="IConnection{T}"/>.
+    /// The referenced connection type exposes the standard connection fields
+    /// (edges, nodes, pageInfo and totalCount) for the specified node type.
+    /// </summary>
+    /// <param name="context">
+    /// The descriptor context.
+    /// </param>
+    /// <param name="connectionName">
+    /// The connection name, for example <c>Book</c> for a <c>BookConnection</c>.
+    /// </param>
+    /// <param name="nodeType">
+    /// The type reference of the node type.
+    /// </param>
+    /// <param name="nonNull">
+    /// Specifies if the connection type is wrapped in a non-null type.
+    /// </param>
+    /// <returns>
+    /// A type reference that can be set as the field type.
+    /// </returns>
+    public static TypeReference CreateConnectionTypeReference(
+        IDescriptorContext context,
+        string connectionName,
+        TypeReference nodeType,
+        bool nonNull)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+        ArgumentNullException.ThrowIfNull(nodeType);
+
+        var typeName = NameHelper.CreateConnectionName(context.Naming, connectionName);
+
+        return TypeReference.Parse(
+            nonNull ? $"{typeName}!" : typeName,
+            TypeContext.Output,
+            factory: c => new ConnectionType(
+                connectionName,
+                nodeType,
+                includeTotalCount: true,
+                includeNodesField: true,
+                c.Naming));
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorOffsetPagingReproTests.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorOffsetPagingReproTests.cs
@@ -1,20 +1,7 @@
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Text.Json;
-using Basic.Reference.Assemblies;
-using GreenDonut;
-using GreenDonut.Data;
-using HotChocolate.Data.Filters;
 using HotChocolate.Execution;
 using HotChocolate.Execution.Configuration;
-using HotChocolate.Execution.Processing;
-using HotChocolate.Features;
-using HotChocolate.Language;
-using HotChocolate.Types.Analyzers;
-using HotChocolate.Types.Pagination;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace HotChocolate.Types;
@@ -38,12 +25,12 @@ public class SourceGeneratorOffsetPagingReproTests
     {
         var assembly = CompileModuleDictionaryReproAssembly();
 
-        var sourceGenerated = await ExecuteWithSourceGeneratorRegistrationAsync(
+        var sourceGenerated = await SourceGeneratorTestHelpers.ExecuteWithSourceGeneratorRegistrationAsync(
             assembly,
             registrationMethodName: "AddDemo",
             query: "{ foo { key value } }");
 
-        var addQueryType = await ExecuteWithAddQueryTypeRegistrationAsync(
+        var addQueryType = await SourceGeneratorTestHelpers.ExecuteWithAddQueryTypeRegistrationAsync(
             assembly,
             runtimeQueryTypeName: "Repro.RuntimeQuery",
             query: "{ foo { key value } }");
@@ -60,7 +47,7 @@ public class SourceGeneratorOffsetPagingReproTests
     {
         var assembly = CompileModuleDictionaryMutationConventionsReproAssembly();
 
-        var sourceGenerated = await ExecuteWithSourceGeneratorRegistrationAsync(
+        var sourceGenerated = await SourceGeneratorTestHelpers.ExecuteWithSourceGeneratorRegistrationAsync(
             assembly,
             registrationMethodName: "AddDemo",
             query:
@@ -80,7 +67,7 @@ public class SourceGeneratorOffsetPagingReproTests
             """,
             configureBuilder: static b => b.AddMutationConventions());
 
-        var addQueryAndMutationType = await ExecuteWithAddQueryAndMutationTypeRegistrationAsync(
+        var addQueryAndMutationType = await SourceGeneratorTestHelpers.ExecuteWithAddQueryAndMutationTypeRegistrationAsync(
             assembly,
             runtimeQueryTypeName: "Repro.RuntimeQuery",
             runtimeMutationTypeName: "Repro.RuntimeMutation",
@@ -116,7 +103,7 @@ public class SourceGeneratorOffsetPagingReproTests
     {
         var assembly = CompileModuleOffsetPagingNullabilityReproAssembly();
 
-        var sourceGenerated = await ExecuteWithSourceGeneratorRegistrationAsync(
+        var sourceGenerated = await SourceGeneratorTestHelpers.ExecuteWithSourceGeneratorRegistrationAsync(
             assembly,
             registrationMethodName: "AddDemo",
             query:
@@ -130,7 +117,7 @@ public class SourceGeneratorOffsetPagingReproTests
             }
             """);
 
-        var addQueryType = await ExecuteWithAddQueryTypeRegistrationAsync(
+        var addQueryType = await SourceGeneratorTestHelpers.ExecuteWithAddQueryTypeRegistrationAsync(
             assembly,
             runtimeQueryTypeName: "Repro.RuntimeQuery",
             query:
@@ -154,7 +141,7 @@ public class SourceGeneratorOffsetPagingReproTests
     {
         var assembly = CompileModuleAnyTypeEscapingReproAssembly();
 
-        var sourceGenerated = await ExecuteWithSourceGeneratorRegistrationAsync(
+        var sourceGenerated = await SourceGeneratorTestHelpers.ExecuteWithSourceGeneratorRegistrationAsync(
             assembly,
             registrationMethodName: "AddDemo",
             query:
@@ -165,7 +152,7 @@ public class SourceGeneratorOffsetPagingReproTests
             """,
             configureBuilder: static b => b.AddJsonTypeConverter());
 
-        var addQueryType = await ExecuteWithAddQueryTypeRegistrationAsync(
+        var addQueryType = await SourceGeneratorTestHelpers.ExecuteWithAddQueryTypeRegistrationAsync(
             assembly,
             runtimeQueryTypeName: "Repro.RuntimeQuery",
             query:
@@ -200,7 +187,7 @@ public class SourceGeneratorOffsetPagingReproTests
         var services = new ServiceCollection();
         var builder = services.AddGraphQLServer(disableDefaultSecurity: true);
 
-        var addTypesMethod = FindRegistrationMethod(
+        var addTypesMethod = SourceGeneratorTestHelpers.FindRegistrationMethod(
             assembly,
             m =>
             {
@@ -229,87 +216,6 @@ public class SourceGeneratorOffsetPagingReproTests
 
         return await Record.ExceptionAsync(
             async () => await builder.BuildSchemaAsync());
-    }
-
-    private static async Task<ExecutionResult> ExecuteWithSourceGeneratorRegistrationAsync(
-        Assembly assembly,
-        string registrationMethodName,
-        string query,
-        Action<IRequestExecutorBuilder>? configureBuilder = null)
-    {
-        var builder = new ServiceCollection().AddGraphQLServer(disableDefaultSecurity: true);
-
-        var addModuleMethod = FindRegistrationMethod(
-            assembly,
-            m =>
-            {
-                var p = m.GetParameters();
-                return m.Name.Equals(registrationMethodName, StringComparison.Ordinal)
-                    && m.ReturnType == typeof(IRequestExecutorBuilder)
-                    && p.Length == 1
-                    && p[0].ParameterType == typeof(IRequestExecutorBuilder);
-            });
-
-        addModuleMethod.Invoke(null, [builder]);
-        configureBuilder?.Invoke(builder);
-
-        var executor = await builder.BuildRequestExecutorAsync();
-        var result = await executor.ExecuteAsync(query);
-        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
-    }
-
-    private static async Task<ExecutionResult> ExecuteWithAddQueryTypeRegistrationAsync(
-        Assembly assembly,
-        string runtimeQueryTypeName,
-        string query,
-        Action<IRequestExecutorBuilder>? configureBuilder = null)
-    {
-        var runtimeQueryType = assembly.GetType(runtimeQueryTypeName)
-            ?? throw new InvalidOperationException("Could not locate runtime query type.");
-
-        var builder = new ServiceCollection()
-            .AddGraphQLServer(disableDefaultSecurity: true)
-            .AddQueryType(runtimeQueryType);
-        configureBuilder?.Invoke(builder);
-
-        var executor = await builder.BuildRequestExecutorAsync();
-        var result = await executor.ExecuteAsync(query);
-        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
-    }
-
-    private static async Task<ExecutionResult> ExecuteWithAddQueryAndMutationTypeRegistrationAsync(
-        Assembly assembly,
-        string runtimeQueryTypeName,
-        string runtimeMutationTypeName,
-        string query,
-        Action<IRequestExecutorBuilder>? configureBuilder = null)
-    {
-        var runtimeQueryType = assembly.GetType(runtimeQueryTypeName)
-            ?? throw new InvalidOperationException("Could not locate runtime query type.");
-        var runtimeMutationType = assembly.GetType(runtimeMutationTypeName)
-            ?? throw new InvalidOperationException("Could not locate runtime mutation type.");
-
-        var builder = new ServiceCollection()
-            .AddGraphQLServer(disableDefaultSecurity: true)
-            .AddQueryType(runtimeQueryType)
-            .AddMutationType(runtimeMutationType);
-        configureBuilder?.Invoke(builder);
-
-        var executor = await builder.BuildRequestExecutorAsync();
-        var result = await executor.ExecuteAsync(query);
-        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
-    }
-
-    private static MethodInfo FindRegistrationMethod(
-        Assembly assembly,
-        Func<MethodInfo, bool> predicate)
-    {
-        return assembly
-            .GetTypes()
-            .Where(t => t is { IsAbstract: true, IsSealed: true }
-                && t.Namespace == "Microsoft.Extensions.DependencyInjection")
-            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
-            .Single(predicate);
     }
 
     private static Assembly CompileOffsetPagingReproAssembly()
@@ -343,7 +249,7 @@ public class SourceGeneratorOffsetPagingReproTests
             }
             """;
 
-        return CompileReproAssembly(source, "SourceGeneratorOffsetPagingRepro");
+        return SourceGeneratorTestHelpers.CompileReproAssembly(source, "SourceGeneratorOffsetPagingRepro");
     }
 
     private static Assembly CompileModuleDictionaryReproAssembly()
@@ -377,7 +283,7 @@ public class SourceGeneratorOffsetPagingReproTests
             }
             """;
 
-        return CompileReproAssembly(source, "SourceGeneratorDictionaryModuleRepro");
+        return SourceGeneratorTestHelpers.CompileReproAssembly(source, "SourceGeneratorDictionaryModuleRepro");
     }
 
     private static Assembly CompileModuleDictionaryMutationConventionsReproAssembly()
@@ -435,7 +341,9 @@ public class SourceGeneratorOffsetPagingReproTests
             }
             """;
 
-        return CompileReproAssembly(source, "SourceGeneratorDictionaryMutationConventionsRepro");
+        return SourceGeneratorTestHelpers.CompileReproAssembly(
+            source,
+            "SourceGeneratorDictionaryMutationConventionsRepro");
     }
 
     private static Assembly CompileModuleOffsetPagingNullabilityReproAssembly()
@@ -474,7 +382,9 @@ public class SourceGeneratorOffsetPagingReproTests
             public record Foo(string Bar);
             """;
 
-        return CompileReproAssembly(source, "SourceGeneratorOffsetPagingNullabilityRepro");
+        return SourceGeneratorTestHelpers.CompileReproAssembly(
+            source,
+            "SourceGeneratorOffsetPagingNullabilityRepro");
     }
 
     private static Assembly CompileModuleAnyTypeEscapingReproAssembly()
@@ -505,93 +415,6 @@ public class SourceGeneratorOffsetPagingReproTests
             public record Foo(string Description);
             """;
 
-        return CompileReproAssembly(source, "SourceGeneratorAnyTypeEscapingRepro");
+        return SourceGeneratorTestHelpers.CompileReproAssembly(source, "SourceGeneratorAnyTypeEscapingRepro");
     }
-
-    private static Assembly CompileReproAssembly(string source, string assemblyName)
-    {
-        var parseOptions = CSharpParseOptions.Default;
-        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
-
-        IEnumerable<PortableExecutableReference> references =
-        [
-#if NET8_0
-            .. Net80.References.All,
-#elif NET9_0
-            .. Net90.References.All,
-#elif NET10_0
-            .. Net100.References.All,
-#elif NET11_0
-            .. Net110.References.All,
-#endif
-            MetadataReference.CreateFromFile(typeof(ITypeSystemMember).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(RequestDelegate).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(RequestContext).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(HotChocolateExecutionSelectionExtensions).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IRequestExecutorBuilder).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(ISelection).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(QueryTypeAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(Connection).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(PageConnection<>).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(ISchemaDefinition).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IFeatureProvider).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(OperationType).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(ParentAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(
-                typeof(HotChocolateAspNetCoreServiceCollectionExtensions).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(DataLoaderBase<,>).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IDataLoader).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(PagingArguments).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IPredicateBuilder).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(DefaultPredicateBuilder).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IFilterContext).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(WebApplication).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(Authorization.AuthorizeAttribute).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(UseOffsetPagingAttribute).Assembly.Location)
-        ];
-
-        var compilation = CSharpCompilation.Create(
-            assemblyName: assemblyName,
-            syntaxTrees: [syntaxTree],
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        var driver = CSharpGeneratorDriver
-            .Create(new GraphQLServerGenerator())
-            .RunGenerators(compilation);
-
-        var generatedTrees = driver
-            .GetRunResult()
-            .Results
-            .SelectMany(t => t.GeneratedSources)
-            .Select(s => CSharpSyntaxTree.ParseText(
-                s.SourceText,
-                parseOptions,
-                path: s.HintName));
-
-        var updatedCompilation = compilation.AddSyntaxTrees(generatedTrees);
-
-        using var stream = new MemoryStream();
-        var emitResult = updatedCompilation.Emit(stream);
-
-        if (!emitResult.Success)
-        {
-            throw new InvalidOperationException(
-                string.Join(
-                    Environment.NewLine,
-                    emitResult.Diagnostics
-                        .OrderBy(d => d.Severity)
-                        .ThenBy(d => d.Id)
-                        .Select(d => d.ToString())));
-        }
-
-        stream.Position = 0;
-
-        var context = new AssemblyLoadContext(assemblyName, isCollectible: true);
-        return context.LoadFromStream(stream);
-    }
-
-    private sealed record ExecutionResult(string Schema, string Result);
 }

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorTestHelpers.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorTestHelpers.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using Basic.Reference.Assemblies;
+using GreenDonut;
+using GreenDonut.Data;
+using HotChocolate.Data.Filters;
+using HotChocolate.Execution;
+using HotChocolate.Execution.Configuration;
+using HotChocolate.Execution.Processing;
+using HotChocolate.Features;
+using HotChocolate.Language;
+using HotChocolate.Types.Analyzers;
+using HotChocolate.Types.Pagination;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Types;
+
+internal static class SourceGeneratorTestHelpers
+{
+    internal static async Task<ExecutionResult> ExecuteWithSourceGeneratorRegistrationAsync(
+        Assembly assembly,
+        string registrationMethodName,
+        string query,
+        Action<IRequestExecutorBuilder>? configureBuilder = null)
+    {
+        var builder = new ServiceCollection().AddGraphQLServer(disableDefaultSecurity: true);
+
+        var addModuleMethod = FindRegistrationMethod(
+            assembly,
+            m =>
+            {
+                var p = m.GetParameters();
+                return m.Name.Equals(registrationMethodName, StringComparison.Ordinal)
+                    && m.ReturnType == typeof(IRequestExecutorBuilder)
+                    && p.Length == 1
+                    && p[0].ParameterType == typeof(IRequestExecutorBuilder);
+            });
+
+        addModuleMethod.Invoke(null, [builder]);
+        configureBuilder?.Invoke(builder);
+
+        var executor = await builder.BuildRequestExecutorAsync();
+        var result = await executor.ExecuteAsync(query);
+        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
+    }
+
+    internal static async Task<ExecutionResult> ExecuteWithAddQueryTypeRegistrationAsync(
+        Assembly assembly,
+        string runtimeQueryTypeName,
+        string query,
+        Action<IRequestExecutorBuilder>? configureBuilder = null)
+    {
+        var runtimeQueryType = assembly.GetType(runtimeQueryTypeName)
+            ?? throw new InvalidOperationException("Could not locate runtime query type.");
+
+        var builder = new ServiceCollection()
+            .AddGraphQLServer(disableDefaultSecurity: true)
+            .AddQueryType(runtimeQueryType);
+        configureBuilder?.Invoke(builder);
+
+        var executor = await builder.BuildRequestExecutorAsync();
+        var result = await executor.ExecuteAsync(query);
+        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
+    }
+
+    internal static async Task<ExecutionResult> ExecuteWithAddQueryAndMutationTypeRegistrationAsync(
+        Assembly assembly,
+        string runtimeQueryTypeName,
+        string runtimeMutationTypeName,
+        string query,
+        Action<IRequestExecutorBuilder>? configureBuilder = null)
+    {
+        var runtimeQueryType = assembly.GetType(runtimeQueryTypeName)
+            ?? throw new InvalidOperationException("Could not locate runtime query type.");
+        var runtimeMutationType = assembly.GetType(runtimeMutationTypeName)
+            ?? throw new InvalidOperationException("Could not locate runtime mutation type.");
+
+        var builder = new ServiceCollection()
+            .AddGraphQLServer(disableDefaultSecurity: true)
+            .AddQueryType(runtimeQueryType)
+            .AddMutationType(runtimeMutationType);
+        configureBuilder?.Invoke(builder);
+
+        var executor = await builder.BuildRequestExecutorAsync();
+        var result = await executor.ExecuteAsync(query);
+        return new ExecutionResult(executor.Schema.ToString(), result.ToJson());
+    }
+
+    internal static MethodInfo FindRegistrationMethod(
+        Assembly assembly,
+        Func<MethodInfo, bool> predicate)
+    {
+        return assembly
+            .GetTypes()
+            .Where(t => t is { IsAbstract: true, IsSealed: true, Namespace: "Microsoft.Extensions.DependencyInjection" })
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .Single(predicate);
+    }
+
+    internal static Assembly CompileReproAssembly(string source, string assemblyName)
+    {
+        var parseOptions = CSharpParseOptions.Default;
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+
+        IEnumerable<PortableExecutableReference> references =
+        [
+#if NET8_0
+            .. Net80.References.All,
+#elif NET9_0
+            .. Net90.References.All,
+#elif NET10_0
+            .. Net100.References.All,
+#elif NET11_0
+            .. Net110.References.All,
+#endif
+            MetadataReference.CreateFromFile(typeof(ITypeSystemMember).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(RequestDelegate).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(RequestContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(HotChocolateExecutionSelectionExtensions).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IRequestExecutorBuilder).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ISelection).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(QueryTypeAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Connection).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(PageConnection<>).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ISchemaDefinition).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IFeatureProvider).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(OperationType).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ParentAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(HotChocolateAspNetCoreServiceCollectionExtensions).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(DataLoaderBase<,>).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IDataLoader).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(PagingArguments).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IPredicateBuilder).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(DefaultPredicateBuilder).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IFilterContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(WebApplication).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IServiceCollection).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Authorization.AuthorizeAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(UseOffsetPagingAttribute).Assembly.Location)
+        ];
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver
+            .Create(new GraphQLServerGenerator())
+            .RunGenerators(compilation);
+
+        var generatedTrees = driver
+            .GetRunResult()
+            .Results
+            .SelectMany(t => t.GeneratedSources)
+            .Select(s => CSharpSyntaxTree.ParseText(
+                s.SourceText,
+                parseOptions,
+                path: s.HintName));
+
+        var updatedCompilation = compilation.AddSyntaxTrees(generatedTrees);
+
+        using var stream = new MemoryStream();
+        var emitResult = updatedCompilation.Emit(stream);
+
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(
+                string.Join(
+                    Environment.NewLine,
+                    emitResult.Diagnostics
+                        .OrderBy(d => d.Severity)
+                        .ThenBy(d => d.Id)
+                        .Select(d => d.ToString())));
+        }
+
+        stream.Position = 0;
+
+        var context = new AssemblyLoadContext(assemblyName, isCollectible: true);
+        return context.LoadFromStream(stream);
+    }
+
+    internal sealed record ExecutionResult(string Schema, string Result);
+}

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorUseConnectionTests.cs
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/SourceGeneratorUseConnectionTests.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+
+namespace HotChocolate.Types;
+
+public class SourceGeneratorUseConnectionTests
+{
+    [Fact]
+    public async Task UseConnection_Should_ExposeConnectionType_When_ResolverReturnsGenericConnection()
+    {
+        // arrange
+        var assembly = CompileConnectionAssembly();
+
+        // act
+        var sourceGenerated = await SourceGeneratorTestHelpers.ExecuteWithSourceGeneratorRegistrationAsync(
+            assembly,
+            registrationMethodName: "AddDemo",
+            query:
+            """
+            {
+              books {
+                edges {
+                  cursor
+                  node {
+                    id
+                  }
+                }
+                nodes {
+                  id
+                }
+                pageInfo {
+                  hasNextPage
+                  hasPreviousPage
+                  startCursor
+                  endCursor
+                }
+                totalCount
+              }
+            }
+            """);
+
+        // assert
+        var snapshot = new Snapshot();
+        snapshot.Add(sourceGenerated.Schema, "Schema", MarkdownLanguages.GraphQL);
+        snapshot.Add(sourceGenerated.Result, "Result", MarkdownLanguages.Json);
+        await snapshot.MatchMarkdownAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static Assembly CompileConnectionAssembly()
+    {
+        const string source = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using GreenDonut.Data;
+            using HotChocolate;
+            using HotChocolate.Types;
+            using HotChocolate.Types.Pagination;
+
+            [assembly: Module("Demo")]
+
+            namespace Repro;
+
+            public sealed class Book
+            {
+                public int Id { get; set; }
+
+                public string Title { get; set; } = default!;
+            }
+
+            [QueryType]
+            public static partial class BookQueries
+            {
+                [UseConnection]
+                public static Task<Connection<Book>> GetBooksAsync(
+                    PagingArguments paging,
+                    CancellationToken cancellationToken)
+                {
+                    var edges = new IEdge<Book>[]
+                    {
+                        new Edge<Book>(new Book { Id = 1, Title = "A" }, "cursor1")
+                    };
+                    var info = new ConnectionPageInfo(
+                        hasNextPage: false,
+                        hasPreviousPage: false,
+                        startCursor: "cursor1",
+                        endCursor: "cursor1");
+
+                    return Task.FromResult(new Connection<Book>(edges, info, 1));
+                }
+            }
+            """;
+
+        return SourceGeneratorTestHelpers.CompileReproAssembly(source, "SourceGeneratorUseConnection");
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/PagingTests.GenerateSource_ConnectionT_MatchesSnapshot.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/PagingTests.GenerateSource_ConnectionT_MatchesSnapshot.md
@@ -39,6 +39,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Authors", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -46,13 +47,36 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Author",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Author), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Author")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Author>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
+
+                    configuration.Member = context.ThisType.GetMethod(
+                        "GetAuthorsAsync",
+                        global::HotChocolate.Utilities.ReflectionUtils.StaticMemberFlags,
+                        new global::System.Type[]
+                        {
+                            typeof(global::GreenDonut.Data.PagingArguments),
+                            typeof(global::System.Threading.CancellationToken)
+                        })!;
+
+                    var fieldDescriptor = global::HotChocolate.Types.Descriptors.ObjectFieldDescriptor.From(field.Context, configuration);
+                    HotChocolate.Internal.ConfigurationHelper.ApplyConfiguration(
+                        field.Context,
+                        fieldDescriptor,
+                        configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute());
+                    configuration.ConfigurationsAreApplied = true;
+                    fieldDescriptor.CreateConfiguration();
 
                     configuration.Resolvers = context.Resolvers.GetAuthorsAsync();
                     configuration.ResultPostProcessor = global::HotChocolate.Execution.ListPostProcessor<global::TestNamespace.Author>.Default;

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextConnectionAnalyzerTests.CorrectGenericTypeMatch_WithConnection_NoError.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextConnectionAnalyzerTests.CorrectGenericTypeMatch_WithConnection_NoError.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -95,6 +101,26 @@ namespace TestNamespace
 
                         configuration.Arguments.Add(argumentConfiguration);
                     }
+
+                    configuration.Member = context.ThisType.GetMethod(
+                        "GetProductsAsync",
+                        global::HotChocolate.Utilities.ReflectionUtils.StaticMemberFlags,
+                        new global::System.Type[]
+                        {
+                            typeof(global::GreenDonut.Data.PagingArguments),
+                            typeof(global::GreenDonut.Data.QueryContext<global::TestNamespace.Product>),
+                            typeof(global::TestNamespace.ProductService),
+                            typeof(global::System.Threading.CancellationToken)
+                        })!;
+
+                    var fieldDescriptor = global::HotChocolate.Types.Descriptors.ObjectFieldDescriptor.From(field.Context, configuration);
+                    HotChocolate.Internal.ConfigurationHelper.ApplyConfiguration(
+                        field.Context,
+                        fieldDescriptor,
+                        configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute());
+                    configuration.ConfigurationsAreApplied = true;
+                    fieldDescriptor.CreateConfiguration();
 
                     configuration.Resolvers = context.Resolvers.GetProductsAsync();
                     configuration.ResultPostProcessor = global::HotChocolate.Execution.ListPostProcessor<global::TestNamespace.Product>.Default;

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextConnectionAnalyzerTests.TypeMismatch_WithConnection_RaisesError.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextConnectionAnalyzerTests.TypeMismatch_WithConnection_RaisesError.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -95,6 +101,26 @@ namespace TestNamespace
 
                         configuration.Arguments.Add(argumentConfiguration);
                     }
+
+                    configuration.Member = context.ThisType.GetMethod(
+                        "GetProductsAsync",
+                        global::HotChocolate.Utilities.ReflectionUtils.StaticMemberFlags,
+                        new global::System.Type[]
+                        {
+                            typeof(global::GreenDonut.Data.PagingArguments),
+                            typeof(global::GreenDonut.Data.QueryContext<global::TestNamespace.Brand>),
+                            typeof(global::TestNamespace.ProductService),
+                            typeof(global::System.Threading.CancellationToken)
+                        })!;
+
+                    var fieldDescriptor = global::HotChocolate.Types.Descriptors.ObjectFieldDescriptor.From(field.Context, configuration);
+                    HotChocolate.Internal.ConfigurationHelper.ApplyConfiguration(
+                        field.Context,
+                        fieldDescriptor,
+                        configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute());
+                    configuration.ConfigurationsAreApplied = true;
+                    fieldDescriptor.CreateConfiguration();
 
                     configuration.Resolvers = context.Resolvers.GetProductsAsync();
                     configuration.ResultPostProcessor = global::HotChocolate.Execution.ListPostProcessor<global::TestNamespace.Product>.Default;

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_MultipleAttributes_OnlyUseProjectionFlagged.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_MultipleAttributes_OnlyUseProjectionFlagged.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -112,6 +118,7 @@ namespace TestNamespace
                         field.Context,
                         fieldDescriptor,
                         configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute(),
                         new global::HotChocolate.Types.UsePagingAttribute(null, 14),
                         new global::HotChocolate.Data.UseProjectionAttribute(15),
                         new global::HotChocolate.Data.UseFilteringAttribute(null, 16),

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithUseProjection_RaisesError.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithUseProjection_RaisesError.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -112,6 +118,7 @@ namespace TestNamespace
                         field.Context,
                         fieldDescriptor,
                         configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute(),
                         new global::HotChocolate.Types.UsePagingAttribute(null, 14),
                         new global::HotChocolate.Data.UseProjectionAttribute(15),
                         new global::HotChocolate.Data.UseFilteringAttribute(null, 16),

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithUseProjections_RaisesError.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithUseProjections_RaisesError.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -112,6 +118,7 @@ namespace TestNamespace
                         field.Context,
                         fieldDescriptor,
                         configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute(),
                         new global::HotChocolate.Types.UsePagingAttribute(null, 14),
                         new global::HotChocolate.Data.UseFilteringAttribute(null, 16),
                         new global::HotChocolate.Data.UseSortingAttribute(null, 17));

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithoutUseProjection_NoError.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/QueryContextProjectionAnalyzerTests.QueryContext_WithoutUseProjection_NoError.md
@@ -63,6 +63,7 @@ namespace TestNamespace
 
             descriptor
                 .Field(naming.GetMemberName("Products", global::HotChocolate.Types.MemberKind.ObjectField))
+                .AddPagingArguments()
                 .ExtendWith(static (field, context) =>
                 {
                     var configuration = field.Configuration;
@@ -70,13 +71,18 @@ namespace TestNamespace
                     var bindingResolver = field.Context.ParameterBindingResolver;
                     var naming = field.Context.Naming;
 
-                    configuration.Type = global::HotChocolate.Types.Descriptors.TypeReference.Create(
+                    configuration.Type = global::HotChocolate.Types.Pagination.ConnectionTypeHelper.CreateConnectionTypeReference(
+                        field.Context,
+                        "Product",
                         typeInspector.GetTypeRef(typeof(global::TestNamespace.Product), HotChocolate.Types.TypeContext.Output),
-                        new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.ListTypeNode(new global::HotChocolate.Language.NonNullTypeNode(new global::HotChocolate.Language.NamedTypeNode("global__TestNamespace_Product")))));
+                        nonNull: true);
                     configuration.ResultType = typeof(global::HotChocolate.Types.Pagination.Connection<global::TestNamespace.Product>);
                     configuration.DeclaringType = context.ThisType;
 
                     configuration.SetSourceGeneratorFlags();
+                    configuration.SetConnectionFlags();
+                    var pagingOptions = global::HotChocolate.Types.Pagination.PagingHelper.GetPagingOptions(field.Context, null);
+                    configuration.Features.Set(pagingOptions);
 
                     var bindingInfo = field.Context.ParameterBindingResolver;
                     var parameter = context.Resolvers.CreateParameterDescriptor_GetProductsAsync_productService();
@@ -112,6 +118,7 @@ namespace TestNamespace
                         field.Context,
                         fieldDescriptor,
                         configuration.Member,
+                        new global::HotChocolate.Types.UseConnectionAttribute(),
                         new global::HotChocolate.Types.UsePagingAttribute(null, 14),
                         new global::HotChocolate.Data.UseFilteringAttribute(null, 15),
                         new global::HotChocolate.Data.UseSortingAttribute(null, 16));

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/SourceGeneratorUseConnectionTests.UseConnection_Should_ExposeConnectionType_When_ResolverReturnsGenericConnection.md
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/SourceGeneratorUseConnectionTests.UseConnection_Should_ExposeConnectionType_When_ResolverReturnsGenericConnection.md
@@ -1,0 +1,90 @@
+# UseConnection_Should_ExposeConnectionType_When_ResolverReturnsGenericConnection
+
+## Schema
+
+```graphql
+schema {
+  query: Query
+}
+
+type Query {
+  books(
+    "Returns the first _n_ elements from the list."
+    first: Int
+    "Returns the elements in the list that come after the specified cursor."
+    after: String
+    "Returns the last _n_ elements from the list."
+    last: Int
+    "Returns the elements in the list that come before the specified cursor."
+    before: String
+  ): BookConnection!
+}
+
+type Book {
+  id: Int!
+  title: String
+}
+
+"A connection to a list of items."
+type BookConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [BookEdge!]
+  "A flattened list of the nodes."
+  nodes: [Book]
+  "Identifies the total count of items in the connection."
+  totalCount: Int!
+}
+
+"An edge in a connection."
+type BookEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Book
+}
+
+"Information about pagination in a connection."
+type PageInfo {
+  "Indicates whether more edges exist following the set defined by the clients arguments."
+  hasNextPage: Boolean!
+  "Indicates whether more edges exist prior the set defined by the clients arguments."
+  hasPreviousPage: Boolean!
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+```
+
+## Result
+
+```json
+{
+  "data": {
+    "books": {
+      "edges": [
+        {
+          "cursor": "cursor1",
+          "node": {
+            "id": 1
+          }
+        }
+      ],
+      "nodes": [
+        {
+          "id": 1
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "cursor1",
+        "endCursor": "cursor1"
+      },
+      "totalCount": 1
+    }
+  }
+}
+```


### PR DESCRIPTION
`[UseConnection]` on a source generated resolver only worked for `PageConnection<T>`. Returning `Task<Connection<T>>` (the type the common DataLoader pattern `ToConnectionAsync()` produces) was broken two different ways:

1. The generator did not recognize `Connection<T>` as a connection, because `IsConnectionType` only matched types deriving from `ConnectionBase<,,>`. The field ended up typed as a plain list with no paging arguments.

2. Once recognized, the generator built the connection type by reflecting over `Connection<T>`'s public members. That produced code that does not compile (a bogus resolver for `Accept(IPageObserver)`) and the wrong schema shape: no `nodes` field, `info` instead of `pageInfo`, and an edge type missing `cursor` (interface base members aren't reachable through `BaseType`).

#### Fix

Mirror the split the runtime already uses for `[UsePaging]`: a shared generic connection type for plain `Connection<T>`, reflection based named types only for custom classes.

- `IsConnectionType` now matches `IConnection<T>` implementors, a superset of the old `ConnectionBase<,,>` check.
- When a resolver returns exactly `Connection<T>` or `IConnection<T>`, `ConnectionTypeTransformer` skips type synthesis and the generated code binds the field to the existing shared runtime `ConnectionType` through a new helper, `ConnectionTypeHelper.CreateConnectionTypeReference`. This gives correct `edges { cursor node }, nodes, pageInfo`, and `totalCount` with no reflection over the connection class.
- `PageConnection<T>` and custom connection classes keep the existing reflection path.
- Reflection based synthesis now skips void returning methods, so custom subclasses of `Connection<T>` can't hit the `Accept` compile error either.