### PR TITLE
Add registration tests for the validator and composer rule lists

### DIFF
--- a/src/HotChocolate/Core/src/Types.Validation/HotChocolate.Types.Validation.csproj
+++ b/src/HotChocolate/Core/src/Types.Validation/HotChocolate.Types.Validation.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="HotChocolate.Fusion.Composition" />
+    <InternalsVisibleTo Include="HotChocolate.Types.Validation.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -38,6 +38,11 @@ public sealed class SchemaValidator
     }
 
     /// <summary>
+    /// Gets the rules that this validator will run, in the order they were added.
+    /// </summary>
+    internal IReadOnlyList<object> Rules => _rules;
+
+    /// <summary>
     /// Adds the default validation rules to the schema validator.
     /// </summary>
     public void AddDefaultRules()

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
@@ -13,7 +13,8 @@ public sealed class SchemaValidatorTests
     public void AddDefaultRules_Should_RegisterTheDefaultRuleSet()
     {
         // arrange
-        var validator = new SchemaValidator();
+        var validator = new SchemaValidator([]);
+        validator.AddDefaultRules();
 
         // act
         var rules = validator.Rules.Select(r => r.GetType().Name);

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
@@ -10,6 +10,42 @@ public sealed class SchemaValidatorTests
     private readonly ValidationLog _log = new();
 
     [Fact]
+    public void AddDefaultRules_Should_RegisterTheDefaultRuleSet()
+    {
+        // arrange
+        var validator = new SchemaValidator();
+
+        // act
+        var rules = validator.Rules.Select(r => r.GetType().Name);
+
+        // assert
+        Assert.Equal(
+            [
+                "DirectiveDefinitionIncludesLocationRule",
+                "DirectiveDefinitionNoSelfReferenceRule",
+                "DirectiveIsDefinedRule",
+                "DirectiveIsUniqueRule",
+                "EnumValueIsDefinedRule",
+                "NoInputObjectCycleRule",
+                "NoInputObjectDefaultValueCycleRule",
+                "NonEmptyEnumTypeRule",
+                "NonEmptyInputObjectTypeRule",
+                "NonEmptyInterfaceTypeRule",
+                "NonEmptyObjectTypeRule",
+                "NonEmptyUnionTypeRule",
+                "NoSelfImplementationRule",
+                "TypeIsDefinedRule",
+                "ValidDefaultValueRule",
+                "ValidDeprecationRule",
+                "ValidImplementationsRule",
+                "ValidNameRule",
+                "ValidObjectDeprecationRule",
+                "ValidOneOfFieldRule"
+            ],
+            rules);
+    }
+
+    [Fact]
     public void Validate_WithDefaultRules()
     {
         // arrange

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/SchemaComposer.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/SchemaComposer.cs
@@ -150,7 +150,7 @@ internal sealed class SchemaComposer
 
         // Validate Source Schemas
         var validationResult =
-            new SourceSchemaValidator(schemas, s_sourceSchemaRules, _log).Validate();
+            new SourceSchemaValidator(schemas, SourceSchemaRules, _log).Validate();
 
         if (validationResult.IsFailure)
         {
@@ -159,7 +159,7 @@ internal sealed class SchemaComposer
 
         // Pre Merge Validation
         var preMergeValidationResult =
-            new PreMergeValidator(schemas, s_preMergeRules, _log).Validate();
+            new PreMergeValidator(schemas, PreMergeRules, _log).Validate();
 
         if (preMergeValidationResult.IsFailure)
         {
@@ -182,7 +182,7 @@ internal sealed class SchemaComposer
 
         // Post Merge Validation
         var postMergeValidationResult =
-            new PostMergeValidator(mergedSchema, s_postMergeRules, schemas, _log).Validate();
+            new PostMergeValidator(mergedSchema, PostMergeRules, schemas, _log).Validate();
 
         if (postMergeValidationResult.IsFailure)
         {
@@ -231,7 +231,10 @@ internal sealed class SchemaComposer
         return new CompositionError(message);
     }
 
-    private static readonly ImmutableArray<object> s_sourceSchemaRules =
+    /// <summary>
+    /// Gets the rules that run against each source schema, in the order they are applied.
+    /// </summary>
+    internal static ImmutableArray<object> SourceSchemaRules { get; } =
     [
         new DisallowedInaccessibleElementsRule(),
         new ExternalOnInterfaceRule(),
@@ -272,7 +275,11 @@ internal sealed class SchemaComposer
         new EventStreamTopicsEmptyRule()
     ];
 
-    private static readonly ImmutableArray<object> s_preMergeRules =
+    /// <summary>
+    /// Gets the rules that run across the source schemas before the merge, in the order they are
+    /// applied.
+    /// </summary>
+    internal static ImmutableArray<object> PreMergeRules { get; } =
     [
         new EnumValuesMismatchRule(),
         new ExternalArgumentDefaultMismatchRule(),
@@ -296,7 +303,10 @@ internal sealed class SchemaComposer
         new TypeKindMismatchRule()
     ];
 
-    private static readonly ImmutableArray<object> s_postMergeRules =
+    /// <summary>
+    /// Gets the rules that run against the merged schema, in the order they are applied.
+    /// </summary>
+    internal static ImmutableArray<object> PostMergeRules { get; } =
     [
         new EmptyMergedEnumTypeRule(),
         new EmptyMergedInputObjectTypeRule(),

--- a/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/SchemaComposerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Composition.Tests/SchemaComposerTests.cs
@@ -805,4 +805,120 @@ public sealed class SchemaComposerTests
             }
             """);
     }
+
+    [Fact]
+    public void SourceSchemaRules_Should_ContainTheRegisteredRuleSet()
+    {
+        // act
+        var rules = SchemaComposer.SourceSchemaRules.Select(r => r.GetType().Name);
+
+        // assert
+        Assert.Equal(
+            [
+                "DisallowedInaccessibleElementsRule",
+                "ExternalOnInterfaceRule",
+                "ExternalOverrideCollisionRule",
+                "ExternalProvidesCollisionRule",
+                "ExternalRequireCollisionRule",
+                "ExternalUnusedRule",
+                "EventCursorMarkerRule",
+                "InterfaceObjectKeyMissingRule",
+                "InvalidShareableUsageRule",
+                "IsInvalidFieldTypeRule",
+                "IsInvalidSyntaxRule",
+                "IsInvalidUsageRule",
+                "KeyDirectiveInFieldsArgumentRule",
+                "KeyFieldsSelectInvalidTypeRule",
+                "KeyInvalidArgumentsRule",
+                "KeyInvalidFieldsTypeRule",
+                "KeyInvalidSyntaxRule",
+                "LookupMustHaveArgumentsRule",
+                "LookupReturnsListRule",
+                "LookupReturnsNonNullableTypeRule",
+                "OverrideFromSelfRule",
+                "OverrideOnInterfaceRule",
+                "ProvidesDirectiveInFieldsArgumentRule",
+                "ProvidesFieldsHasArgumentsRule",
+                "ProvidesFieldsMissingExternalRule",
+                "ProvidesInvalidFieldsRule",
+                "ProvidesInvalidFieldsTypeRule",
+                "ProvidesInvalidSyntaxRule",
+                "ProvidesOnNonCompositeFieldRule",
+                "QueryRootTypeInaccessibleRule",
+                "RequireInvalidFieldTypeRule",
+                "RequireInvalidSyntaxRule",
+                "RootMutationUsedRule",
+                "RootQueryUsedRule",
+                "RootSubscriptionUsedRule",
+                "EventStreamMessageInvalidFieldsRule",
+                "EventStreamTopicsEmptyRule"
+            ],
+            rules);
+    }
+
+    [Fact]
+    public void PreMergeRules_Should_ContainTheRegisteredRuleSet()
+    {
+        // act
+        var rules = SchemaComposer.PreMergeRules.Select(r => r.GetType().Name);
+
+        // assert
+        Assert.Equal(
+            [
+                "EnumValuesMismatchRule",
+                "ExternalArgumentDefaultMismatchRule",
+                "ExternalArgumentMissingRule",
+                "ExternalArgumentTypeMismatchRule",
+                "ExternalMissingOnBaseRule",
+                "ExternalTypeMismatchRule",
+                "FieldArgumentTypesMergeableRule",
+                "FieldWithMissingRequiredArgumentRule",
+                "InputFieldDefaultMismatchRule",
+                "InputFieldTypesMergeableRule",
+                "InputWithMissingRequiredFieldsRule",
+                "InputWithMissingOneOfRule",
+                "InterfaceObjectKeyMismatchRule",
+                "InterfaceObjectNoInterfaceRule",
+                "InvalidFieldSharingRule",
+                "MultipleEventStreamSourcesRule",
+                "OptInFeatureStabilityMismatchRule",
+                "OutputFieldTypesMergeableRule",
+                "SpecifiedByUrlMismatchRule",
+                "TypeKindMismatchRule"
+            ],
+            rules);
+    }
+
+    [Fact]
+    public void PostMergeRules_Should_ContainTheRegisteredRuleSet()
+    {
+        // act
+        var rules = SchemaComposer.PostMergeRules.Select(r => r.GetType().Name);
+
+        // assert
+        Assert.Equal(
+            [
+                "EmptyMergedEnumTypeRule",
+                "EmptyMergedInputObjectTypeRule",
+                "EmptyMergedInterfaceTypeRule",
+                "EmptyMergedObjectTypeRule",
+                "EmptyMergedUnionTypeRule",
+                "EnumTypeDefaultValueInaccessibleRule",
+                "EventStreamMessageAbstractTypeRequiresTypeNameRule",
+                "ImplementedByInaccessibleRule",
+                "ImplementWithoutDefaultRule",
+                "InterfaceFieldNoImplementationRule",
+                "InterfaceObjectFieldRequiresImplementRule",
+                "InvalidProjectedFieldSharingRule",
+                "IsInvalidFieldsRule",
+                "KeyInvalidFieldsRule",
+                "NonNullInputFieldIsInaccessibleRule",
+                "NoQueriesRule",
+                "ReferenceToDeprecatedTypeRule",
+                "ReferenceToInaccessibleTypeRule",
+                "ReferenceToInternalTypeRule",
+                "RequireInvalidFieldsRule"
+            ],
+            rules);
+    }
 }


### PR DESCRIPTION
## Summary

- Rule tests inject the rule under test directly, so a rule's own tests stay green when it is dropped from the list that actually runs it. Across the four lists only five of the 97 rules were pinned at all, incidentally, by composer-level tests that assert a specific error code.
- Four tests now assert each registered set in order: `SchemaValidator.AddDefaultRules` (20 rules), and `SchemaComposer`'s source-schema (37), pre-merge (20), and post-merge (20) lists. Order is part of the assertion because handler dispatch follows registration order.
- To reach the lists, the three composer lists become `internal static` properties carrying the literal, so there is one member per list rather than a field plus an accessor, and `SchemaValidator` gains an `internal Rules` accessor with an `InternalsVisibleTo` entry for its test project.

## Test plan

- Six mutations confirm the tests bite: removing a rule from each of the four lists, adding a duplicate rule, and swapping two adjacent rules in `AddDefaultRules`.
- Full suites run for `Types.Validation` (142) and `Fusion.Composition` (743).
