### PR TITLE
Move non-repeatable directive uniqueness to schema validation

### DIFF
--- a/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryCodes.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryCodes.cs
@@ -35,4 +35,5 @@ internal static class LogEntryCodes
     public const string IncompatibleArgumentDefaultValue = "HCV0028";
     public const string IncompatibleInputFieldDefaultValue = "HCV0029";
     public const string InvalidObjectDeprecation = "HCV0030";
+    public const string DirectiveNotUnique = "HCV0031";
 }

--- a/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryHelper.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryHelper.cs
@@ -67,6 +67,19 @@ internal static class LogEntryHelper
             .Build();
     }
 
+    public static LogEntry DirectiveNotUnique(IDirective directive, ITypeSystemMember member)
+    {
+        return LogEntryBuilder.New()
+            .SetMessage(
+                LogEntryHelper_DirectiveNotUnique,
+                directive.Name,
+                GetDirectiveMemberName(member))
+            .SetCode(LogEntryCodes.DirectiveNotUnique)
+            .SetSeverity(LogSeverity.Error)
+            .SetTypeSystemMember(member)
+            .Build();
+    }
+
     public static LogEntry DuplicateFieldInDefaultValue(
         IInputValueDefinition root,
         IReadOnlyList<object> path,
@@ -502,7 +515,7 @@ internal static class LogEntryHelper
             .SetMessage(
                 LogEntryHelper_UndefinedDirective,
                 directive.Name,
-                member is ISchemaCoordinateProvider m ? m.Coordinate.ToString() : "?")
+                GetDirectiveMemberName(member))
             .SetCode(LogEntryCodes.UndefinedDirective)
             .SetSeverity(LogSeverity.Error)
             .SetTypeSystemMember(member)
@@ -617,6 +630,16 @@ internal static class LogEntryHelper
         }
 
         return builder.ToString();
+    }
+
+    private static string GetDirectiveMemberName(ITypeSystemMember member)
+    {
+        return member switch
+        {
+            ISchemaCoordinateProvider coordinateProvider => coordinateProvider.Coordinate.ToString(),
+            ISchemaDefinition => "schema",
+            _ => "?"
+        };
     }
 
     private static TypeKind GetTypeSystemMemberKind(ITypeSystemMember member)

--- a/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.Designer.cs
@@ -186,6 +186,15 @@ namespace HotChocolate.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The non-repeatable directive &apos;@{0}&apos; on &apos;{1}&apos; is applied more than once..
+        /// </summary>
+        internal static string LogEntryHelper_DirectiveNotUnique {
+            get {
+                return ResourceManager.GetString("LogEntryHelper_DirectiveNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Enum type &apos;{0}&apos; must define one or more values..
         /// </summary>
         internal static string LogEntryHelper_EmptyEnumType {

--- a/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.resx
+++ b/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.resx
@@ -60,6 +60,9 @@
   <data name="LogEntryHelper_DirectiveDefinitionSelfApplication" xml:space="preserve">
     <value>The directive definition '@{0}' must not reference itself.</value>
   </data>
+  <data name="LogEntryHelper_DirectiveNotUnique" xml:space="preserve">
+    <value>The non-repeatable directive '@{0}' on '{1}' is applied more than once.</value>
+  </data>
   <data name="LogEntryHelper_EmptyEnumType" xml:space="preserve">
     <value>The Enum type '{0}' must define one or more values.</value>
   </data>

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsUniqueRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsUniqueRule.cs
@@ -1,0 +1,46 @@
+using HotChocolate.Events;
+using HotChocolate.Events.Contracts;
+using HotChocolate.Types;
+using static HotChocolate.Logging.LogEntryHelper;
+
+namespace HotChocolate.Rules;
+
+/// <summary>
+/// Checks that a directive that is not repeatable is applied at most once per location.
+/// </summary>
+public sealed class DirectiveIsUniqueRule : IValidationEventHandler<DirectiveEvent>
+{
+    /// <summary>
+    /// Checks that a directive that is not repeatable is applied at most once per location.
+    /// </summary>
+    public void Handle(DirectiveEvent @event, ValidationContext context)
+    {
+        var (directive, member) = @event;
+
+        if (directive.Definition.IsRepeatable || member is not IDirectivesProvider provider)
+        {
+            return;
+        }
+
+        var precedingApplications = 0;
+
+        foreach (var other in provider.Directives)
+        {
+            if (ReferenceEquals(other, directive))
+            {
+                break;
+            }
+
+            if (other.Name.Equals(directive.Name, StringComparison.Ordinal))
+            {
+                precedingApplications++;
+            }
+        }
+
+        // Reported at the second application, so a location reports one entry per directive name.
+        if (precedingApplications == 1)
+        {
+            context.Log.Write(DirectiveNotUnique(directive, member));
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -47,6 +47,7 @@ public sealed class SchemaValidator
         _rules.Add(new DirectiveDefinitionIncludesLocationRule());
         _rules.Add(new DirectiveDefinitionNoSelfReferenceRule());
         _rules.Add(new DirectiveIsDefinedRule());
+        _rules.Add(new DirectiveIsUniqueRule());
         _rules.Add(new EnumValueIsDefinedRule());
         _rules.Add(new NoInputObjectCycleRule());
         _rules.Add(new NoInputObjectDefaultValueCycleRule());
@@ -89,6 +90,8 @@ public sealed class SchemaValidator
         var schema = context.Schema;
 
         PublishEvent(new InputObjectTypesEvent(schema.Types.OfType<IInputObjectTypeDefinition>()), context);
+
+        PublishDirectiveEvents(schema, context);
 
         foreach (var type in schema.Types)
         {

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsUniqueRuleTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsUniqueRuleTests.cs
@@ -1,0 +1,236 @@
+using HotChocolate.Rules;
+
+namespace HotChocolate.Types.Validation.Rules;
+
+public sealed class DirectiveIsUniqueRuleTests : RuleTestBase<DirectiveIsUniqueRule>
+{
+    [Fact]
+    public void Validate_NonRepeatableDirectiveAppliedOnce_Succeeds()
+    {
+        AssertValid(
+            """
+            type Object @example {
+                field(argument: Int @example): Int @example
+            }
+
+            directive @example on ARGUMENT_DEFINITION | FIELD_DEFINITION | OBJECT
+            """);
+    }
+
+    [Fact]
+    public void Validate_RepeatableDirectiveAppliedTwice_Succeeds()
+    {
+        AssertValid(
+            """
+            type Object @example @example {
+                field: Int
+            }
+
+            directive @example repeatable on OBJECT
+            """);
+    }
+
+    [Fact]
+    public void Validate_NonRepeatableDirectiveAppliedTwice_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object @example @example {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Object' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Object",
+                "member": "Object",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_NonRepeatableDirectiveAppliedThreeTimes_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object @example @example @example {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Object' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Object",
+                "member": "Object",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_NonRepeatableDirectiveAppliedByTypeExtension_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object @example {
+                field: Int
+            }
+
+            extend type Object @example
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Object' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Object",
+                "member": "Object",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_NonRepeatableSpecDirectiveAppliedTwice_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object {
+                field: Int @deprecated(reason: "first") @deprecated(reason: "second")
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@deprecated' on 'Object.field' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Object.field",
+                "member": "field",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_NonRepeatableDirectiveAppliedTwiceOnEachTraversedLocation_Fails()
+    {
+        AssertInvalid(
+            """
+            schema @example @example {
+                query: Query
+            }
+
+            type Query @example @example {
+                field(argument: Int @example @example): Int @example @example
+            }
+
+            input Input {
+                field: Int @example @example
+            }
+
+            enum Enum {
+                VALUE @example @example
+            }
+
+            directive @other(argument: Int @example @example) @example @example on OBJECT
+
+            directive @example on ARGUMENT_DEFINITION
+                | DIRECTIVE_DEFINITION
+                | ENUM_VALUE
+                | FIELD_DEFINITION
+                | INPUT_FIELD_DEFINITION
+                | OBJECT
+                | SCHEMA
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'schema' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "member": "default",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Query' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Query",
+                "member": "Query",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Query.field(argument:)' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Query.field(argument:)",
+                "member": "argument",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Query.field' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Query.field",
+                "member": "field",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Input.field' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Input.field",
+                "member": "field",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on 'Enum.VALUE' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "Enum.VALUE",
+                "member": "VALUE",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on '@other' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "@other",
+                "member": "@other",
+                "extensions": {}
+            }
+            """,
+            """
+            {
+                "message": "The non-repeatable directive '@example' on '@other(argument:)' is applied more than once.",
+                "code": "HCV0031",
+                "severity": "Error",
+                "coordinate": "@other(argument:)",
+                "member": "argument",
+                "extensions": {}
+            }
+            """);
+    }
+}

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/Definitions/LinkMutableDirectiveDefinition.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/Definitions/LinkMutableDirectiveDefinition.cs
@@ -1,0 +1,45 @@
+using HotChocolate.Fusion.ApolloFederation;
+using HotChocolate.Types;
+using HotChocolate.Types.Mutable;
+
+namespace HotChocolate.Fusion.Definitions;
+
+/// <summary>
+/// The <c>@link</c> directive from Apollo Federation declares the federation vocabulary a source
+/// schema imports. It is recognized on source schemas and removed during composition.
+/// </summary>
+internal sealed class LinkMutableDirectiveDefinition : MutableDirectiveDefinition
+{
+    public LinkMutableDirectiveDefinition(MutableScalarTypeDefinition stringType)
+        : base(FederationDirectiveNames.Link)
+    {
+        Arguments.Add(
+            new MutableInputFieldDefinition(
+                WellKnownArgumentNames.Url,
+                new NonNullType(stringType)));
+        Arguments.Add(new MutableInputFieldDefinition(ArgumentNames.As, stringType));
+        Arguments.Add(new MutableInputFieldDefinition(ArgumentNames.For, stringType));
+        Arguments.Add(new MutableInputFieldDefinition(ArgumentNames.Import, new ListType(stringType)));
+        IsRepeatable = true;
+        Locations = DirectiveLocation.Schema;
+    }
+
+    public static LinkMutableDirectiveDefinition Create(ISchemaDefinition schema)
+    {
+        if (!schema.Types.TryGetType<MutableScalarTypeDefinition>(
+            SpecScalarNames.String.Name,
+            out var stringType))
+        {
+            stringType = BuiltIns.String.Create();
+        }
+
+        return new LinkMutableDirectiveDefinition(stringType);
+    }
+
+    private static class ArgumentNames
+    {
+        public const string As = "as";
+        public const string For = "for";
+        public const string Import = "import";
+    }
+}

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/SourceSchemaParser.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/SourceSchemaParser.cs
@@ -43,13 +43,19 @@ internal sealed class SourceSchemaParser(
         // of a missing one; preprocessing then rewrites it to @require and removes the
         // definition. A non-federation schema does not get the definition, so an applied
         // @requires is reported as an unknown directive, steering authors to @require.
-        if (!isApolloFederationV1
-            && IsFederationSourceText(sourceSchemaText)
-            && schema.Types.TryGetType<MutableScalarTypeDefinition>(
-                WellKnownTypeNames.FieldSelectionSet, out var fieldSelectionSetType))
+        if (!isApolloFederationV1 && IsFederationSourceText(sourceSchemaText))
         {
-            schema.DirectiveDefinitions.Add(
-                new RequiresMutableDirectiveDefinition(fieldSelectionSetType));
+            if (schema.Types.TryGetType<MutableScalarTypeDefinition>(
+                WellKnownTypeNames.FieldSelectionSet, out var fieldSelectionSetType))
+            {
+                schema.DirectiveDefinitions.Add(
+                    new RequiresMutableDirectiveDefinition(fieldSelectionSetType));
+            }
+
+            // @link carries the federation vocabulary a subgraph imports and is applied to the
+            // schema itself. RemoveFederationInfrastructure drops the definition and every
+            // application during preprocessing.
+            schema.DirectiveDefinitions.Add(LinkMutableDirectiveDefinition.Create(schema));
         }
 
         // Parse source schema.

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Properties/MutableResources.Designer.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Properties/MutableResources.Designer.cs
@@ -193,14 +193,5 @@ namespace HotChocolate.Types.Mutable.Properties {
                 return ResourceManager.GetString("SchemaParser_InvalidUnionMemberType", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The non-repeatable directive &apos;@{0}&apos; was already applied to &apos;{1}&apos; and cannot be applied again by an extension..
-        /// </summary>
-        internal static string SchemaParser_NonRepeatableDirectiveAlreadyApplied {
-            get {
-                return ResourceManager.GetString("SchemaParser_NonRepeatableDirectiveAlreadyApplied", resourceCulture);
-            }
-        }
     }
 }

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Properties/MutableResources.resx
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Properties/MutableResources.resx
@@ -63,7 +63,4 @@
   <data name="SchemaParser_InvalidUnionMemberType" xml:space="preserve">
     <value>The Union type '{0}' cannot include the type '{1}'. Unions can only contain Object types.</value>
   </data>
-  <data name="SchemaParser_NonRepeatableDirectiveAlreadyApplied" xml:space="preserve">
-    <value>The non-repeatable directive '@{0}' was already applied to '{1}' and cannot be applied again by an extension.</value>
-  </data>
 </root>

--- a/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
+++ b/src/HotChocolate/Mutable/src/Types.Mutable/Serialization/SchemaParser.cs
@@ -592,11 +592,7 @@ public static class SchemaParser
                     type.Name));
         }
 
-        MergeDirectives(
-            schema,
-            existingField.Directives,
-            fieldNode.Directives,
-            $"{type.Name}.{existingField.Name}");
+        BuildDirectiveCollection(schema, existingField.Directives, fieldNode.Directives);
 
         if (IsDeprecated(existingField.Directives, out var reason))
         {
@@ -678,11 +674,7 @@ public static class SchemaParser
                     $"{field.DeclaringMember?.Name}.{field.Name}"));
         }
 
-        MergeDirectives(
-            schema,
-            existingArg.Directives,
-            argumentNode.Directives,
-            $"{field.DeclaringMember?.Name}.{field.Name}({existingArg.Name}:)");
+        BuildDirectiveCollection(schema, existingArg.Directives, argumentNode.Directives);
 
         if (IsDeprecated(existingArg.Directives, out var reason))
         {
@@ -997,7 +989,7 @@ public static class SchemaParser
         MutableDirectiveDefinition type,
         DirectiveExtensionNode node)
     {
-        MergeDirectives(schema, type.Directives, node.Directives, $"@{type.Name}");
+        BuildDirectiveCollection(schema, type.Directives, node.Directives);
 
         if (IsDeprecated(type.Directives, out var reason))
         {
@@ -1057,32 +1049,6 @@ public static class SchemaParser
                 directiveType,
                 directiveNode.Arguments.Select(t => new ArgumentAssignment(t.Name.Value, t.Value)).ToList());
             directives.Add(directive);
-        }
-    }
-
-    private static void MergeDirectives(
-        MutableSchemaDefinition schema,
-        DirectiveCollection target,
-        IReadOnlyList<DirectiveNode> nodes,
-        string targetName)
-    {
-        foreach (var directiveNode in nodes)
-        {
-            var directiveType = ResolveDirectiveDefinition(schema, directiveNode);
-
-            if (!directiveType.IsRepeatable && target.ContainsName(directiveType.Name))
-            {
-                throw new SchemaInitializationException(
-                    string.Format(
-                        SchemaParser_NonRepeatableDirectiveAlreadyApplied,
-                        directiveType.Name,
-                        targetName));
-            }
-
-            var directive = new Directive(
-                directiveType,
-                directiveNode.Arguments.Select(t => new ArgumentAssignment(t.Name.Value, t.Value)).ToList());
-            target.Add(directive);
         }
     }
 

--- a/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
+++ b/src/HotChocolate/Mutable/test/Types.Mutable.Tests/SchemaParserTests.cs
@@ -685,9 +685,10 @@ public class SchemaParserTests
     }
 
     [Fact]
-    public void Parse_Should_Throw_When_ExtensionAppliesNonRepeatableDirectiveAlreadyApplied()
+    public void Parse_Should_AppendBothDirectives_When_ExtensionAppliesNonRepeatableDirectiveAlreadyApplied()
     {
         // arrange
+        // the schema is invalid; the parser represents it and DirectiveIsUniqueRule reports it
         const string sdl =
             """
             type Query {
@@ -700,13 +701,40 @@ public class SchemaParserTests
             """;
 
         // act
-        static void Action() => SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
 
         // assert
-        Assert.Equal(
-            "The non-repeatable directive '@deprecated' was already applied to 'Query.id' "
-            + "and cannot be applied again by an extension.",
-            Assert.Throws<SchemaInitializationException>(Action).Message);
+        var queryType = Assert.IsType<MutableObjectTypeDefinition>(schema.Types["Query"]);
+        var field = Assert.Single(queryType.Fields.AsEnumerable());
+        Assert.Equal(2, field.Directives["deprecated"].Count());
+        Assert.Equal("first", field.DeprecationReason);
+    }
+
+    [Fact]
+    public void Parse_Should_AppendBothDirectives_When_ExtensionArgumentAppliesNonRepeatableDirectiveAlreadyApplied()
+    {
+        // arrange
+        // the schema is invalid; the parser represents it and DirectiveIsUniqueRule reports it
+        const string sdl =
+            """
+            type Query {
+                user(id: String @deprecated(reason: "first")): String
+            }
+
+            extend type Query {
+                user(id: String @deprecated(reason: "second")): String
+            }
+            """;
+
+        // act
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+
+        // assert
+        var queryType = Assert.IsType<MutableObjectTypeDefinition>(schema.Types["Query"]);
+        var field = Assert.Single(queryType.Fields.AsEnumerable());
+        var argument = Assert.Single(field.Arguments.AsEnumerable());
+        Assert.Equal(2, argument.Directives["deprecated"].Count());
+        Assert.Equal("first", argument.DeprecationReason);
     }
 
     [Fact]
@@ -904,9 +932,10 @@ public class SchemaParserTests
     }
 
     [Fact]
-    public void Parse_Should_Throw_When_DirectiveExtensionAppliesNonRepeatableDirectiveAlreadyApplied()
+    public void Parse_Should_AppendBothDirectives_When_DirectiveExtensionAppliesNonRepeatableDirectiveAlreadyApplied()
     {
         // arrange
+        // the schema is invalid; the parser represents it and DirectiveIsUniqueRule reports it
         const string sdl =
             """
             directive @meta(value: String) on DIRECTIVE_DEFINITION
@@ -917,13 +946,11 @@ public class SchemaParserTests
             """;
 
         // act
-        static void Action() => SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
+        var schema = SchemaParser.Parse(Encoding.UTF8.GetBytes(sdl));
 
         // assert
-        Assert.Equal(
-            "The non-repeatable directive '@meta' was already applied to '@foo' "
-            + "and cannot be applied again by an extension.",
-            Assert.Throws<SchemaInitializationException>(Action).Message);
+        var directiveDefinition = schema.DirectiveDefinitions["foo"];
+        Assert.Equal(2, directiveDefinition.Directives["meta"].Count());
     }
 
     [Fact]

--- a/website/content/docs/fusion/source-schema-extensions.md
+++ b/website/content/docs/fusion/source-schema-extensions.md
@@ -180,7 +180,7 @@ The base schema is stored exactly as supplied. Fusion does not fold the extensio
 | Extension declares a field that already exists on the base type | Directives merge onto the existing field. Return type and any provided arguments must match the base. |
 | Same field appears twice in one `extend` block                  | Parsing fails with a duplicate field error.                                                           |
 | Extension applies a directive the schema does not define        | Implicit at parse time. Fusion's built-ins compose as-is; other custom directives must be declared.   |
-| Extension re-applies a non-repeatable directive to the target   | Parsing fails when the extension's directives are merged onto the target.                             |
+| Extension re-applies a non-repeatable directive to the target   | The parser keeps both applications. Composition then fails validation.                                |
 
 # Troubleshooting
 


### PR DESCRIPTION
## Summary

- `Types.Validation` gains `DirectiveIsUniqueRule` (`HCV0031`), which reports a non-repeatable directive applied more than once at the same location, one entry per directive name however many times it repeats.
- The Mutable `SchemaParser` no longer throws when an extension re-applies a non-repeatable directive. `MergeDirectives` is removed and all three extension paths append like every other path, so the invalid state is representable and reported by validation instead of aborting the parse.
- `SchemaValidator` publishes directive events for the schema definition, so `SCHEMA`-location applications reach the directive rules. Apollo Federation source schemas apply `@link` to the schema without declaring it, so a `@link` definition is registered for them; `RemoveFederationInfrastructure` already strips both the definition and its applications during preprocessing.

## Test plan

- `DirectiveIsUniqueRuleTests` covers every location the validator traverses in one case — schema, type, output field, argument, input field, enum value, directive definition, and directive-definition argument — plus a repeatable directive, three applications collapsing to one entry, the type-extension path, and a spec directive.
- The three `SchemaParserTests` extension cases assert both applications are kept instead of asserting a throw. The argument path had no coverage before.
- Full suites run for `Types.Validation` (141), `Types.Mutable` (88), and `Fusion.Composition` (740), plus `Types.Abstractions`, `Adapters.OpenApi`, `Fusion.Utilities`, and `Fusion.Execution` as the remaining consumers of `Types.Validation` and the Mutable parser.
