### PR TITLE
Add fragment arguments support to the GraphQL syntax layer

### DIFF
--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FragmentDefinitionNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FragmentDefinitionNode.cs
@@ -86,6 +86,12 @@ public sealed class FragmentDefinitionNode : NamedSyntaxNode, IExecutableDefinit
     public override IEnumerable<ISyntaxNode> GetNodes()
     {
         yield return Name;
+
+        foreach (var variableDefinition in VariableDefinitions)
+        {
+            yield return variableDefinition;
+        }
+
         yield return TypeCondition;
 
         foreach (var directive in Directives)

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/FragmentSpreadNode.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/FragmentSpreadNode.cs
@@ -2,22 +2,75 @@ using HotChocolate.Language.Utilities;
 
 namespace HotChocolate.Language;
 
+/// <summary>
+/// <para>Represents a fragment spread.</para>
+/// <para>FragmentSpread : ... FragmentName Arguments? Directives?</para>
+/// </summary>
 public sealed class FragmentSpreadNode : NamedSyntaxNode, ISelectionNode
 {
+    /// <summary>
+    /// Initializes a new instance of <see cref="FragmentSpreadNode"/>.
+    /// </summary>
+    /// <param name="location">
+    /// The location of the syntax node within the original source text.
+    /// </param>
+    /// <param name="name">
+    /// The name of the fragment that is spread.
+    /// </param>
+    /// <param name="directives">
+    /// The applied directives.
+    /// </param>
+    [Obsolete("Use the constructor overload that accepts arguments.")]
     public FragmentSpreadNode(
         Location? location,
         NameNode name,
         IReadOnlyList<DirectiveNode> directives)
+        : this(location, name, [], directives)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FragmentSpreadNode"/>.
+    /// </summary>
+    /// <param name="location">
+    /// The location of the syntax node within the original source text.
+    /// </param>
+    /// <param name="name">
+    /// The name of the fragment that is spread.
+    /// </param>
+    /// <param name="arguments">
+    /// The values passed to the variables that the spread fragment declares.
+    /// </param>
+    /// <param name="directives">
+    /// The applied directives.
+    /// </param>
+    public FragmentSpreadNode(
+        Location? location,
+        NameNode name,
+        IReadOnlyList<ArgumentNode> arguments,
+        IReadOnlyList<DirectiveNode> directives)
         : base(location, name, directives)
-    { }
+    {
+        Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
 
     /// <inheritdoc/>
     public override SyntaxKind Kind => SyntaxKind.FragmentSpread;
+
+    /// <summary>
+    /// Gets the values passed to the variables that the spread fragment declares.
+    /// </summary>
+    public IReadOnlyList<ArgumentNode> Arguments { get; }
 
     /// <inheritdoc/>
     public override IEnumerable<ISyntaxNode> GetNodes()
     {
         yield return Name;
+
+        foreach (var argument in Arguments)
+        {
+            yield return argument;
+        }
 
         foreach (var directive in Directives)
         {
@@ -46,10 +99,14 @@ public sealed class FragmentSpreadNode : NamedSyntaxNode, ISelectionNode
     /// </returns>
     public override string ToString(bool indented) => SyntaxPrinter.Print(this, indented);
 
-    public FragmentSpreadNode WithLocation(Location? location) => new(location, Name, Directives);
+    public FragmentSpreadNode WithLocation(Location? location)
+        => new(location, Name, Arguments, Directives);
 
-    public FragmentSpreadNode WithName(NameNode name) => new(Location, name, Directives);
+    public FragmentSpreadNode WithName(NameNode name) => new(Location, name, Arguments, Directives);
+
+    public FragmentSpreadNode WithArguments(IReadOnlyList<ArgumentNode> arguments)
+        => new(Location, Name, arguments, Directives);
 
     public FragmentSpreadNode WithDirectives(IReadOnlyList<DirectiveNode> directives)
-        => new(Location, Name, directives);
+        => new(Location, Name, Arguments, directives);
 }

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/SyntaxEqualityComparer.cs
@@ -236,6 +236,7 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
 
     private bool Equals(FragmentSpreadNode x, FragmentSpreadNode y)
         => Equals(x.Name, y.Name)
+            && Equals(x.Arguments, y.Arguments)
             && Equals(x.Directives, y.Directives);
 
     private bool Equals(InlineFragmentNode x, InlineFragmentNode y)
@@ -867,6 +868,12 @@ internal sealed class SyntaxEqualityComparer(bool ignoreDescriptions = false) : 
         var hashCode = new HashCode();
         hashCode.Add(node.Kind);
         hashCode.Add(GetHashCode(node.Name));
+
+        for (var i = 0; i < node.Arguments.Count; i++)
+        {
+            var argument = node.Arguments[i];
+            hashCode.Add(GetHashCode(argument));
+        }
 
         for (var i = 0; i < node.Directives.Count; i++)
         {

--- a/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.QuerySyntax.cs
+++ b/src/HotChocolate/Language/src/Language.SyntaxTree/Utilities/SyntaxSerializer.QuerySyntax.cs
@@ -321,6 +321,11 @@ public sealed partial class SyntaxSerializer
         writer.Write("...");
         writer.WriteName(node.Name);
 
+        if (node.Arguments.Count > 0)
+        {
+            WriteArguments(node.Arguments, writer);
+        }
+
         WriteDirectives(node.Directives, writer);
     }
 

--- a/src/HotChocolate/Language/src/Language.Utf8/ParserOptions.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/ParserOptions.cs
@@ -14,6 +14,9 @@ public sealed class ParserOptions
     /// <param name="allowFragmentVariables">
     /// Defines that the parser shall parse fragment variables.
     /// </param>
+    /// <param name="allowFragmentArguments">
+    /// Defines that the parser shall parse fragment variables and fragment spread arguments.
+    /// </param>
     /// <param name="maxAllowedNodes">
     /// Parser CPU and memory usage is linear to the number of nodes in a document
     /// however in extreme cases it becomes quadratic due to memory exhaustion.
@@ -43,6 +46,7 @@ public sealed class ParserOptions
     public ParserOptions(
         bool noLocations = false,
         bool allowFragmentVariables = false,
+        bool allowFragmentArguments = false,
         int maxAllowedNodes = int.MaxValue,
         int maxAllowedTokens = int.MaxValue,
         int maxAllowedFields = 2048,
@@ -50,7 +54,7 @@ public sealed class ParserOptions
         int maxAllowedRecursionDepth = 200)
     {
         NoLocations = noLocations;
-        Experimental = new(allowFragmentVariables);
+        Experimental = new(allowFragmentVariables, allowFragmentArguments);
         MaxAllowedTokens = maxAllowedTokens;
         MaxAllowedNodes = maxAllowedNodes;
         MaxAllowedFields = maxAllowedFields;

--- a/src/HotChocolate/Language/src/Language.Utf8/ParserOptions.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/ParserOptions.cs
@@ -14,9 +14,6 @@ public sealed class ParserOptions
     /// <param name="allowFragmentVariables">
     /// Defines that the parser shall parse fragment variables.
     /// </param>
-    /// <param name="allowFragmentArguments">
-    /// Defines that the parser shall parse fragment variables and fragment spread arguments.
-    /// </param>
     /// <param name="maxAllowedNodes">
     /// Parser CPU and memory usage is linear to the number of nodes in a document
     /// however in extreme cases it becomes quadratic due to memory exhaustion.
@@ -46,7 +43,60 @@ public sealed class ParserOptions
     public ParserOptions(
         bool noLocations = false,
         bool allowFragmentVariables = false,
-        bool allowFragmentArguments = false,
+        int maxAllowedNodes = int.MaxValue,
+        int maxAllowedTokens = int.MaxValue,
+        int maxAllowedFields = 2048,
+        int maxAllowedDirectives = 4,
+        int maxAllowedRecursionDepth = 200)
+        : this(
+            new ParserOptionsExperimental(allowFragmentVariables),
+            noLocations,
+            maxAllowedNodes,
+            maxAllowedTokens,
+            maxAllowedFields,
+            maxAllowedDirectives,
+            maxAllowedRecursionDepth)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ParserOptions"/>.
+    /// </summary>
+    /// <param name="experimental">
+    /// The experimental parser options.
+    /// </param>
+    /// <param name="noLocations">
+    /// Defines that the parse shall not preserve syntax node locations.
+    /// </param>
+    /// <param name="maxAllowedNodes">
+    /// Parser CPU and memory usage is linear to the number of nodes in a document
+    /// however in extreme cases it becomes quadratic due to memory exhaustion.
+    /// Parsing happens before validation so even invalid queries can burn lots of
+    /// CPU time and memory.
+    ///
+    /// To prevent this you can set a maximum number of nodes allowed within a document.
+    /// </param>
+    /// <param name="maxAllowedTokens">
+    /// Parser CPU and memory usage is linear to the number of tokens in a document
+    /// however in extreme cases it becomes quadratic due to memory exhaustion.
+    /// Parsing happens before validation so even invalid queries can burn lots of
+    /// CPU time and memory.
+    ///
+    /// To prevent this you can set a maximum number of tokens allowed within a document.
+    /// </param>
+    /// <param name="maxAllowedFields">
+    /// The maximum number of fields allowed within a query document.
+    /// </param>
+    /// <param name="maxAllowedDirectives">
+    /// The maximum number of directives allowed per location (e.g. per field, per operation).
+    /// </param>
+    /// <param name="maxAllowedRecursionDepth">
+    /// The maximum allowed recursion depth when parsing a document.
+    /// This prevents stack overflow from deeply nested queries.
+    /// </param>
+    public ParserOptions(
+        ParserOptionsExperimental experimental,
+        bool noLocations = false,
         int maxAllowedNodes = int.MaxValue,
         int maxAllowedTokens = int.MaxValue,
         int maxAllowedFields = 2048,
@@ -54,7 +104,7 @@ public sealed class ParserOptions
         int maxAllowedRecursionDepth = 200)
     {
         NoLocations = noLocations;
-        Experimental = new(allowFragmentVariables, allowFragmentArguments);
+        Experimental = experimental ?? throw new ArgumentNullException(nameof(experimental));
         MaxAllowedTokens = maxAllowedTokens;
         MaxAllowedNodes = maxAllowedNodes;
         MaxAllowedFields = maxAllowedFields;

--- a/src/HotChocolate/Language/src/Language.Utf8/ParserOptionsExperimental.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/ParserOptionsExperimental.cs
@@ -5,9 +5,19 @@ namespace HotChocolate.Language;
 /// </summary>
 public sealed class ParserOptionsExperimental
 {
-    internal ParserOptionsExperimental(
-        bool allowFragmentVariables,
-        bool allowFragmentArguments)
+    /// <summary>
+    /// Initializes a new instance of <see cref="ParserOptionsExperimental"/>.
+    /// </summary>
+    /// <param name="allowFragmentVariables">
+    /// Defines that the parser shall parse fragment variable definitions.
+    /// </param>
+    /// <param name="allowFragmentArguments">
+    /// Defines that the parser shall parse fragment variable definitions and fragment spread
+    /// arguments.
+    /// </param>
+    public ParserOptionsExperimental(
+        bool allowFragmentVariables = false,
+        bool allowFragmentArguments = false)
     {
         AllowFragmentVariables = allowFragmentVariables;
         AllowFragmentArguments = allowFragmentArguments;

--- a/src/HotChocolate/Language/src/Language.Utf8/ParserOptionsExperimental.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/ParserOptionsExperimental.cs
@@ -5,27 +5,59 @@ namespace HotChocolate.Language;
 /// </summary>
 public sealed class ParserOptionsExperimental
 {
-    internal ParserOptionsExperimental(bool allowFragmentVariables)
+    internal ParserOptionsExperimental(
+        bool allowFragmentVariables,
+        bool allowFragmentArguments)
     {
         AllowFragmentVariables = allowFragmentVariables;
+        AllowFragmentArguments = allowFragmentArguments;
     }
 
     /// <summary>
-    /// If enabled, the parser will understand and parse variable
-    /// definitions contained in a fragment definition.They'll be
-    /// represented in the `variableDefinitions` field of the
-    /// FragmentDefinitionNode.
-    ///
-    /// The syntax is identical to normal, query-defined variables.
-    /// For example:
+    /// <para>
+    /// If enabled, the parser will parse the variable definitions of a fragment definition into
+    /// <see cref="FragmentDefinitionNode.VariableDefinitions"/>.
+    /// </para>
+    /// <para>
+    /// A variable definition uses the same syntax as an operation variable.
+    /// </para>
+    /// <code>
+    /// fragment A($var: Boolean = false) on T
+    /// {
+    ///   ...
+    /// }
+    /// </code>
+    /// <para>
+    /// Note: this feature is experimental and may change or be removed in the future. Enabling
+    /// <see cref="AllowFragmentArguments"/> also enables this.
+    /// </para>
+    /// </summary>
+    public bool AllowFragmentVariables { get; }
+
+    /// <summary>
+    /// <para>
+    /// If enabled, the parser will parse the variable definitions of a fragment definition into
+    /// <see cref="FragmentDefinitionNode.VariableDefinitions"/>, and the arguments of a fragment
+    /// spread into <see cref="FragmentSpreadNode.Arguments"/>.
+    /// </para>
+    /// <para>
+    /// A variable definition uses the same syntax as an operation variable, and an argument uses
+    /// the same syntax as a field argument.
+    /// </para>
+    /// <code>
+    /// query
+    /// {
+    ///   ...A(var: true)
+    /// }
     ///
     /// fragment A($var: Boolean = false) on T
     /// {
-    ///    ...
+    ///   ...
     /// }
-    ///
-    /// Note: this feature is experimental and may change or be
-    /// removed in the future.
+    /// </code>
+    /// <para>
+    /// Note: this feature is experimental and may change or be removed in the future.
+    /// </para>
     /// </summary>
-    public bool AllowFragmentVariables { get; }
+    public bool AllowFragmentArguments { get; }
 }

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLOperationParser.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLOperationParser.cs
@@ -48,7 +48,8 @@ public ref struct Utf8GraphQLOperationParser
         options ??= ParserOptions.Default;
         _source = sourceText;
         _metadata = metadata;
-        _allowFragmentVariables = options.Experimental.AllowFragmentVariables;
+        _allowFragmentVariables = options.Experimental.AllowFragmentArguments
+            || options.Experimental.AllowFragmentVariables;
         _maxAllowedNodes = options.MaxAllowedNodes;
         _maxAllowedFields = options.MaxAllowedFields;
         _maxAllowedDirectives = options.MaxAllowedDirectives;

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Fragments.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.Fragments.cs
@@ -93,7 +93,7 @@ public ref partial struct Utf8GraphQLParser
     /// <summary>
     /// Parses a fragment spread.
     /// <see cref="FragmentSpreadNode" />:
-    /// ... FragmentName Directives?
+    /// ... FragmentName Arguments? Directives?
     /// </summary>
     /// <param name="start">
     /// The start token of the current fragment node.
@@ -101,6 +101,14 @@ public ref partial struct Utf8GraphQLParser
     private FragmentSpreadNode ParseFragmentSpread(in TokenInfo start)
     {
         var name = ParseFragmentName();
+
+        // Experimental support for passing arguments to a fragment spread
+        // changes the grammar of FragmentSpread:
+        // ... FragmentName Arguments? Directives?
+        var arguments = _allowFragmentArgs
+            ? ParseArguments(isConstant: false)
+            : s_emptyArguments;
+
         var directives = ParseDirectives(false, isQueryLocation: true);
         var location = CreateLocation(in start);
 
@@ -108,6 +116,7 @@ public ref partial struct Utf8GraphQLParser
         (
             location,
             name,
+            arguments,
             directives
         );
     }

--- a/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.cs
+++ b/src/HotChocolate/Language/src/Language.Utf8/Utf8GraphQLParser.cs
@@ -9,6 +9,7 @@ namespace HotChocolate.Language;
 public ref partial struct Utf8GraphQLParser
 {
     private readonly bool _createLocation;
+    private readonly bool _allowFragmentArgs;
     private readonly bool _allowFragmentVars;
     private readonly int _maxAllowedNodes;
     private readonly int _maxAllowedFields;
@@ -32,7 +33,8 @@ public ref partial struct Utf8GraphQLParser
 
         options ??= ParserOptions.Default;
         _createLocation = !options.NoLocations;
-        _allowFragmentVars = options.Experimental.AllowFragmentVariables;
+        _allowFragmentArgs = options.Experimental.AllowFragmentArguments;
+        _allowFragmentVars = _allowFragmentArgs || options.Experimental.AllowFragmentVariables;
         _maxAllowedNodes = options.MaxAllowedNodes;
         _maxAllowedFields = options.MaxAllowedFields;
         _maxAllowedDirectives = options.MaxAllowedDirectives;
@@ -52,7 +54,8 @@ public ref partial struct Utf8GraphQLParser
 
         options ??= ParserOptions.Default;
         _createLocation = !options.NoLocations;
-        _allowFragmentVars = options.Experimental.AllowFragmentVariables;
+        _allowFragmentArgs = options.Experimental.AllowFragmentArguments;
+        _allowFragmentVars = _allowFragmentArgs || options.Experimental.AllowFragmentVariables;
         _maxAllowedNodes = options.MaxAllowedNodes;
         _maxAllowedFields = options.MaxAllowedFields;
         _maxAllowedDirectives = options.MaxAllowedDirectives;
@@ -72,7 +75,8 @@ public ref partial struct Utf8GraphQLParser
 
         options ??= ParserOptions.Default;
         _createLocation = !options.NoLocations;
-        _allowFragmentVars = options.Experimental.AllowFragmentVariables;
+        _allowFragmentArgs = options.Experimental.AllowFragmentArguments;
+        _allowFragmentVars = _allowFragmentArgs || options.Experimental.AllowFragmentVariables;
         _maxAllowedNodes = options.MaxAllowedNodes;
         _maxAllowedFields = options.MaxAllowedFields;
         _maxAllowedDirectives = options.MaxAllowedDirectives;

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxRewriter~1.cs
@@ -337,14 +337,17 @@ public class SyntaxRewriter<TContext> : ISyntaxRewriter<TContext>
         TContext context)
     {
         var name = RewriteNode(node.Name, context);
+        var arguments = RewriteList(node.Arguments, context);
         var directives = RewriteList(node.Directives, context);
 
         if (!ReferenceEquals(name, node.Name)
+            || !ReferenceEquals(arguments, node.Arguments)
             || !ReferenceEquals(directives, node.Directives))
         {
             return new FragmentSpreadNode(
                 node.Location,
                 name,
+                arguments,
                 directives);
         }
 

--- a/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
+++ b/src/HotChocolate/Language/src/Language.Visitors/SyntaxVisitor~1.VisitationMap.cs
@@ -290,6 +290,17 @@ public partial class SyntaxVisitor<TContext>
             return Break;
         }
 
+        if (_options.VisitArguments)
+        {
+            for (var i = 0; i < node.Arguments.Count; i++)
+            {
+                if (Visit(node.Arguments[i], node, context).IsBreak())
+                {
+                    return Break;
+                }
+            }
+        }
+
         if (_options.VisitDirectives)
         {
             for (var i = 0; i < node.Directives.Count; i++)
@@ -342,6 +353,14 @@ public partial class SyntaxVisitor<TContext>
         if (_options.VisitNames && Visit(node.Name, node, context).IsBreak())
         {
             return Break;
+        }
+
+        for (var i = 0; i < node.VariableDefinitions.Count; i++)
+        {
+            if (Visit(node.VariableDefinitions[i], node, context).IsBreak())
+            {
+                return Break;
+            }
         }
 
         if (Visit(node.TypeCondition, node, context).IsBreak())

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentDefinitionNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentDefinitionNodeTests.cs
@@ -135,4 +135,40 @@ public class FragmentDefinitionNodeTests
         Assert.Equal(cHash, dHash);
         Assert.NotEqual(aHash, dHash);
     }
+
+    [Fact]
+    public void GetNodes_Should_YieldVariableDefinitionsBetweenNameAndTypeCondition()
+    {
+        // arrange
+        var a = new FragmentDefinitionNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            description: null,
+            new List<VariableDefinitionNode>
+            {
+                new(
+                    null,
+                    new VariableNode("bb"),
+                    description: null,
+                    new NamedTypeNode("Int"),
+                    defaultValue: null,
+                    new List<DirectiveNode>())
+            },
+            new NamedTypeNode("cc"),
+            new List<DirectiveNode>(),
+            new SelectionSetNode(new List<ISelectionNode>()));
+
+        // act
+        var kinds = a.GetNodes().Select(t => t.Kind).ToArray();
+
+        // assert
+        Assert.Equal(
+            [
+                SyntaxKind.Name,
+                SyntaxKind.VariableDefinition,
+                SyntaxKind.NamedType,
+                SyntaxKind.SelectionSet
+            ],
+            kinds);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
+++ b/src/HotChocolate/Language/test/Language.SyntaxTree.Tests/FragmentSpreadNodeTests.cs
@@ -9,14 +9,17 @@ public class FragmentSpreadNodeTests
         var a = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var b = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var c = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("bb"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
 
         // act
@@ -39,14 +42,17 @@ public class FragmentSpreadNodeTests
         var a = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var b = new FragmentSpreadNode(
             new Location(2, 2, 2, 2),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var c = new FragmentSpreadNode(
             new Location(3, 3, 3, 3),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>
             {
                 new("bb")
@@ -72,18 +78,22 @@ public class FragmentSpreadNodeTests
         var a = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var b = new FragmentSpreadNode(
             new Location(2, 2, 2, 2),
             new("aa"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var c = new FragmentSpreadNode(
             new Location(1, 1, 1, 1),
             new("bb"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
         var d = new FragmentSpreadNode(
             new Location(2, 2, 2, 2),
             new("bb"),
+            new List<ArgumentNode>(0),
             new List<DirectiveNode>(0));
 
         // act
@@ -97,5 +107,195 @@ public class FragmentSpreadNodeTests
         Assert.NotEqual(aHash, cHash);
         Assert.Equal(cHash, dHash);
         Assert.NotEqual(aHash, dHash);
+    }
+
+    [Fact]
+    public void Equals_Should_ReturnFalse_When_ArgumentsDiffer()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+        var b = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+        var c = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(2))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var abResult = SyntaxComparer.BySyntax.Equals(a, b);
+        var acResult = SyntaxComparer.BySyntax.Equals(a, c);
+
+        // assert
+        Assert.True(abResult);
+        Assert.False(acResult);
+    }
+
+    [Fact]
+    public void GetHashCode_Should_ReturnDifferentHash_When_ArgumentsDiffer()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+        var b = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(2))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var aHash = SyntaxComparer.BySyntax.GetHashCode(a);
+        var bHash = SyntaxComparer.BySyntax.GetHashCode(b);
+
+        // assert
+        Assert.NotEqual(aHash, bHash);
+    }
+
+    [Fact]
+    public void WithName_Should_PreserveArguments()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var b = a.WithName(new NameNode("cc"));
+
+        // assert
+        var argument = Assert.Single(b.Arguments);
+        Assert.Equal("bb: 1", argument.ToString());
+    }
+
+    [Fact]
+    public void WithDirectives_Should_PreserveArguments()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var b = a.WithDirectives(new List<DirectiveNode> { new("cc") });
+
+        // assert
+        var argument = Assert.Single(b.Arguments);
+        Assert.Equal("bb: 1", argument.ToString());
+    }
+
+    [Fact]
+    public void WithLocation_Should_PreserveArguments()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var b = a.WithLocation(new Location(2, 2, 2, 2));
+
+        // assert
+        var argument = Assert.Single(b.Arguments);
+        Assert.Equal("bb: 1", argument.ToString());
+    }
+
+    [Fact]
+    public void WithArguments_Should_ReplaceArguments()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode>(0));
+
+        // act
+        var b = a.WithArguments(new List<ArgumentNode> { new("cc", new IntValueNode(2)) });
+
+        // assert
+        var argument = Assert.Single(b.Arguments);
+        Assert.Equal("cc: 2", argument.ToString());
+    }
+
+    [Fact]
+    public void GetNodes_Should_YieldArgumentsBetweenNameAndDirectives()
+    {
+        // arrange
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<ArgumentNode>
+            {
+                new("bb", new IntValueNode(1))
+            },
+            new List<DirectiveNode> { new("cc") });
+
+        // act
+        var kinds = a.GetNodes().Select(t => t.Kind).ToArray();
+
+        // assert
+        Assert.Equal(
+            [SyntaxKind.Name, SyntaxKind.Argument, SyntaxKind.Directive],
+            kinds);
+    }
+
+    [Fact]
+    public void Constructor_Should_YieldEmptyArguments_When_ArgumentsAreNotProvided()
+    {
+        // act
+#pragma warning disable CS0618 // The obsolete constructor overload is under test.
+        var a = new FragmentSpreadNode(
+            new Location(1, 1, 1, 1),
+            new("aa"),
+            new List<DirectiveNode> { new("bb") });
+#pragma warning restore CS0618
+
+        // assert
+        Assert.Empty(a.Arguments);
+        var directive = Assert.Single(a.Directives);
+        Assert.Equal("bb", directive.Name.Value);
     }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/ParserOptionsTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/ParserOptionsTests.cs
@@ -1,0 +1,42 @@
+namespace HotChocolate.Language;
+
+public class ParserOptionsTests
+{
+    [Fact]
+    public void Constructor_Should_UseTheGivenExperimentalOptions_When_ExperimentalIsProvided()
+    {
+        // arrange
+        var experimental = new ParserOptionsExperimental(allowFragmentArguments: true);
+
+        // act
+        var options = new ParserOptions(experimental, maxAllowedFields: 10);
+
+        // assert
+        Assert.Same(experimental, options.Experimental);
+        Assert.True(options.Experimental.AllowFragmentArguments);
+        Assert.Equal(10, options.MaxAllowedFields);
+        Assert.False(options.NoLocations);
+    }
+
+    [Fact]
+    public void Constructor_Should_Throw_When_ExperimentalIsNull()
+    {
+        // act
+        static void Action() => _ = new ParserOptions(experimental: null!);
+
+        // assert
+        var exception = Assert.Throws<ArgumentNullException>(Action);
+        Assert.Equal("experimental", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_Should_LeaveFragmentArgumentsDisabled_When_ExperimentalIsNotProvided()
+    {
+        // act
+        var options = new ParserOptions(allowFragmentVariables: true);
+
+        // assert
+        Assert.True(options.Experimental.AllowFragmentVariables);
+        Assert.False(options.Experimental.AllowFragmentArguments);
+    }
+}

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
@@ -790,7 +790,7 @@ public class QueryParserTests
         // act
         var document = Utf8GraphQLParser.Parse(
             query,
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // assert
         var operation = (OperationDefinitionNode)document.Definitions[0];
@@ -808,7 +808,7 @@ public class QueryParserTests
         // act
         var document = Utf8GraphQLParser.Parse(
             query,
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // assert
         var fragment = (FragmentDefinitionNode)document.Definitions[0];
@@ -825,7 +825,7 @@ public class QueryParserTests
         // act
         var document = Utf8GraphQLParser.Parse(
             query,
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // assert
         var operation = (OperationDefinitionNode)document.Definitions[0];

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/QueryParserTests.cs
@@ -780,4 +780,73 @@ public class QueryParserTests
         // assert
         document.ToString().MatchSnapshot(extension: ".graphql");
     }
+
+    [Fact]
+    public void Parse_Should_ReadSpreadArguments_When_FragmentArgumentsAllowed()
+    {
+        // arrange
+        const string query = "{ ...Bar(baz: 1) }";
+
+        // act
+        var document = Utf8GraphQLParser.Parse(
+            query,
+            new ParserOptions(allowFragmentArguments: true));
+
+        // assert
+        var operation = (OperationDefinitionNode)document.Definitions[0];
+        var spread = (FragmentSpreadNode)operation.SelectionSet.Selections[0];
+        var argument = Assert.Single(spread.Arguments);
+        Assert.Equal("baz: 1", argument.ToString());
+    }
+
+    [Fact]
+    public void Parse_Should_ReadVariableDefinitions_When_FragmentArgumentsAllowed()
+    {
+        // arrange
+        const string query = "fragment Bar($baz: Int!) on Foo { id }";
+
+        // act
+        var document = Utf8GraphQLParser.Parse(
+            query,
+            new ParserOptions(allowFragmentArguments: true));
+
+        // assert
+        var fragment = (FragmentDefinitionNode)document.Definitions[0];
+        var variableDefinition = Assert.Single(fragment.VariableDefinitions);
+        Assert.Equal("$baz: Int!", variableDefinition.ToString());
+    }
+
+    [Fact]
+    public void Parse_Should_ReadEmptyArguments_When_SpreadHasNoArguments()
+    {
+        // arrange
+        const string query = "{ ...Bar }";
+
+        // act
+        var document = Utf8GraphQLParser.Parse(
+            query,
+            new ParserOptions(allowFragmentArguments: true));
+
+        // assert
+        var operation = (OperationDefinitionNode)document.Definitions[0];
+        var spread = (FragmentSpreadNode)operation.SelectionSet.Selections[0];
+        Assert.Empty(spread.Arguments);
+    }
+
+    [Fact]
+    public void Parse_Should_Throw_When_SpreadHasArgumentsAndFragmentArgumentsNotAllowed()
+    {
+        // arrange
+        const string query = "{ ...Bar(baz: 1) }";
+
+        // act
+        static void Action() => Utf8GraphQLParser.Parse(query);
+
+        // assert
+        Assert
+            .Throws<SyntaxException>(Action)
+            .Message
+            .MatchInlineSnapshot(
+                "Expected a `Name`-token, but found a `LeftParenthesis`-token.");
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8SyntaxFormatterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8SyntaxFormatterTests.cs
@@ -441,7 +441,7 @@ public class Utf8SyntaxFormatterTests
         // arrange
         var document = Utf8GraphQLOperationParser.Parse(
             Encoding.UTF8.GetBytes("fragment F($a: Int = 1) on Thing { id(x: $a) }"),
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // act
         var writer = new ArrayBufferWriter<byte>();

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8SyntaxFormatterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/Utf8SyntaxFormatterTests.cs
@@ -436,6 +436,22 @@ public class Utf8SyntaxFormatterTests
     }
 
     [Fact]
+    public void Format_Should_EmitVariableDefinitions_When_FragmentArgumentsAllowed()
+    {
+        // arrange
+        var document = Utf8GraphQLOperationParser.Parse(
+            Encoding.UTF8.GetBytes("fragment F($a: Int = 1) on Thing { id(x: $a) }"),
+            new ParserOptions(allowFragmentArguments: true));
+
+        // act
+        var writer = new ArrayBufferWriter<byte>();
+        document.Format(writer, indented: false);
+
+        // assert
+        Text(writer).MatchInlineSnapshot("fragment F($a:Int=1)on Thing{id(x:$a)}");
+    }
+
+    [Fact]
     public void Format_Should_EmitKeyword_When_OperationIsShorthandOrMutation()
     {
         // arrange

--- a/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/KitchenSinkParserTests.ParseFacebookKitchenSinkQuery.snap
+++ b/src/HotChocolate/Language/test/Language.Tests/Parser/__snapshots__/KitchenSinkParserTests.ParseFacebookKitchenSinkQuery.snap
@@ -552,6 +552,7 @@ AST:
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
@@ -129,4 +129,36 @@ public class SyntaxPrinterTests
         // assert
         Assert.Equal(query, printed);
     }
+
+    [Fact]
+    public void Serialize_FragmentSpreadWithArguments_InOutShouldBeTheSame()
+    {
+        // arrange
+        const string query = "{ ...Foo(bar: 1, baz: [\"abc\"]) }";
+
+        var queryDocument = Utf8GraphQLParser.Parse(query,
+            new ParserOptions(allowFragmentArguments: true));
+
+        // act
+        var printed = queryDocument.Print(false);
+
+        // assert
+        Assert.Equal(query, printed);
+    }
+
+    [Fact]
+    public void Serialize_FragmentSpreadWithArgumentsAndDirective_InOutShouldBeTheSame()
+    {
+        // arrange
+        const string query = "{ ...Foo(bar: $bar) @include(if: true) }";
+
+        var queryDocument = Utf8GraphQLParser.Parse(query,
+            new ParserOptions(allowFragmentArguments: true));
+
+        // act
+        var printed = queryDocument.Print(false);
+
+        // assert
+        Assert.Equal(query, printed);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Utilities/SyntaxPrinterTests.cs
@@ -137,7 +137,7 @@ public class SyntaxPrinterTests
         const string query = "{ ...Foo(bar: 1, baz: [\"abc\"]) }";
 
         var queryDocument = Utf8GraphQLParser.Parse(query,
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // act
         var printed = queryDocument.Print(false);
@@ -153,7 +153,7 @@ public class SyntaxPrinterTests
         const string query = "{ ...Foo(bar: $bar) @include(if: true) }";
 
         var queryDocument = Utf8GraphQLParser.Parse(query,
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // act
         var printed = queryDocument.Print(false);

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
@@ -121,4 +121,37 @@ public class SyntaxRewriterTests
         // assert
         Assert.Equal("extend directive @foo @b", document?.ToString(indented: false));
     }
+
+    [Fact]
+    public void Rewrite_Should_PreserveFragmentSpreadArguments_When_SpreadIsUnchanged()
+    {
+        // arrange
+        var document = Parse(
+            "{ ...Foo(bar: 1) }",
+            new ParserOptions(allowFragmentArguments: true));
+
+        // act
+        var rewriter = SyntaxRewriter.Create(static node => node);
+        var rewritten = (DocumentNode?)rewriter.Rewrite(document, context: null);
+
+        // assert
+        Assert.Equal("{ ...Foo(bar: 1) }", rewritten?.Print(indented: false));
+    }
+
+    [Fact]
+    public void Rewrite_Should_RewriteFragmentSpreadArguments_When_ArgumentValueChanges()
+    {
+        // arrange
+        var document = Parse(
+            "{ ...Foo(bar: 1) }",
+            new ParserOptions(allowFragmentArguments: true));
+
+        // act
+        var rewriter = SyntaxRewriter.Create(
+            static node => node is IntValueNode ? new IntValueNode(2) : node);
+        var rewritten = (DocumentNode?)rewriter.Rewrite(document, context: null);
+
+        // assert
+        Assert.Equal("{ ...Foo(bar: 2) }", rewritten?.Print(indented: false));
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxRewriterTests.cs
@@ -128,7 +128,7 @@ public class SyntaxRewriterTests
         // arrange
         var document = Parse(
             "{ ...Foo(bar: 1) }",
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // act
         var rewriter = SyntaxRewriter.Create(static node => node);
@@ -144,7 +144,7 @@ public class SyntaxRewriterTests
         // arrange
         var document = Parse(
             "{ ...Foo(bar: 1) }",
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         // act
         var rewriter = SyntaxRewriter.Create(

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
@@ -97,7 +97,7 @@ public class SyntaxVisitorTests
 
         var document = Parse(
             "{ ...Foo(bar: 1, baz: 2) }",
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         var visitor = Create<object?>(
             enter: (n, _) =>
@@ -127,7 +127,7 @@ public class SyntaxVisitorTests
 
         var document = Parse(
             "{ ...Foo(bar: 1) }",
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         var visitor = Create<object?>(
             enter: (n, _) =>
@@ -157,7 +157,7 @@ public class SyntaxVisitorTests
 
         var document = Parse(
             "fragment Foo($bar: Int!, $baz: String) on Thing { id }",
-            new ParserOptions(allowFragmentArguments: true));
+            new ParserOptions(new ParserOptionsExperimental(allowFragmentArguments: true)));
 
         var visitor = Create<object?>(
             enter: (n, _) =>

--- a/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
+++ b/src/HotChocolate/Language/test/Language.Tests/Visitors/SyntaxVisitorTests.cs
@@ -88,4 +88,93 @@ public class SyntaxVisitorTests
         // assert
         Assert.Equal("@foo", Assert.Single(list));
     }
+
+    [Fact]
+    public void Visit_Should_VisitFragmentSpreadArguments_When_VisitArgumentsIsEnabled()
+    {
+        // arrange
+        var list = new List<string>();
+
+        var document = Parse(
+            "{ ...Foo(bar: 1, baz: 2) }",
+            new ParserOptions(allowFragmentArguments: true));
+
+        var visitor = Create<object?>(
+            enter: (n, _) =>
+            {
+                if (n is ArgumentNode argument)
+                {
+                    list.Add(argument.Name.Value);
+                }
+
+                return SyntaxVisitor.Continue;
+            },
+            defaultAction: SyntaxVisitor.Continue,
+            options: new() { VisitArguments = true });
+
+        // act
+        visitor.Visit(document, null);
+
+        // assert
+        Assert.Equal(["bar", "baz"], list);
+    }
+
+    [Fact]
+    public void Visit_Should_NotVisitFragmentSpreadArguments_When_VisitArgumentsIsDisabled()
+    {
+        // arrange
+        var list = new List<string>();
+
+        var document = Parse(
+            "{ ...Foo(bar: 1) }",
+            new ParserOptions(allowFragmentArguments: true));
+
+        var visitor = Create<object?>(
+            enter: (n, _) =>
+            {
+                if (n is ArgumentNode argument)
+                {
+                    list.Add(argument.Name.Value);
+                }
+
+                return SyntaxVisitor.Continue;
+            },
+            defaultAction: SyntaxVisitor.Continue,
+            options: new() { VisitArguments = false });
+
+        // act
+        visitor.Visit(document, null);
+
+        // assert
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void Visit_Should_VisitFragmentDefinitionVariableDefinitions()
+    {
+        // arrange
+        var list = new List<string>();
+
+        var document = Parse(
+            "fragment Foo($bar: Int!, $baz: String) on Thing { id }",
+            new ParserOptions(allowFragmentArguments: true));
+
+        var visitor = Create<object?>(
+            enter: (n, _) =>
+            {
+                if (n is VariableDefinitionNode variableDefinition)
+                {
+                    list.Add(variableDefinition.Variable.Name.Value);
+                }
+
+                return SyntaxVisitor.Continue;
+            },
+            defaultAction: SyntaxVisitor.Continue);
+
+        // act
+        visitor.Visit(document, null);
+
+        // assert
+        Assert.Equal(["bar", "baz"], list);
+    }
 }

--- a/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Id_As_Name.snap
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Id_As_Name.snap
@@ -483,6 +483,7 @@
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_AllProps_No_Cache.snap
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_AllProps_No_Cache.snap
@@ -523,6 +523,7 @@ Query:
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_No_Cache.snap
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_No_Cache.snap
@@ -483,6 +483,7 @@
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_With_Cache.snap
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Parse_Kitchen_Sink_Query_With_Cache.snap
@@ -483,6 +483,7 @@
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Utf8GraphQLRequestParser_Parse.snap
+++ b/src/HotChocolate/Language/test/Language.Web.Tests/__snapshots__/Utf8GraphQLRequestParserTests.Utf8GraphQLRequestParser_Parse.snap
@@ -483,6 +483,7 @@
                                   },
                                   {
                                     "Kind": "FragmentSpread",
+                                    "Arguments": [],
                                     "Location": {
                                       "Start": 481,
                                       "End": 498,

--- a/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
+++ b/src/HotChocolate/Utilities/src/Utilities.Introspection/IntrospectionQueryBuilder.cs
@@ -99,6 +99,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("FullType"),
+                        Array.Empty<ArgumentNode>(),
                         Array.Empty<DirectiveNode>())
                 }));
 
@@ -209,6 +210,7 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
+                            Array.Empty<ArgumentNode>(),
                             Array.Empty<DirectiveNode>()),
                         new FieldNode("isDeprecated"),
                         new FieldNode("deprecationReason")
@@ -224,6 +226,7 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
+                            Array.Empty<ArgumentNode>(),
                             Array.Empty<DirectiveNode>())
                     }));
 
@@ -239,6 +242,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
+                        Array.Empty<ArgumentNode>(),
                         Array.Empty<DirectiveNode>())
                 }));
 
@@ -258,6 +262,7 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
+                            Array.Empty<ArgumentNode>(),
                             Array.Empty<DirectiveNode>()),
                         new FieldNode("isDeprecated"),
                         new FieldNode("deprecationReason")
@@ -273,6 +278,7 @@ internal static class IntrospectionQueryBuilder
                         new FragmentSpreadNode(
                             null,
                             new NameNode("InputValue"),
+                            Array.Empty<ArgumentNode>(),
                             Array.Empty<DirectiveNode>())
                     }));
 
@@ -288,6 +294,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
+                        Array.Empty<ArgumentNode>(),
                         Array.Empty<DirectiveNode>())
                 }));
 
@@ -323,6 +330,7 @@ internal static class IntrospectionQueryBuilder
                     new FragmentSpreadNode(
                         null,
                         new NameNode("TypeRef"),
+                        Array.Empty<ArgumentNode>(),
                         Array.Empty<DirectiveNode>())
                 }));
 


### PR DESCRIPTION
## Summary

- Parses fragment spread arguments (`...F(size: 10)`) into a new `FragmentSpreadNode.Arguments`, gated behind the experimental `allowFragmentArguments` parser option. It is off by default, so existing documents are unaffected.
- Carries arguments through the rest of the syntax layer: equality and hashing, the query serializer, the visitation map, and `SyntaxRewriter`, which would otherwise silently drop them when rebuilding a spread. `FragmentDefinitionNode` now also walks its own `VariableDefinitions`, mirroring `OperationDefinitionNode`.
- Keeps the three-parameter `FragmentSpreadNode` constructor as an `[Obsolete]` overload that delegates with an empty argument list, so this is non-breaking on the 16.x line. Enabling `allowFragmentArguments` implies `allowFragmentVariables` in both `Utf8GraphQLParser` and `Utf8GraphQLOperationParser`, so one options object means the same thing in both.

This is the syntax layer only. Validation rules and the rewrite pass that substitutes arguments into inlined selection sets are follow-ups; no server configuration can reach either execution engine with a fragment-argument document yet, because neither request-parser options type exposes the flag.

## Test plan

- `dotnet test src/HotChocolate/Language/HotChocolate.Language.slnx` passes 4224 tests across net8.0, net9.0, net10.0, and net11.0.
- New parser tests cover spreads with arguments being accepted with the flag on and rejected with it off, and `Utf8GraphQLOperationParser` honouring the same option as `Utf8GraphQLParser`.
- Round-trip printing tests assert a spread re-prints with its arguments before its directives.
- Visitor, rewriter, and node tests pin that arguments are visited, rewritten, and preserved across every `With*` call; each was mutation-checked, so removing the production code makes them fail.
- Six AST snapshots each gain one `"Arguments": []` line. The introspection query builder's printed-GraphQL snapshots are unchanged, confirming its call-site update is behaviour-neutral.
