### PR TITLE
Fix NuGet package icon path

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -67,7 +67,7 @@
 
   <ItemGroup Condition="'$(PackageIcon)' != ''">
     <None
-      Include="$(MSBuildThisFileDirectory)..\website\static\resources\$(PackageIcon)"
+      Include="$(MSBuildThisFileDirectory)..\website\public\resources\$(PackageIcon)"
       Pack="true"
       PackagePath="$(PackageIcon)"
       Visible="false"


### PR DESCRIPTION
## Summary

- update the central NuGet package icon path after the website assets moved from `website/static/resources` to `website/public/resources`
- restore NuGet packing for projects that define `PackageIcon`

## Validation

- `dotnet pack src/CookieCrumble/src/CookieCrumble/CookieCrumble.csproj -c Release -o /tmp/hc5-package-icon-validation -p:Version=0.0.0-icon-path-validation -p:TargetFrameworks=net11.0 --no-restore`
- verified the generated package contains `cookiecrumble-icon.png`