### PR TITLE
Remove never-published test utilities from Build.Pack.slnx

### DIFF
--- a/src/Build.Pack.slnx
+++ b/src/Build.Pack.slnx
@@ -32,7 +32,6 @@
     <Project Path="HotChocolate/AspNetCore/src/Transport.Http/HotChocolate.Transport.Http.csproj" />
     <Project Path="HotChocolate/AspNetCore/src/Transport.Sockets.Client/HotChocolate.Transport.Sockets.Client.csproj" />
     <Project Path="HotChocolate/AspNetCore/src/Transport.Sockets/HotChocolate.Transport.Sockets.csproj" />
-    <Project Path="HotChocolate/AspNetCore/test/AspNetCore.Tests.Utilities/HotChocolate.AspNetCore.Tests.Utilities.csproj" />
     <Project Path="HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions.IsolatedProcess/HotChocolate.AzureFunctions.IsolatedProcess.csproj" />
     <Project Path="HotChocolate/AzureFunctions/src/HotChocolate.AzureFunctions/HotChocolate.AzureFunctions.csproj" />
     <Project Path="HotChocolate/Caching/src/Caching.Core/HotChocolate.Caching.Core.csproj" />
@@ -69,8 +68,6 @@
     <Project Path="HotChocolate/Core/src/Types.Validation/HotChocolate.Types.Validation.csproj" />
     <Project Path="HotChocolate/Core/src/Types/HotChocolate.Types.csproj" />
     <Project Path="HotChocolate/Core/src/Validation/HotChocolate.Validation.csproj" />
-    <Project Path="HotChocolate/Core/test/Types.Tests.Documentation/HotChocolate.Types.Tests.Documentation.csproj" />
-    <Project Path="HotChocolate/Core/test/Utilities/HotChocolate.Tests.Utilities.csproj" />
     <Project Path="HotChocolate/CostAnalysis/src/CostAnalysis/HotChocolate.CostAnalysis.csproj" />
     <Project Path="HotChocolate/Data/src/Data/HotChocolate.Data.csproj" />
     <Project Path="HotChocolate/Data/src/EntityFramework/HotChocolate.Data.EntityFramework.csproj" />
@@ -93,7 +90,6 @@
     <Project Path="HotChocolate/Fusion/src/Fusion.Subscriptions.Redis/HotChocolate.Fusion.Subscriptions.Redis.csproj" />
     <Project Path="HotChocolate/Fusion/src/Fusion.Subscriptions.NATS/HotChocolate.Fusion.Subscriptions.NATS.csproj" />
     <Project Path="HotChocolate/Fusion/src/Fusion.Utilities/HotChocolate.Fusion.Utilities.csproj" />
-    <Project Path="HotChocolate/Fusion/test/Fusion.Tests.Shared/HotChocolate.Fusion.Tests.Shared.csproj" />
     <Project Path="HotChocolate/Json/src/Json/HotChocolate.Text.Json.csproj" />
     <Project Path="HotChocolate/Language/src/Language.SyntaxTree/HotChocolate.Language.SyntaxTree.csproj" />
     <Project Path="HotChocolate/Language/src/Language.Utf8/HotChocolate.Language.Utf8.csproj" />
@@ -136,8 +132,6 @@
     <Project Path="Mocha/src/Mocha.Transport.RabbitMQ/Mocha.Transport.RabbitMQ.csproj" />
     <Project Path="Mocha/src/Mocha.Utilities/Mocha.Utilities.csproj" />
     <Project Path="Mocha/src/Mocha/Mocha.csproj" />
-    <Project Path="Mocha/test/Mocha.Sagas.TestHelpers/Mocha.Sagas.TestHelpers.csproj" />
-    <Project Path="Mocha/test/Mocha.TestHelpers/Mocha.TestHelpers.csproj" />
     <Project Path="Nitro/CommandLine/src/CommandLine.FusionCompatibility/Nitro.CommandLine.FusionCompatibility.csproj" />
     <Project Path="Nitro/CommandLine/src/CommandLine/Nitro.CommandLine.csproj" />
     <Project Path="Nitro/Common/src/ChilliCream.Nitro.Adapters.Mcp.Packaging/ChilliCream.Nitro.Adapters.Mcp.Packaging.csproj" />


### PR DESCRIPTION
## Summary

- `Build.Pack.slnx` listed six test-support libraries that evaluate to `IsPackable=false`, so `dotnet pack` on that solution produced nothing for them. They are removed, leaving 151 entries that all produce a package.
- None of the six was ever published to nuget.org. Checked against `https://api.nuget.org/v3-flatcontainer/<id>/index.json`, the raw package storage endpoint, which lists every version for an ID including unlisted ones. All six return HTTP 404, against 1987 versions for the `HotChocolate.Types` control. The IDs came from each project's evaluated `PackageId`, not its file name.
- Everything that references them is itself a test project, and none of those is in the pack solution, so nothing in `Build.Pack.slnx` depended on these entries.

Follows on from #10248, which made the packability of every project explicit.

## Test plan

- Every one of the 151 remaining entries evaluates to `IsPackable=true` via `dotnet msbuild -getProperty:IsPackable`, so the solution no longer contains a project that packs to nothing.
- `dotnet sln src/Build.Pack.slnx list` returns 151 projects, confirming the edited solution still parses.
- No `/test/` path remains in the file.
