### PR TITLE
Widen Fusion composite MetaDb operation reference ids to 22 bits

### DIFF
--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/CompositeObjectCreateTemplateBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/CompositeObjectCreateTemplateBenchmark.cs
@@ -515,7 +515,7 @@ public class CompositeObjectCreateTemplateBenchmark : FusionBenchmarkBase
             Unsafe.WriteUnaligned(
                 ref Unsafe.Add(ref row, 4),
                 selectionId
-                | ((int)OperationReferenceType.Selection << 15)
+                | ((int)OperationReferenceType.Selection << DbRow.OperationReferenceTypeShift)
                 | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
 
             // ints 2..3 must be zero (int 4 is written directly below)
@@ -555,7 +555,7 @@ public class CompositeObjectCreateTemplateBenchmark : FusionBenchmarkBase
                 Unsafe.WriteUnaligned(
                     ref Unsafe.Add(ref row0, 4),
                     selectionId
-                    | ((int)OperationReferenceType.Selection << 15)
+                    | ((int)OperationReferenceType.Selection << DbRow.OperationReferenceTypeShift)
                     | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
                 Unsafe.InitBlockUnaligned(ref Unsafe.Add(ref row0, 8), 0, 8);
                 Unsafe.WriteUnaligned(
@@ -597,7 +597,7 @@ public class CompositeObjectCreateTemplateBenchmark : FusionBenchmarkBase
             Unsafe.WriteUnaligned(
                 ref Unsafe.Add(ref row, 4),
                 selectionSetId
-                | ((int)OperationReferenceType.SelectionSet << 15)
+                | ((int)OperationReferenceType.SelectionSet << DbRow.OperationReferenceTypeShift)
                 | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
 
             // int 2: sizeOrLength = property count

--- a/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/DbRowWriteBenchmark.cs
+++ b/src/HotChocolate/Fusion/benchmarks/Fusion.Execution.Benchmarks/DbRowWriteBenchmark.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using BenchmarkDotNet.Attributes;
+using DbRow = HotChocolate.Fusion.Text.Json.CompositeResultDocument.DbRow;
 
 namespace HotChocolate.Fusion.Execution.Benchmarks;
 
@@ -83,7 +84,7 @@ internal static class DbRowBenchData
         Unsafe.WriteUnaligned(ref row, 3 /*PropertyName*/ | (parent << 4));
         Unsafe.WriteUnaligned(
             ref Unsafe.Add(ref row, 4),
-            selectionId | (2 << 15) | (flags << 17));
+            selectionId | (2 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift));
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref row, 8), 0);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref row, 12), 0);
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref row, 16), 0);
@@ -95,7 +96,7 @@ internal static class DbRowBenchData
         Unsafe.WriteUnaligned(ref row, 3 | (parent << 4));
         Unsafe.WriteUnaligned(
             ref Unsafe.Add(ref row, 4),
-            selectionId | (2 << 15) | (flags << 17));
+            selectionId | (2 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift));
         Unsafe.InitBlockUnaligned(ref Unsafe.Add(ref row, 8), 0, 12);
     }
 
@@ -103,7 +104,7 @@ internal static class DbRowBenchData
     public static void WriteEmptyProp_Vec128PlusScalar(ref byte row, int parent, int selectionId, int flags)
     {
         var int0 = 3 | (parent << 4);
-        var int1 = selectionId | (2 << 15) | (flags << 17);
+        var int1 = selectionId | (2 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift);
 
         var v = Vector128.Create(int0, int1, 0, 0).AsByte();
         v.StoreUnsafe(ref row);
@@ -116,7 +117,7 @@ internal static class DbRowBenchData
         Unsafe.WriteUnaligned(ref row, 3 | (parent << 4));
         Unsafe.WriteUnaligned(
             ref Unsafe.Add(ref row, 4),
-            selectionId | (2 << 15) | (flags << 17));
+            selectionId | (2 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift));
         // Covers ints 2..4 using a 16-byte zero store (overwrites 4 bytes past end, but row is 20B
         // and buffer is row-aligned multiples of 20B — works only when room exists after).
         // To be safe here we do two stores: Vec128.Zero at offset 8 would write 16 bytes,
@@ -134,7 +135,7 @@ internal static class DbRowBenchData
         Unsafe.WriteUnaligned(ref row, 1 | (parent << 4));
         Unsafe.WriteUnaligned(
             ref Unsafe.Add(ref row, 4),
-            selectionId | (1 << 15) | (flags << 17));
+            selectionId | (1 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift));
         Unsafe.WriteUnaligned(ref Unsafe.Add(ref row, 8), propertyCount);
         Unsafe.WriteUnaligned(
             ref Unsafe.Add(ref row, 12),
@@ -160,7 +161,7 @@ internal static class DbRowBenchData
     public static void WriteStartObj_Vec128PlusScalar(ref byte row, int parent, int selectionId, int propertyCount, int flags)
     {
         var int0 = 1 | (parent << 4);
-        var int1 = selectionId | (1 << 15) | (flags << 17);
+        var int1 = selectionId | (1 << DbRow.OperationReferenceTypeShift) | (flags << DbRow.FlagsShift);
         var int2 = propertyCount;
         var int3 = ((propertyCount * 2) + 1) & 0x07FFFFFF;
 
@@ -192,8 +193,8 @@ internal static class DbRowBenchData
             var locationOrRows = location != 0 ? location : numberOfRows;
             _typeAndParent = (tokenType & 0x0F) | (parentRow << 4);
             _selectionAndFlags = operationReferenceId
-                | (operationReferenceType << 15)
-                | (flags << 17);
+                | (operationReferenceType << DbRow.OperationReferenceTypeShift)
+                | (flags << DbRow.FlagsShift);
             _sizeOrLengthUnion = sizeOrLength;
             _locationOrRows = locationOrRows & 0x07FFFFFF;
             _source = sourceDocumentId & 0x7FFF;

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.DbRow.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.DbRow.cs
@@ -18,14 +18,21 @@ public sealed partial class CompositeResultDocument
         internal const int SizeOffset = 8;
         internal const int LocationOrRowsOffset = 12;
         internal const int SourceAndTypeOffset = 16;
-        internal const int FlagsShift = 17;
+
+        // Bit layout of _selectionAndFlags, low to high: OperationReferenceId,
+        // OperationReferenceType, Flags. The layout fills the int exactly.
+        internal const int OperationReferenceIdBitCount = 22;
+        internal const int OperationReferenceIdMask = (1 << OperationReferenceIdBitCount) - 1;
+        internal const int OperationReferenceTypeShift = OperationReferenceIdBitCount;
+        internal const int OperationReferenceTypeMask = 0x03;
+        internal const int FlagsShift = OperationReferenceTypeShift + 2;
         internal const int FlagsBitCount = 8;
         internal const int FlagsMask = 0xFF;
 
         // 29 bits parent cursor value + 3 reserved
         private readonly int _parent;
 
-        // 15 bits OperationReferenceId + 2 bits OperationReferenceType + 8 bits Flags + 7 reserved
+        // 22 bits OperationReferenceId + 2 bits OperationReferenceType + 8 bits Flags
         private readonly int _selectionAndFlags;
 
         // 1 bit HasComplexChildren (sign) + 31 bits SizeOrLength
@@ -53,9 +60,9 @@ public sealed partial class CompositeResultDocument
             Debug.Assert(sizeOrLength >= UnknownSize);
             Debug.Assert(sourceDocumentId is >= 0 and <= 0x7FFF); // 15 bits
             Debug.Assert(parentRow is >= 0 and <= 0x1FFFFFFF); // 29 bits (cursor value)
-            Debug.Assert(operationReferenceId is >= 0 and <= 0x7FFF); // 15 bits
+            Debug.Assert(operationReferenceId is >= 0 and <= OperationReferenceIdMask); // 22 bits
             Debug.Assert(numberOfRows is >= 0 and <= 0x1FFFFFFF); // 29 bits
-            Debug.Assert((byte)operationReferenceType <= 3); // 2 bits
+            Debug.Assert((byte)operationReferenceType <= OperationReferenceTypeMask); // 2 bits
             Debug.Assert((int)flags is >= 0 and <= FlagsMask);
             Debug.Assert(Unsafe.SizeOf<DbRow>() == Size);
 
@@ -63,7 +70,7 @@ public sealed partial class CompositeResultDocument
 
             _parent = parentRow & 0x1FFFFFFF;
             _selectionAndFlags = operationReferenceId
-                | ((int)operationReferenceType << 15)
+                | ((int)operationReferenceType << OperationReferenceTypeShift)
                 | (((int)flags & FlagsMask) << FlagsShift);
             _sizeOrLengthUnion = sizeOrLength;
             _locationOrRows = locationOrRows & 0x1FFFFFFF;
@@ -85,7 +92,8 @@ public sealed partial class CompositeResultDocument
         /// 2 bits = 4 possible values
         /// </remarks>
         public OperationReferenceType OperationReferenceType
-            => (OperationReferenceType)((_selectionAndFlags >> 15) & 0x03);
+            => (OperationReferenceType)(
+                (_selectionAndFlags >>> OperationReferenceTypeShift) & OperationReferenceTypeMask);
 
         /// <summary>
         /// Byte offset in source data, or the packed cursor value of the target row for references.
@@ -141,9 +149,9 @@ public sealed partial class CompositeResultDocument
         /// Reference to GraphQL selection set or selection metadata.
         /// </summary>
         /// <remarks>
-        /// 15 bits = 32K selections
+        /// 22 bits = 4M selections
         /// </remarks>
-        public int OperationReferenceId => _selectionAndFlags & 0x7FFF;
+        public int OperationReferenceId => _selectionAndFlags & OperationReferenceIdMask;
 
         /// <summary>
         /// Element metadata flags.
@@ -159,11 +167,11 @@ public sealed partial class CompositeResultDocument
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int ReadOperationReferenceId(int selectionAndFlags)
-            => selectionAndFlags & 0x7FFF;
+            => selectionAndFlags & OperationReferenceIdMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ElementFlags ReadFlags(int selectionAndFlags)
-            => (ElementFlags)((selectionAndFlags >> 17) & 0x7F);
+            => (ElementFlags)((selectionAndFlags >>> FlagsShift) & FlagsMask);
 
         /// <summary>
         /// True for primitive JSON values (strings, numbers, booleans, null).

--- a/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.MetaDb.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Execution/Text/Json/CompositeResultDocument.MetaDb.cs
@@ -101,7 +101,7 @@ public sealed partial class CompositeResultDocument
         internal Cursor AppendEmptyProperty(int parentRow, int selectionId, ElementFlags flags)
         {
             Debug.Assert(parentRow is >= 0 and <= 0x1FFFFFFF);
-            Debug.Assert(selectionId is >= 0 and <= 0x7FFF);
+            Debug.Assert(selectionId is >= 0 and <= DbRow.OperationReferenceIdMask);
             Debug.Assert((int)flags is >= 0 and <= DbRow.FlagsMask);
 
             var (chunk, byteOffset, cursor) = ReserveRow();
@@ -116,7 +116,7 @@ public sealed partial class CompositeResultDocument
             Unsafe.WriteUnaligned(
                 ref Unsafe.Add(ref row, 4),
                 selectionId
-                | ((int)OperationReferenceType.Selection << 15)
+                | ((int)OperationReferenceType.Selection << DbRow.OperationReferenceTypeShift)
                 | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
 
             // ints 2..3 must be zero (int 4 is written directly below)
@@ -135,7 +135,7 @@ public sealed partial class CompositeResultDocument
         internal Cursor AppendEmptyPropertyWithNullValue(int parentRow, int selectionId, ElementFlags flags)
         {
             Debug.Assert(parentRow is >= 0 and <= 0x1FFFFFFF);
-            Debug.Assert(selectionId is >= 0 and <= 0x7FFF);
+            Debug.Assert(selectionId is >= 0 and <= DbRow.OperationReferenceIdMask);
             Debug.Assert((int)flags is >= 0 and <= DbRow.FlagsMask);
 
             var next = _next;
@@ -155,7 +155,7 @@ public sealed partial class CompositeResultDocument
                 Unsafe.WriteUnaligned(
                     ref Unsafe.Add(ref row0, 4),
                     selectionId
-                    | ((int)OperationReferenceType.Selection << 15)
+                    | ((int)OperationReferenceType.Selection << DbRow.OperationReferenceTypeShift)
                     | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
                 Unsafe.InitBlockUnaligned(ref Unsafe.Add(ref row0, 8), 0, 8);
                 // int 4: PropertyName token
@@ -182,7 +182,7 @@ public sealed partial class CompositeResultDocument
         internal Cursor AppendStartObject(int parentRow, int selectionSetId, int propertyCount, ElementFlags flags)
         {
             Debug.Assert(parentRow is >= 0 and <= 0x1FFFFFFF);
-            Debug.Assert(selectionSetId is >= 0 and <= 0x7FFF);
+            Debug.Assert(selectionSetId is >= 0 and <= DbRow.OperationReferenceIdMask);
             Debug.Assert(propertyCount is >= 0 and <= 0x0FFFFFFF); // room for (count*2)+1 in 29 bits
             Debug.Assert((int)flags is >= 0 and <= DbRow.FlagsMask);
 
@@ -198,7 +198,7 @@ public sealed partial class CompositeResultDocument
             Unsafe.WriteUnaligned(
                 ref Unsafe.Add(ref row, 4),
                 selectionSetId
-                | ((int)OperationReferenceType.SelectionSet << 15)
+                | ((int)OperationReferenceType.SelectionSet << DbRow.OperationReferenceTypeShift)
                 | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
 
             // int 2: sizeOrLength = property count
@@ -623,7 +623,7 @@ public sealed partial class CompositeResultDocument
             Unsafe.WriteUnaligned(
                 ref Unsafe.Add(ref row, DbRow.SelectionAndFlagsOffset),
                 operationReferenceId
-                | ((int)operationReferenceType << 15)
+                | ((int)operationReferenceType << DbRow.OperationReferenceTypeShift)
                 | (((int)flags & DbRow.FlagsMask) << DbRow.FlagsShift));
 
             // int 2: SizeOrLength (full 32 bits; preserves the sign bit / UnknownSize sentinel)

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Text/Json/CompositeResultDocumentMetaDbTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Text/Json/CompositeResultDocumentMetaDbTests.cs
@@ -141,9 +141,11 @@ public class CompositeResultDocumentMetaDbTests : IDisposable
         _metaDb.ReplacePreserveParent(replaceCursor, ElementTokenType.String, flags: flags);
 
         // Assert
-        Assert.Equal(17, DbRow.FlagsShift);
+        // The flags sit above the 22-bit id and the 2-bit reference type and fill the int.
+        Assert.Equal(24, DbRow.FlagsShift);
         Assert.Equal(8, DbRow.FlagsBitCount);
         Assert.Equal(0xFF, DbRow.FlagsMask);
+        Assert.Equal(32, DbRow.FlagsShift + DbRow.FlagsBitCount);
         Assert.All(cursors, cursor => Assert.Equal(flags, _metaDb.Get(cursor).Flags));
     }
 
@@ -231,7 +233,7 @@ public class CompositeResultDocumentMetaDbTests : IDisposable
         const int maxSizeOrLength = int.MaxValue; // 31 bits
         const int maxSourceDocumentId = 0x7FFF; // 15 bits (reduced from 16)
         const int maxParentRow = 0x0FFFFFFF; // 28 bits
-        const int maxSelectionSetId = 0x7FFF; // 15 bits
+        const int maxSelectionSetId = CompositeResultDocument.DbRow.OperationReferenceIdMask; // 22 bits
 
         // Act
         var index = _metaDb.Append(
@@ -251,6 +253,78 @@ public class CompositeResultDocumentMetaDbTests : IDisposable
         Assert.Equal(maxSourceDocumentId, row.SourceDocumentId);
         Assert.Equal(maxParentRow, row.Parent);
         Assert.Equal(maxSelectionSetId, row.OperationReferenceId);
+    }
+
+    [Fact]
+    public void OperationReferenceId_Should_NotOverlapTypeAndFlags_When_AllBitsAreSet()
+    {
+        // Arrange
+        // The widest id, a non-zero reference type and every flag share one int; each
+        // field must survive the round trip untouched by its neighbors.
+        const int maxId = CompositeResultDocument.DbRow.OperationReferenceIdMask;
+        const ElementFlags allFlags = (ElementFlags)CompositeResultDocument.DbRow.FlagsMask;
+
+        // Act
+        var index = _metaDb.Append(
+            ElementTokenType.StartObject,
+            operationReferenceId: maxId,
+            operationReferenceType: OperationReferenceType.Selection,
+            flags: allFlags);
+        var row = _metaDb.Get(index);
+
+        var snapshot =
+            $$"""
+            Id: {{row.OperationReferenceId}}
+            Type: {{row.OperationReferenceType}}
+            Flags: {{row.Flags}}
+            IdBits: {{CompositeResultDocument.DbRow.OperationReferenceIdBitCount}}
+            IdMax: {{maxId}}
+            """;
+
+        // Assert
+        snapshot.MatchInlineSnapshot(
+            """
+            Id: 4194303
+            Type: Selection
+            Flags: Invalidated, SourceResult, IsNullable, IsRoot, IsInternal, IsExcluded, IsEnumValue, NullMarker
+            IdBits: 22
+            IdMax: 4194303
+            """);
+    }
+
+    [Fact]
+    public void InlineAppenders_Should_EncodeSameLayoutAsRowConstructor_When_IdExceedsFifteenBits()
+    {
+        // Arrange
+        // The templated appenders write the selection-and-flags word inline instead of
+        // going through the DbRow constructor, so an id above the old 15-bit ceiling
+        // must decode identically from every producer.
+        const int wideId = 0x8000 + 12345; // needs bit 15 and above
+        const ElementFlags flags = ElementFlags.IsNullable | ElementFlags.NullMarker;
+
+        // Act
+        var constructed = _metaDb.Append(
+            ElementTokenType.PropertyName,
+            operationReferenceId: wideId,
+            operationReferenceType: OperationReferenceType.Selection,
+            flags: flags);
+        var emptyProperty = _metaDb.AppendEmptyProperty(parentRow: 0, wideId, flags);
+        var propertyWithNull = _metaDb.AppendEmptyPropertyWithNullValue(parentRow: 0, wideId, flags);
+        var startObject = _metaDb.AppendStartObject(parentRow: 0, wideId, propertyCount: 1, flags);
+
+        var rows = new[]
+        {
+            _metaDb.Get(constructed),
+            _metaDb.Get(emptyProperty),
+            _metaDb.Get(propertyWithNull),
+            _metaDb.Get(startObject)
+        };
+
+        // Assert
+        Assert.All(rows, row => Assert.Equal(wideId, row.OperationReferenceId));
+        Assert.All(rows, row => Assert.Equal(flags, row.Flags));
+        Assert.Equal(OperationReferenceType.Selection, rows[1].OperationReferenceType);
+        Assert.Equal(OperationReferenceType.SelectionSet, rows[3].OperationReferenceType);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The composite result MetaDb stored each row's selection or selection-set id in 15 bits, capping an operation at about 32,700 ids. Large Relay-generated operations reach 40k+ selections and could not be represented.

The id now occupies 22 bits (about 4.19M ids) by absorbing the 7 previously reserved high bits of the same word. The reference type and flags shift up so the layout fills the int exactly:

| Field | Before | After |
|---|---|---|
| `OperationReferenceId` | 15 bits @ 0 | 22 bits @ 0 |
| `OperationReferenceType` | 2 bits @ 15 | 2 bits @ 22 |
| `Flags` | 8 bits @ 17 | 8 bits @ 24 |
| reserved | 7 bits | 0 |

Keeping the id contiguous at the bottom means the hottest decode stays a single `& mask`.

## Changes

- `DbRow`: new `OperationReferenceIdBitCount/Mask`, `OperationReferenceTypeShift/Mask` constants; `FlagsShift` 17 -> 24; ctor asserts, getters, `ReadOperationReferenceId` and `ReadFlags` derive from them. `ReadFlags` previously masked with `0x7F`, silently dropping the `NullMarker` bit; it now uses `FlagsMask`.
- `MetaDb`: the 3 asserts and 4 inline appender encoders reference the constants instead of literal shifts.
- Benchmarks: the byte-faithful replicas in `CompositeObjectCreateTemplateBenchmark` and `DbRowWriteBenchmark` track the constants. The template benchmark's `[GlobalSetup]` byte-identity check against the real MetaDb passes and still reproduces the 0.26 ratio from #10139.
- `ObjectTemplate` goes through the `DbRow` ctor and needed no change; ids are plain ints from `++lastId` with no upstream ceiling.

## Tests

- Existing max-value test raised to the new ceiling; the `FlagsShift` pin updated with a "fills 32 bits" assertion.
- New `OperationReferenceId_Should_NotOverlapTypeAndFlags_When_AllBitsAreSet`: widest id, non-zero type, and all 8 flags round-trip untouched (inline snapshot).
- New `InlineAppenders_Should_EncodeSameLayoutAsRowConstructor_When_IdExceedsFifteenBits`: `AppendEmptyProperty`, `AppendEmptyPropertyWithNullValue`, and `AppendStartObject` decode an id above the old 15-bit ceiling identically to the ctor path.

Gates: MetaDb tests 46/46, `Fusion.Execution.Tests` 1063/0/3, full `dotnet test src/HotChocolate/Fusion` green (one `CancellationTests` timeout flake, passes in isolation).