### PR TITLE
Enable variable definition directive parser test

### DIFF
--- a/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
@@ -766,11 +766,11 @@ public class QueryParserTests
         document.ToString().MatchSnapshot(extension: ".graphql");
     }
 
-    [Fact(Skip = "Implement Parse Variable Directives")]
+    [Fact]
     public void ParseVariablesWithDirective()
     {
         // arrange
-        var sourceText = @"query ($a: String! @foo) a(a: $a)"u8.ToArray();
+        var sourceText = "query ($a: String! @foo) { a(a: $a) }"u8.ToArray();
 
         // act
         var parser = new Utf8GraphQLParser(

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/QueryParserTests.ParseVariablesWithDirective.graphql
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/QueryParserTests.ParseVariablesWithDirective.graphql
@@ -1,0 +1,3 @@
+query($a: String! @foo) {
+  a(a: $a)
+}


### PR DESCRIPTION
## Summary

- Enables `QueryParserTests.ParseVariablesWithDirective`, which was skipped with "Implement Parse Variable Directives". Directives on variable definitions are parsed by `ParseVariableDefinition`, so the skip no longer reflects the parser.
- Corrects the test's query document, which was not valid GraphQL: `query ($a: String! @foo) a(a: $a)` has no braces around the selection set, so the test threw `Expected a LeftBrace token but found Name` before reaching its assertion. It now parses `query ($a: String! @foo) { a(a: $a) }`.
- Adds the accompanying snapshot, which covers the printer round-trip as well as the parse, so the directive is asserted to survive on the way back out.

The existing `ParseDirectiveOnVariableDefinition` test stays as-is. It asserts the directive on the syntax node for a named operation, while this one covers an anonymous operation with a non-null variable type and checks the printed document.

## Test plan

- `dotnet run -f net10.0 -- --filter-class '*QueryParserTests*'` in `src/HotChocolate/Language/test/Language.Tests`: 51 passed, 0 failed, 0 skipped.
- Ran the single test a second time so the assertion ran against the committed snapshot rather than creating it.
