### PR TITLE
Report OpenAPI definitions the adapter cannot use

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/DynamicOpenApiDocumentTransformer.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.AspNetCore/DynamicOpenApiDocumentTransformer.cs
@@ -58,10 +58,11 @@ internal sealed class DynamicOpenApiDocumentTransformer
         OpenApiEndpointDefinition[] endpoints,
         OpenApiModelDefinition[] models,
         IDictionary<string, OpenApiModelDefinition> modelsByName,
-        ISchemaDefinition schema)
+        ISchemaDefinition schema,
+        IOpenApiDiagnosticEvents events)
     {
         var (endpointDescriptors, modelDescriptors, inputComponents) =
-            new DocumentBuilder(schema, modelsByName).Build(endpoints, models);
+            new DocumentBuilder(schema, modelsByName, events).Build(endpoints, models);
 
         _endpoints = endpointDescriptors;
         _models = modelDescriptors;
@@ -180,10 +181,12 @@ internal sealed class DynamicOpenApiDocumentTransformer
     // ambient values (schema, models) are read from fields instead of threaded as parameters.
     private sealed class DocumentBuilder(
         ISchemaDefinition schema,
-        IDictionary<string, OpenApiModelDefinition> modelsByName)
+        IDictionary<string, OpenApiModelDefinition> modelsByName,
+        IOpenApiDiagnosticEvents events)
     {
         private readonly ISchemaDefinition _schema = schema;
         private readonly IDictionary<string, OpenApiModelDefinition> _modelsByName = modelsByName;
+        private readonly IOpenApiDiagnosticEvents _events = events;
         private readonly Dictionary<string, int> _operationIdUsages = [];
         private readonly Dictionary<string, OpenApiSchemaAbstraction> _inputComponents = [];
         private readonly HashSet<string> _registeredInputNames = [];
@@ -201,9 +204,16 @@ internal sealed class DynamicOpenApiDocumentTransformer
                     var endpointDescriptor = CreateEndpointDescriptor(endpoint);
                     endpointDescriptors.Add(endpointDescriptor);
                 }
-                catch
+                catch (Exception exception)
                 {
-                    // If the construction of an endpoint descriptor fails, we just skip over it.
+                    // If the construction of an endpoint descriptor fails, we skip over it and
+                    // report why the endpoint is missing from the OpenAPI document.
+                    var endpointName = endpoint.OperationDefinition.Name?.Value;
+
+                    ReportError(
+                        $"Endpoint '{endpointName}' could not be added to the OpenAPI document: "
+                        + exception.Message,
+                        endpoint);
                 }
             }
 
@@ -214,9 +224,14 @@ internal sealed class DynamicOpenApiDocumentTransformer
                     var modelDescriptor = CreateModelDescriptor(model);
                     modelDescriptors.Add(modelDescriptor);
                 }
-                catch
+                catch (Exception exception)
                 {
-                    // If the construction of an model descriptor fails, we just skip over it.
+                    // If the construction of an model descriptor fails, we skip over it and
+                    // report why the model is missing from the OpenAPI document.
+                    ReportError(
+                        $"Model '{model.Name}' could not be added to the OpenAPI document: "
+                        + exception.Message,
+                        model);
                 }
             }
 
@@ -537,9 +552,22 @@ internal sealed class DynamicOpenApiDocumentTransformer
                     var fieldName = field.Name.Value;
                     var responseName = field.Alias?.Value ?? fieldName;
 
-                    var fieldType = fieldName == IntrospectionFieldNames.TypeName ?
-                        new NonNullType(_schema.Types["String"]) :
-                        ((IComplexTypeDefinition)namedType).Fields[fieldName].Type;
+                    IOutputType fieldType;
+
+                    if (fieldName == IntrospectionFieldNames.TypeName)
+                    {
+                        fieldType = new NonNullType(_schema.Types["String"]);
+                    }
+                    else if (namedType is IComplexTypeDefinition complexType
+                        && complexType.Fields.TryGetField(fieldName, out var fieldDefinition))
+                    {
+                        fieldType = fieldDefinition.Type;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(
+                            $"Expected to find field '{fieldName}' on type '{namedType.Name}'.");
+                    }
 
                     OpenApiSchemaAbstraction typeSchema;
                     if (field.SelectionSet is not null)
@@ -622,7 +650,12 @@ internal sealed class DynamicOpenApiDocumentTransformer
                     }
                     else
                     {
-                        var fragment = localFragmentLookup[fragmentName];
+                        if (!localFragmentLookup.TryGetValue(fragmentName, out var fragment))
+                        {
+                            throw new InvalidOperationException(
+                                $"Expected to find a definition for fragment '{fragmentName}'.");
+                        }
+
                         var typeCondition = _schema.Types[fragment.TypeCondition.Name.Value];
                         var isDifferentType = !typeCondition.IsAssignableFrom(namedType);
                         var typeName = typeCondition.Name;
@@ -1300,6 +1333,11 @@ internal sealed class DynamicOpenApiDocumentTransformer
                 str.AsSpan().CopyTo(span);
                 span[0] = char.ToLowerInvariant(span[0]);
             });
+        }
+
+        private void ReportError(string message, IOpenApiDefinition definition)
+        {
+            _events.ValidationErrors([new OpenApiDefinitionValidationError(message, definition)]);
         }
     }
 }

--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/Execution/OpenApiEndpointDescriptor.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/Execution/OpenApiEndpointDescriptor.cs
@@ -6,12 +6,15 @@ namespace HotChocolate.Adapters.OpenApi;
 
 internal sealed record OpenApiEndpointDescriptor(
     DocumentNode Document,
-    bool HasValidDocument,
+    IReadOnlyList<IError> DocumentErrors,
     string HttpMethod,
     RoutePattern Route,
     VariableValueInsertionTrie ParameterTrie,
     string? VariableFilledThroughBody,
-    OpenApiResponseBodySelection ResponseBodySelection);
+    OpenApiResponseBodySelection ResponseBodySelection)
+{
+    public bool HasValidDocument => DocumentErrors.Count == 0;
+}
 
 internal interface IVariableValueInsertionTrieSegment;
 

--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/Execution/OpenApiEndpointFactory.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/Execution/OpenApiEndpointFactory.cs
@@ -73,11 +73,10 @@ internal static class OpenApiEndpointFactory
         var documentValidator = schema.Services.GetRequiredService<DocumentValidator>();
 
         var validationResult = documentValidator.Validate(schema, document);
-        var hasValidDocument = !validationResult.HasErrors;
 
         return new OpenApiEndpointDescriptor(
             document,
-            hasValidDocument,
+            validationResult.Errors,
             endpointDefinition.HttpMethod,
             route,
             parameterTrie,

--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/IDynamicOpenApiDocumentTransformer.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/IDynamicOpenApiDocumentTransformer.cs
@@ -6,5 +6,6 @@ internal interface IDynamicOpenApiDocumentTransformer
         OpenApiEndpointDefinition[] endpoints,
         OpenApiModelDefinition[] models,
         IDictionary<string, OpenApiModelDefinition> modelsByName,
-        ISchemaDefinition schema);
+        ISchemaDefinition schema,
+        IOpenApiDiagnosticEvents events);
 }

--- a/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/OpenApiDefinitionRegistry.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.OpenApi.Core/OpenApiDefinitionRegistry.cs
@@ -153,12 +153,13 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
             validDefinitions.Add(definition);
         }
 
-        UpdateEndpointsAndOpenApiDefinitions(validDefinitions, schema);
+        UpdateEndpointsAndOpenApiDefinitions(validDefinitions, schema, events);
     }
 
     private void UpdateEndpointsAndOpenApiDefinitions(
         List<IOpenApiDefinition> definitions,
-        ISchemaDefinition schema)
+        ISchemaDefinition schema,
+        IOpenApiDiagnosticEvents events)
     {
         var endpoints = definitions
             .OfType<OpenApiEndpointDefinition>()
@@ -191,14 +192,23 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
                 continue;
             }
 
+            var endpointName = endpoint.OperationDefinition.Name!.Value;
+
             OpenApiEndpointDescriptor descriptor;
 
             try
             {
                 descriptor = OpenApiEndpointFactory.CreateEndpointDescriptor(endpoint, modelsByName, schema);
             }
-            catch
+            catch (Exception exception)
             {
+                events.ValidationErrors(
+                [
+                    new OpenApiDefinitionValidationError(
+                        $"Endpoint '{endpointName}' could not be initialized: {exception.Message}",
+                        endpoint)
+                ]);
+
                 continue;
             }
 
@@ -217,18 +227,35 @@ internal sealed class OpenApiDefinitionRegistry : IDisposable
 
                 keyHasValid.Add(key);
             }
-            else if (!keyToIndex.ContainsKey(key))
+            else
             {
-                keyToIndex[key] = chosenEndpoints.Count;
-                chosenEndpoints.Add((endpoint, descriptor));
+                events.ValidationErrors(
+                [
+                    .. descriptor.DocumentErrors.Select(
+                        error => new OpenApiDefinitionValidationError(
+                            $"Endpoint '{endpointName}' has an invalid document: {error.Message}",
+                            endpoint))
+                ]);
+
+                if (!keyToIndex.ContainsKey(key))
+                {
+                    keyToIndex[key] = chosenEndpoints.Count;
+                    chosenEndpoints.Add((endpoint, descriptor));
+                }
             }
         }
 
+        // Endpoints with an invalid document cannot execute, so they are left out of the
+        // OpenAPI document rather than described as callable.
         _transformer.AddDefinitions(
-            chosenEndpoints.Select(e => e.Definition).ToArray(),
+            chosenEndpoints
+                .Where(e => e.Descriptor.HasValidDocument)
+                .Select(e => e.Definition)
+                .ToArray(),
             models,
             modelsByName,
-            schema);
+            schema,
+            events);
 
         var httpEndpoints = new List<Endpoint>();
 

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Validation/ValidationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Validation/ValidationTestBase.cs
@@ -96,10 +96,15 @@ public abstract class ValidationTestBase : OpenApiTestBase
         eventListener.HasReportedErrors.Wait(cts.Token);
 
         // assert
-        var error = Assert.Single(eventListener.Errors);
-        Assert.Equal(
-            "OpenAPI models cannot contain the '@responseBody' directive.",
-            error.Message);
+        Assert.Collection(
+            eventListener.Errors,
+            error => Assert.Equal(
+                "OpenAPI models cannot contain the '@responseBody' directive.",
+                error.Message),
+            error => Assert.Equal(
+                "Endpoint 'GetUser' has an invalid document: "
+                + "The specified fragment `UserPreferences` does not exist.",
+                error.Message));
     }
 
     #endregion
@@ -757,6 +762,105 @@ public abstract class ValidationTestBase : OpenApiTestBase
         // assert
         var error = Assert.Single(eventListener.Errors);
         Assert.Equal($"Endpoint has invalid route pattern '{route}'.", error.Message);
+    }
+
+    [Fact]
+    public async Task Endpoint_References_Missing_Model_RaisesError()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            query GetUser @http(method: GET, route: "/user") {
+              userById(id: "1") {
+                ...User
+              }
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Endpoint 'GetUser' has an invalid document: "
+            + "The specified fragment `User` does not exist.",
+            error.Message);
+    }
+
+    [Fact]
+    public async Task Endpoint_References_Local_Fragment_Of_Model_RaisesError()
+    {
+        // arrange
+        // 'UserContact' is a local fragment of the 'User' model, so it cannot be spread
+        // from another definition.
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            query GetUser @http(method: GET, route: "/user") {
+              userById(id: "1") {
+                ...UserContact
+              }
+            }
+            """,
+            """
+            fragment User on User {
+              id
+              name
+            }
+
+            fragment UserContact on User {
+              email
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Endpoint 'GetUser' has an invalid document: "
+            + "The specified fragment `UserContact` does not exist.",
+            error.Message);
+    }
+
+    [Fact]
+    public async Task Endpoint_Selects_Unknown_Field_RaisesError()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            query GetUser @http(method: GET, route: "/user") {
+              userById(id: "1") {
+                nonExistentField
+              }
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Endpoint 'GetUser' has an invalid document: "
+            + "The field `nonExistentField` does not exist on the type `User`.",
+            error.Message);
     }
 
     #endregion

--- a/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Validation/ValidationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.OpenApi.Tests/Validation/ValidationTestBase.cs
@@ -107,6 +107,88 @@ public abstract class ValidationTestBase : OpenApiTestBase
                 error.Message));
     }
 
+    [Fact]
+    public async Task Model_Type_Condition_Not_In_Schema_RaisesError()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            fragment User on NonExistentType {
+              id
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Model 'User' could not be added to the OpenAPI document: "
+            + "Expected to find type condition type in the schema.",
+            error.Message);
+    }
+
+    [Fact]
+    public async Task Model_Selects_Unknown_Field_RaisesError()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            fragment User on User {
+              nonExistentField
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Model 'User' could not be added to the OpenAPI document: "
+            + "Expected to find field 'nonExistentField' on type 'User'.",
+            error.Message);
+    }
+
+    [Fact]
+    public async Task Model_References_Missing_Fragment_RaisesError()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        var storage = new TestOpenApiDefinitionStorage(
+            """
+            fragment User on User {
+              id
+              ...MissingHelper
+            }
+            """);
+        var eventListener = new TestOpenApiDiagnosticEventListener();
+        var server = CreateTestServer(storage, eventListener);
+
+        // act
+        await server.Services.GetRequestExecutorAsync(cancellationToken: cts.Token);
+
+        eventListener.HasReportedErrors.Wait(cts.Token);
+
+        // assert
+        var error = Assert.Single(eventListener.Errors);
+        Assert.Equal(
+            "Model 'User' could not be added to the OpenAPI document: "
+            + "Expected to find a definition for fragment 'MissingHelper'.",
+            error.Message);
+    }
+
     #endregion
 
     #region Endpoint

--- a/website/content/docs/hotchocolate/build/adapters/openapi.md
+++ b/website/content/docs/hotchocolate/build/adapters/openapi.md
@@ -221,7 +221,7 @@ To make a fragment referenceable from another document, give it a document of it
 
 Fragment names must be unique across every document that contributes to a single endpoint, which is the endpoint's own document plus each model it spreads, transitively. When two of those documents define a fragment with the same name, the endpoint's composed document is invalid and the endpoint responds with HTTP 500. Private helper fragments are not namespaced by their document, so this applies to them as well.
 
-An endpoint that spreads a fragment no document defines is also invalid, and likewise responds with HTTP 500. In both cases the endpoint is still routed, and it is omitted from the OpenAPI specification.
+An endpoint that spreads a fragment no document defines is also invalid, and likewise responds with HTTP 500. In both cases the endpoint is still routed, and it is omitted from the OpenAPI specification. Register a diagnostic event listener (see [Diagnostics](#diagnostics)) to see the reason.
 
 # Storage
 
@@ -276,6 +276,41 @@ builder
 ```
 
 The storage implements `IObservable<OpenApiDefinitionStorageEventArgs>`. When you push `Updated` or `Removed` events through this observable, the adapter picks up changes at runtime, adding, updating, or removing HTTP endpoints without a restart. This hot-reload behavior extends to the OpenAPI specification.
+
+# Diagnostics
+
+A definition that the adapter cannot use is skipped rather than throwing at startup, so an endpoint can be routed and still fail every call with HTTP 500. Derive from `OpenApiDiagnosticEventListener` to observe why:
+
+```csharp
+using HotChocolate.Adapters.OpenApi;
+
+public class LoggingOpenApiDiagnosticEventListener(
+    ILogger<LoggingOpenApiDiagnosticEventListener> logger)
+    : OpenApiDiagnosticEventListener
+{
+    public override void ValidationErrors(
+        IReadOnlyList<OpenApiDefinitionValidationError> errors)
+    {
+        foreach (var error in errors)
+        {
+            logger.LogError("{ValidationError}", error.Message);
+        }
+    }
+}
+```
+
+Register it on the GraphQL server. The listener is activated from the schema services, so any application service it takes as a constructor argument, `ILogger<T>` included, must be made available with `AddApplicationService<T>()`:
+
+```csharp
+builder
+    .AddGraphQL()
+    .AddQueryType<Query>()
+    .AddOpenApi()
+    .AddApplicationService<ILogger<LoggingOpenApiDiagnosticEventListener>>()
+    .AddDiagnosticEventListener<LoggingOpenApiDiagnosticEventListener>();
+```
+
+The listener receives an error for every definition the adapter cannot use: one that fails a validation rule, an endpoint whose composed document does not validate against the schema, an endpoint that could not be initialized, and a definition that could not be added to the OpenAPI document. Errors are reported whenever definitions are loaded or reloaded, so a hot-reload that breaks an endpoint reports it at that moment.
 
 # OpenAPI Specification
 


### PR DESCRIPTION
## Summary

- Definitions the adapter skips are no longer dropped in silence. Endpoints whose composed document fails validation against the schema, endpoints that cannot be prepared for execution, and definitions that cannot be described in the OpenAPI document all report through `IOpenApiDiagnosticEventListener`, naming the definition and the reason. The errors were already being computed and then discarded.
- Endpoints with an invalid document are excluded from the OpenAPI document. Most already were, because describing them failed anyway; this makes it consistent, so the specification no longer advertises an endpoint that returns HTTP 500 on every call.
- Two unguarded lookups in the document transformer threw `KeyNotFoundException`, whose message would now reach users verbatim. They throw a message naming the missing fragment or field instead.
- Document how to register a listener, including the `AddApplicationService<ILogger<T>>()` step that listener activation from the schema services requires.

Behaviour is otherwise unchanged: an endpoint that cannot execute is still routed and still returns HTTP 500, per the design in #9022.

## Test plan

- Three new tests covering an endpoint that spreads an undefined fragment, one that spreads another model's private helper, and one that selects an unknown field; each asserts the exact reported message.
- Verified the reports actually fire by removing the emitting call and confirming the tests fail, then restoring it.
- Verified the documented listener registration end to end, including that it fails without `AddApplicationService<ILogger<T>>()`.
- Full `HotChocolate.Adapters.OpenApi.Tests` suite on net9.0, net10.0, and net11.0: 238 passed, 2 skipped. No snapshot changed.
- `prettier@3.8.3 --no-config --check` on the changed docs page.

Reported in #10215. Not a full fix for that issue: making these ordinary validation errors, and failing at startup rather than routing an endpoint that returns HTTP 500, are design decisions still to be made.
