### PR TITLE
Update dev tooling packages and remove superseded version pins

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.14" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.14" />
@@ -63,7 +63,7 @@
     <PackageVersion Include="Spectre.Console.Json" Version="0.55.2" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.55.2" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="Squadron.AzureStorage" Version="2.0.0-p.1" />
     <PackageVersion Include="Squadron.Mongo" Version="2.0.0-p.1" />
     <PackageVersion Include="Squadron.Nats" Version="2.0.0-p.1" />
@@ -79,8 +79,8 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.LocalStack" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="4.13.0" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />
@@ -120,11 +120,11 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
@@ -151,11 +151,11 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
@@ -182,10 +182,10 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.29" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.29" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.15" />

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/HotChocolate.Adapters.Mcp.Tests.csproj
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/HotChocolate.Adapters.Mcp.Tests.csproj
@@ -23,11 +23,6 @@
     <PackageReference Include="Moq" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <!-- Dependency of Microsoft.AspNetCore.Authentication.JwtBearer. Pinned to secure version. -->
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" VersionOverride="7.7.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Update="$(MSBuildProjectDirectory)\__resources__\*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Mocha/benchmarks/Directory.Packages.props
+++ b/src/Mocha/benchmarks/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'debug'">
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />

--- a/src/Mocha/examples/Demo/Directory.Packages.props
+++ b/src/Mocha/examples/Demo/Directory.Packages.props
@@ -8,25 +8,16 @@
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.4.6" />
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.RabbitMQ.Client" Version="13.4.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="11.0.0-preview.4.26230.115" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="11.0.0-preview.6.26359.118" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'debug'">
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />

--- a/src/Mocha/examples/PostgresTransport/Directory.Packages.props
+++ b/src/Mocha/examples/PostgresTransport/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'debug'">
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />


### PR DESCRIPTION
## Summary

- Updates 11 dev and test-only package units across the four Central Package Management scopes, each gated on a minimum release age of 7 days: `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Mvc.Testing` and `Microsoft.AspNetCore.TestHost` (8.0.29 / 9.0.18 / 10.0.10), `SQLitePCLRaw.bundle_e_sqlite3` 3.0.5, `Microsoft.Extensions.TimeProvider.Testing` 10.8.0, `Testcontainers` and `Testcontainers.LocalStack` 4.13.0, `BenchmarkDotNet` 0.15.8 in the Mocha benchmarks scope, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Extensions.Http.Resilience`, `Microsoft.Extensions.ServiceDiscovery`, and five `OpenTelemetry.*` packages in the two Mocha example scopes.
- Removes the `Microsoft.IdentityModel.Protocols.OpenIdConnect` `VersionOverride="7.7.1"` from `HotChocolate.Adapters.Mcp.Tests`. `JwtBearer 8.0.29` floors that package at 7.7.3, which is past the 7.1.2 fix for GHSA-59j7-ghrg-fj52, so the pin no longer adds anything and would now be a downgrade against the parent's floor.
- Deletes the net8.0, net9.0, and net10.0 `Microsoft.EntityFrameworkCore.Design` item groups from the Demo scope. That package is referenced only by `Demo.Catalog`, `Demo.Shipping`, and `Demo.Billing`, all of which target net11.0, so those three bands were never evaluated.

Consumer-facing packages are deliberately untouched: they stay at their lowest non-vulnerable version so downstream consumers are not forced to upgrade. Three bumps that would have required raising a shipping sibling (`Microsoft.EntityFrameworkCore.*` test providers, `Npgsql.EntityFrameworkCore.PostgreSQL` plugins, `OpenTelemetry.Exporter.InMemory`) were left alone for that reason.

## Test plan

- `dotnet restore --force-evaluate` on `src/All.slnx`, `Demo.slnx`, and the two benchmark projects that belong to no solution: all clean, zero `NU****` diagnostics.
- `dotnet build src/All.slnx`, and `Demo.slnx` after the item-group removal (0 warnings, 0 errors).
- 6209 tests pass across `Adapters.Mcp.Tests`, `Adapters.OpenApi.Tests`, `Mocha.Hosting.Tests`, `Mocha.Tests`, `Mocha.Sagas.Tests`, and `StrawberryShake.Persistence.SQLite.Tests`. `Adapters.Mcp.Tests` covers the removed pin on all four target frameworks, and its lock file now resolves `OpenIdConnect` and `System.IdentityModel.Tokens.Jwt` at 7.7.3 on net8.0.
- Container-backed suites `Fusion.Subscriptions.AmazonSqs.Tests` and `Fusion.Subscriptions.Redis.Tests` pass 52 assertions against Testcontainers 4.13.0, including the pinned `localstack/localstack:4.14.0` image without an auth token.
- `dotnet nuget verify --all` passes on the resolved packages for every bump.
- Pre-existing and unrelated to this branch: `Fusion.Execution.Benchmarks` and `Mocha.Mediator.Benchmarks` do not compile on `main` either, both being benchmark projects absent from every solution. Confirmed by reproducing `Mocha.Mediator.Benchmarks`' 22 `RCS1163` errors with `BenchmarkDotNet` reverted to 0.15.4.
