### PR TITLE
Retry workflow run watching on transient API failures

### DIFF
--- a/.github/actions/dispatch-and-watch-workflow/action.yml
+++ b/.github/actions/dispatch-and-watch-workflow/action.yml
@@ -84,4 +84,16 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
         REPO: ${{ inputs.repo }}
         RUN_ID: ${{ steps.dispatch.outputs.run-id }}
-      run: gh run watch "$RUN_ID" --repo "$REPO" --exit-status --compact
+      run: |
+        set -euo pipefail
+
+        # A single transient API error kills `gh run watch`, so retry it. Re-watching a run that
+        # really failed costs nothing, because watching a completed run returns immediately.
+        for attempt in 1 2 3; do
+          gh run watch "$RUN_ID" --repo "$REPO" --exit-status --compact && exit 0
+          echo "Watch attempt $attempt/3 failed."
+          sleep 10
+        done
+
+        echo "::error::Run $RUN_ID failed, or its status could not be read."
+        exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -859,4 +859,16 @@ jobs:
           REPO: ChilliCream/nitro-azure-pipelines-tasks
           RUN_ID: ${{ steps.dispatch.outputs.run-id }}
         shell: bash
-        run: gh run watch "$RUN_ID" --repo "$REPO" --exit-status --compact
+        run: |
+          set -euo pipefail
+
+          # A single transient API error kills `gh run watch`, so retry it. Re-watching a run that
+          # really failed costs nothing, because watching a completed run returns immediately.
+          for attempt in 1 2 3; do
+            gh run watch "$RUN_ID" --repo "$REPO" --exit-status --compact && exit 0
+            echo "Watch attempt $attempt/3 failed."
+            sleep 10
+          done
+
+          echo "::error::Run $RUN_ID failed, or its status could not be read."
+          exit 1


### PR DESCRIPTION
## Summary

- `gh run watch --exit-status` fails its step on a single transient API error, so a release job can go red even though the downstream run it was watching succeeded. That happened on the 16.6.1-p.1 release: the watcher hit `failed to get run: HTTP 500` 0.2s in, while the [dispatched run](https://github.com/ChilliCream/nitro-fusion-publish/actions/runs/31475633257) completed fine.
- Both watch sites now retry up to 3 times, 10 seconds apart: the shared `dispatch-and-watch-workflow` action (used by the action-repository matrix and the cloud platform update) and the inline watch in the Azure Pipelines extension job.
- Trade-off: a run that genuinely failed is now watched 3 times rather than once. That costs 20 seconds of sleeps, because watching an already-completed run returns immediately.

## Test plan

- Both files parse as YAML, and every `run:` script passes `bash -n`.
- Exercised the loop against a stub `gh`: clean first attempt exits 0, two transient failures then success exits 0, and permanent failure exits 1 after 3 attempts.
- Confirmed `set -e` does not abort on the failing left-hand side of the `&&`, so a failed watch reaches the retry instead of killing the script.
