### PR TITLE
Validate fragment arguments and scope fragment variables

### DIFF
--- a/src/HotChocolate/Core/src/Validation/DocumentValidatorContext.cs
+++ b/src/HotChocolate/Core/src/Validation/DocumentValidatorContext.cs
@@ -206,7 +206,8 @@ public sealed class DocumentValidatorContext : IFeatureProvider
     /// </param>
     public bool IsFragmentVariable(string variableName)
     {
-        for (var i = 0; i < _shadowedVariables.Count; i++)
+        // The innermost scope is at the end of the list.
+        for (var i = _shadowedVariables.Count - 1; i >= 0; i--)
         {
             if (_shadowedVariables[i].Name.Equals(variableName, StringComparison.Ordinal))
             {

--- a/src/HotChocolate/Core/src/Validation/DocumentValidatorContext.cs
+++ b/src/HotChocolate/Core/src/Validation/DocumentValidatorContext.cs
@@ -15,6 +15,8 @@ public sealed class DocumentValidatorContext : IFeatureProvider
 {
     private readonly List<IError> _errors = [];
     private readonly PooledFeatureCollection _features;
+    private readonly List<int> _fragmentVariableScopes = [];
+    private readonly List<(string Name, VariableDefinitionNode? Shadowed)> _shadowedVariables = [];
     private ISchemaDefinition? _schema;
     private int _maxAllowedErrors;
     private int _maxLocationsPerError;
@@ -172,6 +174,81 @@ public sealed class DocumentValidatorContext : IFeatureProvider
     }
 
     /// <summary>
+    /// Brings the variables that <paramref name="fragment"/> declares into scope. A declaration
+    /// shadows a variable of the same name until the scope is left.
+    /// </summary>
+    /// <param name="fragment">
+    /// The fragment definition whose variables shall be brought into scope.
+    /// </param>
+    public void EnterFragmentVariableScope(FragmentDefinitionNode fragment)
+    {
+        _fragmentVariableScopes.Add(_shadowedVariables.Count);
+
+        var variableDefinitions = fragment.VariableDefinitions;
+
+        for (var i = 0; i < variableDefinitions.Count; i++)
+        {
+            var variableDefinition = variableDefinitions[i];
+            var variableName = variableDefinition.Variable.Name.Value;
+
+            Variables.TryGetValue(variableName, out var shadowed);
+            _shadowedVariables.Add((variableName, shadowed));
+            Variables[variableName] = variableDefinition;
+        }
+    }
+
+    /// <summary>
+    /// Defines whether a fragment that is currently in scope declares
+    /// <paramref name="variableName"/>.
+    /// </summary>
+    /// <param name="variableName">
+    /// The name of the variable, without the leading dollar sign.
+    /// </param>
+    public bool IsFragmentVariable(string variableName)
+    {
+        for (var i = 0; i < _shadowedVariables.Count; i++)
+        {
+            if (_shadowedVariables[i].Name.Equals(variableName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Takes the variables of the innermost fragment scope out of scope and restores the
+    /// declarations they shadowed.
+    /// </summary>
+    public void LeaveFragmentVariableScope()
+    {
+        if (_fragmentVariableScopes.Count == 0)
+        {
+            return;
+        }
+
+        var start = _fragmentVariableScopes[^1];
+        _fragmentVariableScopes.RemoveAt(_fragmentVariableScopes.Count - 1);
+
+        for (var i = _shadowedVariables.Count - 1; i >= start; i--)
+        {
+            var (variableName, shadowed) = _shadowedVariables[i];
+
+            if (shadowed is null)
+            {
+                Variables.Remove(variableName);
+            }
+            else
+            {
+                Variables[variableName] = shadowed;
+            }
+        }
+
+        _shadowedVariables.RemoveRange(start, _shadowedVariables.Count - start);
+    }
+
+    /// <summary>
     /// Reports an error.
     /// </summary>
     /// <param name="error">
@@ -204,6 +281,8 @@ public sealed class DocumentValidatorContext : IFeatureProvider
         Fields.Clear();
         InputFields.Clear();
         VisitedFragments.Clear();
+        _shadowedVariables.Clear();
+        _fragmentVariableScopes.Clear();
 
         // we just make sure that all features are reset but we do not want
         // to fully reset the feature collection.
@@ -232,6 +311,8 @@ public sealed class DocumentValidatorContext : IFeatureProvider
         SelectionSets.Clear();
         Fragments.Clear();
         Variables.Clear();
+        _shadowedVariables.Clear();
+        _fragmentVariableScopes.Clear();
         Types.Clear();
         Directives.Clear();
         OutputFields.Clear();

--- a/src/HotChocolate/Core/src/Validation/ErrorHelper.cs
+++ b/src/HotChocolate/Core/src/Validation/ErrorHelper.cs
@@ -38,6 +38,21 @@ internal static class ErrorHelper
                 .Build();
         }
 
+        public IError FragmentVariableNotUsed(
+            FragmentDefinitionNode node,
+            IEnumerable<string> unusedVariables)
+        {
+            return ErrorBuilder.New()
+                .SetMessage(
+                    Resources.ErrorHelper_FragmentVariableNotUsed,
+                    node.Name.Value,
+                    string.Join(", ", unusedVariables))
+                .AddLocation(node)
+                .SetPath(context.CreateErrorPath())
+                .SpecifiedBy("sec-All-Variables-Used")
+                .Build();
+        }
+
         public IError VariableNotDeclared(
             OperationDefinitionNode node,
             IEnumerable<string> usedVariables)
@@ -470,7 +485,8 @@ internal static class ErrorHelper
         public IError ArgumentNotUnique(
             ArgumentNode node,
             SchemaCoordinate? field = null,
-            IDirectiveDefinition? directive = null)
+            IDirectiveDefinition? directive = null,
+            string? fragment = null)
         {
             var builder = ErrorBuilder.New()
                 .SetMessage(Resources.ErrorHelper_ArgumentNotUnique)
@@ -489,6 +505,11 @@ internal static class ErrorHelper
                 builder.SetExtension("directive", directive.Name);
             }
 
+            if (fragment is not null)
+            {
+                builder.SetExtension("fragment", fragment);
+            }
+
             return builder
                 .SetExtension("argument", node.Name.Value)
                 .SpecifiedBy("sec-Argument-Uniqueness")
@@ -499,7 +520,8 @@ internal static class ErrorHelper
             ISyntaxNode node,
             string argumentName,
             SchemaCoordinate? field = null,
-            IDirectiveDefinition? directive = null)
+            IDirectiveDefinition? directive = null,
+            string? fragment = null)
         {
             var builder = ErrorBuilder.New()
                 .SetMessage(Resources.ErrorHelper_ArgumentRequired, argumentName)
@@ -518,6 +540,11 @@ internal static class ErrorHelper
                 builder.SetExtension("directive", directive.Name);
             }
 
+            if (fragment is not null)
+            {
+                builder.SetExtension("fragment", fragment);
+            }
+
             return builder
                 .SetExtension("argument", argumentName)
                 .SpecifiedBy("sec-Required-Arguments")
@@ -527,7 +554,8 @@ internal static class ErrorHelper
         public IError ArgumentDoesNotExist(
             ArgumentNode node,
             SchemaCoordinate? field = null,
-            IDirectiveDefinition? directive = null)
+            IDirectiveDefinition? directive = null,
+            string? fragment = null)
         {
             var builder = ErrorBuilder.New()
                 .SetMessage(Resources.ErrorHelper_ArgumentDoesNotExist, node.Name.Value)
@@ -546,9 +574,14 @@ internal static class ErrorHelper
                 builder.SetExtension("directive", directive.Name);
             }
 
+            if (fragment is not null)
+            {
+                builder.SetExtension("fragment", fragment);
+            }
+
             return builder
                 .SetExtension("argument", node.Name.Value)
-                .SpecifiedBy("sec-Required-Arguments")
+                .SpecifiedBy("sec-Argument-Names")
                 .Build();
         }
 

--- a/src/HotChocolate/Core/src/Validation/FragmentArguments.cs
+++ b/src/HotChocolate/Core/src/Validation/FragmentArguments.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using HotChocolate.Language;
+using HotChocolate.Types;
+
+namespace HotChocolate.Validation;
+
+/// <summary>
+/// Resolves the declaration that an argument of a fragment spread refers to.
+/// </summary>
+internal static class FragmentArguments
+{
+    /// <summary>
+    /// Resolves the type that the argument named <paramref name="argumentName"/> must satisfy.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> if the spread targets an unknown fragment, if the fragment does
+    /// not declare a variable with that name, or if the declared type is not in the schema.
+    /// </returns>
+    public static bool TryGetArgumentType(
+        DocumentValidatorContext context,
+        FragmentSpreadNode spread,
+        string argumentName,
+        [NotNullWhen(true)] out IType? argumentType)
+    {
+        if (TryGetVariableDefinition(context, spread, argumentName, out var variableDefinition))
+        {
+            return context.Schema.Types.TryGetType(variableDefinition.Type, out argumentType);
+        }
+
+        argumentType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the variable definition that the argument named <paramref name="argumentName"/>
+    /// provides a value for.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> if the spread targets an unknown fragment or if the fragment does
+    /// not declare a variable with that name.
+    /// </returns>
+    public static bool TryGetVariableDefinition(
+        DocumentValidatorContext context,
+        FragmentSpreadNode spread,
+        string argumentName,
+        [NotNullWhen(true)] out VariableDefinitionNode? variableDefinition)
+    {
+        if (context.Fragments.TryGet(spread, out var fragment))
+        {
+            var variableDefinitions = fragment.VariableDefinitions;
+
+            for (var i = 0; i < variableDefinitions.Count; i++)
+            {
+                var candidate = variableDefinitions[i];
+
+                if (candidate.Variable.Name.Value.Equals(argumentName, StringComparison.Ordinal))
+                {
+                    variableDefinition = candidate;
+                    return true;
+                }
+            }
+        }
+
+        variableDefinition = null;
+        return false;
+    }
+}

--- a/src/HotChocolate/Core/src/Validation/Properties/Resources.Designer.cs
+++ b/src/HotChocolate/Core/src/Validation/Properties/Resources.Designer.cs
@@ -195,6 +195,12 @@ namespace HotChocolate.Validation.Properties {
             }
         }
         
+        internal static string ErrorHelper_FragmentVariableNotUsed {
+            get {
+                return ResourceManager.GetString("ErrorHelper_FragmentVariableNotUsed", resourceCulture);
+            }
+        }
+        
         internal static string ErrorHelper_InputFieldAmbiguous {
             get {
                 return ResourceManager.GetString("ErrorHelper_InputFieldAmbiguous", resourceCulture);

--- a/src/HotChocolate/Core/src/Validation/Properties/Resources.resx
+++ b/src/HotChocolate/Core/src/Validation/Properties/Resources.resx
@@ -173,6 +173,9 @@
   <data name="ErrorHelper_FragmentOnlyCompositeType" xml:space="preserve">
     <value>Fragments can only be declared on unions, interfaces, and objects.</value>
   </data>
+  <data name="ErrorHelper_FragmentVariableNotUsed" xml:space="preserve">
+    <value>The following variables of fragment `{0}` were not used: {1}.</value>
+  </data>
   <data name="ErrorHelper_InputFieldAmbiguous" xml:space="preserve">
     <value>There can be only one input field named `{0}`.</value>
   </data>

--- a/src/HotChocolate/Core/src/Validation/Rules/ArgumentVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ArgumentVisitor.cs
@@ -115,6 +115,76 @@ internal sealed class ArgumentVisitor()
         return Continue;
     }
 
+    protected override ISyntaxVisitorAction Enter(
+        FragmentSpreadNode node,
+        DocumentValidatorContext context)
+    {
+        if (context.Fragments.TryGet(node, out var fragment))
+        {
+            ValidateFragmentArguments(context, node, fragment);
+            return Continue;
+        }
+
+        context.UnexpectedErrorsDetected = true;
+        return Skip;
+    }
+
+    private static void ValidateFragmentArguments(
+        DocumentValidatorContext context,
+        FragmentSpreadNode node,
+        FragmentDefinitionNode fragment)
+    {
+        var fragmentName = fragment.Name.Value;
+        var variableDefinitions = fragment.VariableDefinitions;
+        var argumentNames = context.Features.GetRequired<ArgumentVisitorFeature>().ArgumentNames;
+        argumentNames.Clear();
+
+        foreach (var argument in node.Arguments)
+        {
+            if (FragmentArguments.TryGetVariableDefinition(
+                context,
+                node,
+                argument.Name.Value,
+                out var variableDefinition))
+            {
+                if (!argumentNames.Add(argument.Name.Value))
+                {
+                    context.ReportError(
+                        context.ArgumentNotUnique(argument, fragment: fragmentName));
+                }
+
+                if (variableDefinition.Type.IsNonNullType()
+                    && variableDefinition.DefaultValue.IsNull()
+                    && argument.Value.IsNull())
+                {
+                    context.ReportError(
+                        context.ArgumentRequired(
+                            argument,
+                            argument.Name.Value,
+                            fragment: fragmentName));
+                }
+            }
+            else
+            {
+                context.ReportError(
+                    context.ArgumentDoesNotExist(argument, fragment: fragmentName));
+            }
+        }
+
+        foreach (var variableDefinition in variableDefinitions)
+        {
+            var variableName = variableDefinition.Variable.Name.Value;
+
+            if (variableDefinition.Type.IsNonNullType()
+                && variableDefinition.DefaultValue.IsNull()
+                && argumentNames.Add(variableName))
+            {
+                context.ReportError(
+                    context.ArgumentRequired(node, variableName, fragment: fragmentName));
+            }
+        }
+    }
+
     private static void ValidateArguments(
         DocumentValidatorContext context,
         ISyntaxNode node,

--- a/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/ValueVisitor.cs
@@ -145,6 +145,23 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         ArgumentNode node,
         DocumentValidatorContext context)
     {
+        // An argument of a fragment spread is declared by a variable definition of the
+        // fragment it targets, not by a field or a directive.
+        if (context.Path.Peek() is FragmentSpreadNode spread)
+        {
+            if (FragmentArguments.TryGetArgumentType(
+                context,
+                spread,
+                node.Name.Value,
+                out var argumentType))
+            {
+                context.Types.Push(argumentType);
+                return Continue;
+            }
+
+            return Skip;
+        }
+
         if (context.Directives.TryPeek(out var directive))
         {
             if (directive.Arguments.TryGetField(node.Name.Value, out var argument))
@@ -177,6 +194,12 @@ internal sealed class ValueVisitor : TypeDocumentValidatorVisitor
         ArgumentNode node,
         DocumentValidatorContext context)
     {
+        if (context.Path.Peek() is FragmentSpreadNode)
+        {
+            context.Types.Pop();
+            return Continue;
+        }
+
         context.InputFields.Pop();
         context.Types.Pop();
         return Continue;

--- a/src/HotChocolate/Core/src/Validation/Rules/VariableVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/Rules/VariableVisitor.cs
@@ -88,17 +88,91 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
     }
 
     protected override ISyntaxVisitorAction Enter(
+        FragmentDefinitionNode node,
+        DocumentValidatorContext context)
+    {
+        var result = base.Enter(node, context);
+
+        // A frame is only pushed when the fragment is entered, because Skip also skips Leave.
+        if (result.IsContinue())
+        {
+            PushFragmentVariableFrame(context);
+        }
+
+        return result;
+    }
+
+    protected override ISyntaxVisitorAction Leave(
+        FragmentDefinitionNode node,
+        DocumentValidatorContext context)
+    {
+        var frame = PeekFragmentVariableFrame(context);
+        List<string>? unused = null;
+
+        if (frame is not null)
+        {
+            foreach (var declared in frame.Declared)
+            {
+                if (!frame.Used.Contains(declared))
+                {
+                    (unused ??= []).Add(declared);
+                }
+            }
+
+            context.Features.GetRequired<VariableVisitorFeature>().FragmentVariableDepth--;
+        }
+
+        if (unused is not null)
+        {
+            unused.Sort(StringComparer.Ordinal);
+            context.ReportError(context.FragmentVariableNotUsed(node, unused));
+        }
+
+        return base.Leave(node, context);
+    }
+
+    private static VariableVisitorFeature.FragmentVariableFrame PushFragmentVariableFrame(
+        DocumentValidatorContext context)
+    {
+        var feature = context.Features.GetRequired<VariableVisitorFeature>();
+
+        if (feature.FragmentVariableDepth == feature.FragmentVariableFrames.Count)
+        {
+            feature.FragmentVariableFrames.Add(new VariableVisitorFeature.FragmentVariableFrame());
+        }
+
+        var frame = feature.FragmentVariableFrames[feature.FragmentVariableDepth++];
+        frame.Declared.Clear();
+        frame.Used.Clear();
+        return frame;
+    }
+
+    private static VariableVisitorFeature.FragmentVariableFrame? PeekFragmentVariableFrame(
+        DocumentValidatorContext context)
+    {
+        var feature = context.Features.GetRequired<VariableVisitorFeature>();
+
+        return feature.FragmentVariableDepth == 0
+            ? null
+            : feature.FragmentVariableFrames[feature.FragmentVariableDepth - 1];
+    }
+
+    protected override ISyntaxVisitorAction Enter(
         VariableDefinitionNode node,
         DocumentValidatorContext context)
     {
         var feature = context.Features.GetRequired<VariableVisitorFeature>();
+        var isFragmentVariable = context.Path.Peek() is FragmentDefinitionNode;
 
         base.Enter(node, context);
 
         var variableName = node.Variable.Name.Value;
 
-        feature.Unused.Add(variableName);
-        feature.Declared.Add(variableName);
+        if (!isFragmentVariable)
+        {
+            feature.Unused.Add(variableName);
+            feature.Declared.Add(variableName);
+        }
 
         if (context.Schema.Types.TryGetType<ITypeDefinition>(
             node.Type.NamedType().Name.Value, out var type)
@@ -107,7 +181,13 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
             context.ReportError(context.VariableNotInputType(node, variableName));
         }
 
-        if (!feature.VariableNames.Add(variableName))
+        // Uniqueness applies per operation or per fragment, so a fragment may declare a
+        // variable whose name an enclosing operation also declares.
+        var variableNames = isFragmentVariable
+            ? PeekFragmentVariableFrame(context)?.Declared ?? feature.VariableNames
+            : feature.VariableNames;
+
+        if (!variableNames.Add(variableName))
         {
             context.ReportError(context.VariableNameNotUnique(node, variableName));
         }
@@ -184,6 +264,23 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         ArgumentNode node,
         DocumentValidatorContext context)
     {
+        // An argument of a fragment spread is declared by a variable definition of the
+        // fragment it targets, not by a field or a directive.
+        if (context.Path.Peek() is FragmentSpreadNode spread)
+        {
+            if (FragmentArguments.TryGetArgumentType(
+                context,
+                spread,
+                node.Name.Value,
+                out var argumentType))
+            {
+                context.Types.Push(argumentType);
+                return Continue;
+            }
+
+            return Skip;
+        }
+
         if (context.Directives.TryPeek(out var directive))
         {
             if (directive.Arguments.TryGetField(node.Name.Value, out var argument))
@@ -214,6 +311,12 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         ArgumentNode node,
         DocumentValidatorContext context)
     {
+        if (context.Path.Peek() is FragmentSpreadNode)
+        {
+            context.Types.Pop();
+            return Continue;
+        }
+
         context.InputFields.Pop();
         context.Types.Pop();
         return Continue;
@@ -248,13 +351,21 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         VariableNode node,
         DocumentValidatorContext context)
     {
-        context.Features.GetRequired<VariableVisitorFeature>().Used.Add(node.Name.Value);
+        // A usage that a fragment's own declaration satisfies neither needs an operation
+        // variable to declare it, nor counts towards the usages of one it shadows.
+        if (!context.IsFragmentVariable(node.Name.Value))
+        {
+            context.Features.GetRequired<VariableVisitorFeature>().Used.Add(node.Name.Value);
+        }
+
+        // A usage only counts for the fragment it appears in, not for one that spreads it.
+        PeekFragmentVariableFrame(context)?.Used.Add(node.Name.Value);
 
         var parent = context.Path.Peek();
 
         var defaultValue = parent.Kind switch
         {
-            SyntaxKind.Argument => context.InputFields.Peek().DefaultValue,
+            SyntaxKind.Argument => GetArgumentDefaultValue(context, (ArgumentNode)parent),
             SyntaxKind.ObjectField => context.InputFields.Peek().DefaultValue,
             _ => null
         };
@@ -298,6 +409,26 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
     {
         context.Types.Pop();
         return Continue;
+    }
+
+    private static IValueNode? GetArgumentDefaultValue(
+        DocumentValidatorContext context,
+        ArgumentNode argument)
+    {
+        // An argument of a fragment spread takes its default from the variable definition of
+        // the fragment it targets.
+        if (context.Path.Count > 1
+            && context.Path[^2] is FragmentSpreadNode spread
+            && FragmentArguments.TryGetVariableDefinition(
+                context,
+                spread,
+                argument.Name.Value,
+                out var variableDefinition))
+        {
+            return variableDefinition.DefaultValue;
+        }
+
+        return context.InputFields.Peek().DefaultValue;
     }
 
     // http://facebook.github.io/graphql/June2018/#IsVariableUsageAllowed()
@@ -386,6 +517,10 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
     {
         public HashSet<string> VariableNames { get; } = [];
 
+        public List<FragmentVariableFrame> FragmentVariableFrames { get; } = [];
+
+        public int FragmentVariableDepth { get; set; }
+
         public HashSet<string> Used { get; } = [];
 
         public HashSet<string> Declared { get; } = [];
@@ -395,9 +530,26 @@ internal sealed class VariableVisitor : TypeDocumentValidatorVisitor
         protected internal override void Reset()
         {
             VariableNames.Clear();
+            FragmentVariableDepth = 0;
+
+            // The frames themselves are kept for reuse, only their contents are released.
+            for (var i = 0; i < FragmentVariableFrames.Count; i++)
+            {
+                var frame = FragmentVariableFrames[i];
+                frame.Declared.Clear();
+                frame.Used.Clear();
+            }
+
             Used.Clear();
             Declared.Clear();
             Unused.Clear();
+        }
+
+        public sealed class FragmentVariableFrame
+        {
+            public HashSet<string> Declared { get; } = [];
+
+            public HashSet<string> Used { get; } = [];
         }
     }
 }

--- a/src/HotChocolate/Core/src/Validation/TypeDocumentValidatorVisitor.cs
+++ b/src/HotChocolate/Core/src/Validation/TypeDocumentValidatorVisitor.cs
@@ -29,6 +29,13 @@ public class TypeDocumentValidatorVisitor : DocumentValidatorVisitor
         VariableDefinitionNode node,
         DocumentValidatorContext context)
     {
+        // The variables a fragment declares are scoped to that fragment and are brought into
+        // scope when it is entered, so they must not register as operation variables here.
+        if (context.Path.Peek() is FragmentDefinitionNode)
+        {
+            return Continue;
+        }
+
         context.Variables[node.Variable.Name.Value] = node;
         return Continue;
     }
@@ -63,6 +70,7 @@ public class TypeDocumentValidatorVisitor : DocumentValidatorVisitor
             out var namedOutputType))
         {
             context.Types.Push(namedOutputType);
+            context.EnterFragmentVariableScope(node);
             return Continue;
         }
 
@@ -95,6 +103,7 @@ public class TypeDocumentValidatorVisitor : DocumentValidatorVisitor
         FragmentDefinitionNode node,
         DocumentValidatorContext context)
     {
+        context.LeaveFragmentVariableScope();
         context.Types.Pop();
         return Continue;
     }

--- a/src/HotChocolate/Core/test/Validation.Tests/AllVariableUsagesAreAllowedRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/AllVariableUsagesAreAllowedRuleTests.cs
@@ -567,4 +567,41 @@ public class AllVariableUsagesAreAllowedRuleTests
             """
         );
     }
+
+    [Fact]
+    public void Validate_Should_ResolveTheOperationVariable_When_UsedAfterAShadowingSpread()
+    {
+        ExpectValid(
+            """
+            query ($x: Boolean!) {
+                dog {
+                    ...shadowing(x: false)
+                    isHouseTrained @skip(if: $x)
+                }
+            }
+
+            fragment shadowing($x: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $x)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
+
+    [Fact]
+    public void Validate_Should_Report_When_ANullableVariableIsPassedToANonNullFragmentArgument()
+    {
+        ExpectErrors(
+            """
+            query ($x: Boolean) {
+                dog {
+                    ...withRequired(y: $x)
+                }
+            }
+
+            fragment withRequired($y: Boolean!) on Dog {
+                isHouseTrained(atOtherHomes: $y)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/AllVariablesUsedRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/AllVariablesUsedRuleTests.cs
@@ -276,4 +276,58 @@ public class AllVariablesUsedRuleTests
                 "The following variables were not declared: "
                 + "atOtherHomes.", t.Message));
     }
+
+    [Fact]
+    public void Validate_Should_TreatAFragmentVariableAsDeclared_When_OnlyTheFragmentDeclaresIt()
+    {
+        ExpectValid(
+            """
+            {
+                dog {
+                    ...withOwnVariable(atOtherHomes: true)
+                }
+            }
+
+            fragment withOwnVariable($atOtherHomes: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $atOtherHomes)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
+
+    [Fact]
+    public void Validate_Should_Report_When_AFragmentDeclaresAVariableItDoesNotUse()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...unusedVariable(atOtherHomes: true)
+                }
+            }
+
+            fragment unusedVariable($atOtherHomes: Boolean) on Dog {
+                name
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
+
+    [Fact]
+    public void Validate_Should_Report_When_AnOperationVariableIsOnlyUsedInsideAShadowingFragment()
+    {
+        ExpectErrors(
+            """
+            query ($x: Boolean!) {
+                dog {
+                    ...shadowing(x: false)
+                }
+            }
+
+            fragment shadowing($x: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $x)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/ArgumentNamesRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ArgumentNamesRuleTests.cs
@@ -403,4 +403,22 @@ public class ArgumentNamesRuleTests
             }
             """);
     }
+
+    [Fact]
+    public void Validate_Should_Report_When_ASpreadPassesAnArgumentTheFragmentDoesNotDeclare()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...withVariable(unknown: true)
+                }
+            }
+
+            fragment withVariable($atOtherHomes: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $atOtherHomes)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/ArgumentUniquenessRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ArgumentUniquenessRuleTests.cs
@@ -47,4 +47,22 @@ public class ArgumentUniquenessRuleTests
                 + "set is ambiguous and invalid.",
                 t.Message));
     }
+
+    [Fact]
+    public void Validate_Should_Report_When_ASpreadPassesTheSameArgumentTwice()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...withVariable(atOtherHomes: true, atOtherHomes: false)
+                }
+            }
+
+            fragment withVariable($atOtherHomes: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $atOtherHomes)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/DocumentValidatorVisitorTestBase.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/DocumentValidatorVisitorTestBase.cs
@@ -21,16 +21,33 @@ public abstract class DocumentValidatorVisitorTestBase
 
     protected ISchemaDefinition StarWars { get; }
 
+    /// <summary>
+    /// Parser options that enable the experimental fragment spread arguments syntax.
+    /// </summary>
+    protected static ParserOptions FragmentArgumentParserOptions { get; } =
+        new(new ParserOptionsExperimental(allowFragmentArguments: true));
+
     protected void ExpectValid(
         [StringSyntax("graphql")] string sourceText)
-        => ExpectValid(null, sourceText);
+        => ExpectValid(null, sourceText, ParserOptions.Default);
+
+    protected void ExpectValid(
+        [StringSyntax("graphql")] string sourceText,
+        ParserOptions parserOptions)
+        => ExpectValid(null, sourceText, parserOptions);
 
     protected void ExpectValid(
         ISchemaDefinition? schema,
         [StringSyntax("graphql")] string sourceText)
+        => ExpectValid(schema, sourceText, ParserOptions.Default);
+
+    protected void ExpectValid(
+        ISchemaDefinition? schema,
+        [StringSyntax("graphql")] string sourceText,
+        ParserOptions parserOptions)
     {
         // arrange
-        var document = Utf8GraphQLParser.Parse(sourceText);
+        var document = Utf8GraphQLParser.Parse(sourceText, parserOptions);
         var context = ValidationUtils.CreateContext(document, schema);
 
         // act
@@ -44,15 +61,28 @@ public abstract class DocumentValidatorVisitorTestBase
     protected void ExpectErrors(
         [StringSyntax("graphql")] string sourceText,
         params Action<IError>[] elementInspectors)
-        => ExpectErrors(null, sourceText, elementInspectors);
+        => ExpectErrors(null, sourceText, ParserOptions.Default, elementInspectors);
+
+    protected void ExpectErrors(
+        [StringSyntax("graphql")] string sourceText,
+        ParserOptions parserOptions,
+        params Action<IError>[] elementInspectors)
+        => ExpectErrors(null, sourceText, parserOptions, elementInspectors);
 
     protected void ExpectErrors(
         ISchemaDefinition? schema,
         [StringSyntax("graphql")] string sourceText,
         params Action<IError>[] elementInspectors)
+        => ExpectErrors(schema, sourceText, ParserOptions.Default, elementInspectors);
+
+    protected void ExpectErrors(
+        ISchemaDefinition? schema,
+        [StringSyntax("graphql")] string sourceText,
+        ParserOptions parserOptions,
+        params Action<IError>[] elementInspectors)
     {
         // arrange
-        var document = Utf8GraphQLParser.Parse(sourceText);
+        var document = Utf8GraphQLParser.Parse(sourceText, parserOptions);
         var context = ValidationUtils.CreateContext(
             document,
             schema,

--- a/src/HotChocolate/Core/test/Validation.Tests/RequiredArgumentRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/RequiredArgumentRuleTests.cs
@@ -436,4 +436,22 @@ public class RequiredArgumentRuleTests
             """
         );
     }
+
+    [Fact]
+    public void Validate_Should_Report_When_ASpreadOmitsARequiredFragmentVariable()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...withRequiredVariable
+                }
+            }
+
+            fragment withRequiredVariable($atOtherHomes: Boolean!) on Dog {
+                isHouseTrained(atOtherHomes: $atOtherHomes)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/ValuesOfCorrectTypeRuleTests.cs
@@ -1342,4 +1342,22 @@ public class ValuesOfCorrectTypeRuleTests
             }
             """);
     }
+
+    [Fact]
+    public void Validate_Should_Report_When_AFragmentArgumentValueHasTheWrongType()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...withVariable(atOtherHomes: "abc")
+                }
+            }
+
+            fragment withVariable($atOtherHomes: Boolean) on Dog {
+                isHouseTrained(atOtherHomes: $atOtherHomes)
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/VariablesAreInputTypesRuleTests.cs
+++ b/src/HotChocolate/Core/test/Validation.Tests/VariablesAreInputTypesRuleTests.cs
@@ -64,4 +64,22 @@ public class VariablesAreInputTypesRuleTests
             }
             """);
     }
+
+    [Fact]
+    public void Validate_Should_Report_When_AFragmentDeclaresAnOutputTypeVariable()
+    {
+        ExpectErrors(
+            """
+            {
+                dog {
+                    ...withVariable(bad: null)
+                }
+            }
+
+            fragment withVariable($bad: Dog) on Dog {
+                name
+            }
+            """,
+            FragmentArgumentParserOptions);
+    }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariableUsagesAreAllowedRuleTests.Validate_Should_Report_When_ANullableVariableIsPassedToANonNullFragmentArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariableUsagesAreAllowedRuleTests.Validate_Should_Report_When_ANullableVariableIsPassedToANonNullFragmentArgument.snap
@@ -1,0 +1,18 @@
+{
+  "message": "The variable \u0060x\u0060 is not compatible with the type of the current location.",
+  "locations": [
+    {
+      "line": 3,
+      "column": 28
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "variable": "x",
+    "variableType": "Boolean",
+    "locationType": "Boolean!",
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-All-Variable-Usages-Are-Allowed"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.Validate_Should_Report_When_AFragmentDeclaresAVariableItDoesNotUse.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.Validate_Should_Report_When_AFragmentDeclaresAVariableItDoesNotUse.snap
@@ -1,0 +1,15 @@
+{
+  "message": "The following variables of fragment \u0060unusedVariable\u0060 were not used: atOtherHomes.",
+  "locations": [
+    {
+      "line": 7,
+      "column": 1
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-All-Variables-Used"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.Validate_Should_Report_When_AnOperationVariableIsOnlyUsedInsideAShadowingFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/AllVariablesUsedRuleTests.Validate_Should_Report_When_AnOperationVariableIsOnlyUsedInsideAShadowingFragment.snap
@@ -1,0 +1,12 @@
+{
+  "message": "The following variables were not used: x.",
+  "locations": [
+    {
+      "line": 1,
+      "column": 1
+    }
+  ],
+  "extensions": {
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-All-Variables-Used"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidDirectiveArgName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidDirectiveArgName.snap
@@ -14,7 +14,7 @@
   "extensions": {
     "directive": "include",
     "argument": "unless",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgName.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "command",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgNameInReusedFragment.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.InvalidFieldArgNameInReusedFragment.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "command",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledDirectiveArgsAreReported.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledDirectiveArgsAreReported.snap
@@ -13,7 +13,7 @@
   "extensions": {
     "directive": "skip",
     "argument": "iff",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledFieldArgsAreReported.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.MisspelledFieldArgsAreReported.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "DogCommand",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsAmongstKnowArgs.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsAmongstKnowArgs.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "whoKnows",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------
@@ -35,7 +35,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "unknown",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsDeeply.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.UnknownArgsDeeply.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "unknown",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.Validate_Should_Report_When_ASpreadPassesAnArgumentTheFragmentDoesNotDeclare.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentNamesRuleTests.Validate_Should_Report_When_ASpreadPassesAnArgumentTheFragmentDoesNotDeclare.snap
@@ -1,17 +1,17 @@
 {
-  "message": "The argument \u0060if\u0060 does not exist.",
+  "message": "The argument \u0060unknown\u0060 does not exist.",
   "locations": [
     {
-      "line": 2,
-      "column": 16
+      "line": 3,
+      "column": 25
     }
   ],
   "path": [
     "dog"
   ],
   "extensions": {
-    "directive": "complex",
-    "argument": "if",
+    "fragment": "withVariable",
+    "argument": "unknown",
     "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentUniquenessRuleTests.Validate_Should_Report_When_ASpreadPassesTheSameArgumentTwice.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ArgumentUniquenessRuleTests.Validate_Should_Report_When_ASpreadPassesTheSameArgumentTwice.snap
@@ -1,0 +1,17 @@
+{
+  "message": "More than one argument with the same name in an argument set is ambiguous and invalid.",
+  "locations": [
+    {
+      "line": 3,
+      "column": 45
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "fragment": "withVariable",
+    "argument": "atOtherHomes",
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Uniqueness"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InvalidFieldArgName.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/DocumentValidatorTests.InvalidFieldArgName.snap
@@ -14,7 +14,7 @@
     "type": "Dog",
     "field": "doesKnowCommand",
     "argument": "command",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.IncorrectValueAndMissingArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.IncorrectValueAndMissingArgument.snap
@@ -14,7 +14,7 @@
     "type": "Arguments",
     "field": "multipleReqs",
     "argument": "req1",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingOneNonNullableArgument.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.MissingOneNonNullableArgument.snap
@@ -14,7 +14,7 @@
     "type": "Arguments",
     "field": "multipleReqs",
     "argument": "req2",
-    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
   }
 }
 ---------------

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.Validate_Should_Report_When_ASpreadOmitsARequiredFragmentVariable.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/RequiredArgumentRuleTests.Validate_Should_Report_When_ASpreadOmitsARequiredFragmentVariable.snap
@@ -1,0 +1,17 @@
+{
+  "message": "The argument \u0060atOtherHomes\u0060 is required.",
+  "locations": [
+    {
+      "line": 3,
+      "column": 9
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "fragment": "withRequiredVariable",
+    "argument": "atOtherHomes",
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ValuesOfCorrectTypeRuleTests.Validate_Should_Report_When_AFragmentArgumentValueHasTheWrongType.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/ValuesOfCorrectTypeRuleTests.Validate_Should_Report_When_AFragmentArgumentValueHasTheWrongType.snap
@@ -1,0 +1,18 @@
+{
+  "message": "The specified argument value does not match the argument type.",
+  "locations": [
+    {
+      "line": 3,
+      "column": 39
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "argument": "atOtherHomes",
+    "argumentValue": "\u0022abc\u0022",
+    "locationType": "Boolean",
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Values-of-Correct-Type"
+  }
+}

--- a/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/VariablesAreInputTypesRuleTests.Validate_Should_Report_When_AFragmentDeclaresAnOutputTypeVariable.snap
+++ b/src/HotChocolate/Core/test/Validation.Tests/__snapshots__/VariablesAreInputTypesRuleTests.Validate_Should_Report_When_AFragmentDeclaresAnOutputTypeVariable.snap
@@ -1,0 +1,37 @@
+---------------
+{
+  "message": "The type of variable \u0060bad\u0060 is not an input type.",
+  "locations": [
+    {
+      "line": 7,
+      "column": 23
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "variable": "bad",
+    "variableType": "Dog",
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Variables-Are-Input-Types"
+  }
+}
+---------------
+
+---------------
+{
+  "message": "The following variables of fragment \u0060withVariable\u0060 were not used: bad.",
+  "locations": [
+    {
+      "line": 7,
+      "column": 1
+    }
+  ],
+  "path": [
+    "dog"
+  ],
+  "extensions": {
+    "specifiedBy": "https://spec.graphql.org/September2025/#sec-All-Variables-Used"
+  }
+}
+---------------

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_Nullable.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_Nullable.snap
@@ -16,7 +16,7 @@
         "type": "FooNullable",
         "field": "objectArray",
         "argument": "order",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
       }
     }
   ]

--- a/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_Nullable.snap
+++ b/src/HotChocolate/Data/test/Data.Projections.SqlServer.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_Nullable.snap
@@ -16,7 +16,7 @@
         "type": "FooNullable",
         "field": "objectArray",
         "argument": "order",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
       }
     }
   ]

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Field_With_Inaccessible_Argument_Cannot_Be_Passed_In.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Field_With_Inaccessible_Argument_Cannot_Be_Passed_In.yaml
@@ -20,7 +20,7 @@ response:
             "type": "Query",
             "field": "inaccessibleText",
             "argument": "text",
-            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
           }
         }
       ]

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Inaccessible_Enum_Type_Cannot_Be_Used.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Inaccessible_Enum_Type_Cannot_Be_Used.yaml
@@ -20,7 +20,7 @@ response:
             "type": "Query",
             "field": "statusField",
             "argument": "status",
-            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
           }
         }
       ]

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Inaccessible_Input_Object_Type_Cannot_Be_Used.yaml
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/__snapshots__/InaccessibleTests.Inaccessible_Input_Object_Type_Cannot_Be_Used.yaml
@@ -20,7 +20,7 @@ response:
             "type": "Query",
             "field": "filterData",
             "argument": "filter",
-            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+            "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
           }
         }
       ]

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Introspection/OptInFeaturesIntrospectionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Introspection/OptInFeaturesIntrospectionTests.cs
@@ -274,7 +274,7 @@ public sealed class OptInFeaturesIntrospectionTests : FusionTestBase
                     "type": "__Type",
                     "field": "fields",
                     "argument": "includeOptIn",
-                    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+                    "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
                   }
                 }
               ]

--- a/src/HotChocolate/Raven/test/Data.Raven.Projections.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_Nullable.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Projections.Tests/__snapshots__/QueryableProjectionSortingTests.Create_DeepFilterObjectTwoProjections_Nullable.snap
@@ -16,7 +16,7 @@
         "type": "FooNullable",
         "field": "objectArray",
         "argument": "order",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
       }
     }
   ]

--- a/src/HotChocolate/Raven/test/Data.Raven.Projections.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_Nullable.snap
+++ b/src/HotChocolate/Raven/test/Data.Raven.Projections.Tests/__snapshots__/QueryableProjectionSortingTests.Create_ListObjectDifferentLevelProjection_Nullable.snap
@@ -16,7 +16,7 @@
         "type": "FooNullable",
         "field": "objectArray",
         "argument": "order",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Required-Arguments"
+        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Argument-Names"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Fragment spread arguments are now validated: an argument the target fragment does not declare, a duplicate argument, and a required argument that is missing or explicitly `null` are each reported. The existing argument messages are reused with a `fragment` extension, so no new wording was needed for them.
- A fragment's variable definitions form their own scope. They shadow an operation variable of the same name for the duration of the fragment and are restored on leave, so a usage after the spread resolves against the operation again. Uniqueness applies per operation or per fragment, and a usage that a fragment's own declaration satisfies neither requires an operation variable to declare it nor counts towards the usages of one it shadows.
- A fragment that declares a variable it never uses is reported, tracked per fragment so that a nested spread does not discard the enclosing fragment's declarations.
- Value checking follows from the same scope work rather than duplicating it: a literal is checked against the declared fragment variable type by the values-of-correct-type rule, and a variable passed as a fragment argument by the variable-usage rule.

Also corrected here: `ArgumentDoesNotExist` linked to `sec-Required-Arguments`, which is the section asserting that a *required argument was supplied*. An argument the target does not declare belongs to `sec-Argument-Names`, as the fragment-arguments RFC states explicitly: "Every argument provided to a named fragment spread must be defined in the set of possible variables of that named fragment." The fix applies to fields and directives too, which moves the `specifiedBy` link in 12 existing snapshots.

Two rules are deliberately held back, because both depend on how the rewrite pass substitutes arguments: the `FieldsInSetCanMerge` extension for same-name spreads carrying different argument sets, and the rejection of a defaulted fragment variable fed a possibly-unprovided operation variable.

All of this is reachable only with the experimental parser option, which no server configuration exposes, so the rules are exercised through `DocumentValidator` directly.

## Test plan

- `dotnet test src/HotChocolate/Core/test/Validation.Tests` passes 2540 tests across net8.0, net9.0, net10.0, and net11.0.
- Ten new tests, eight of them snapshot-based via `ExpectErrors`, which pins each error's message, locations, path, and extensions, including the new `fragment` extension.
- The test base gained `ParserOptions` overloads so fragment-argument documents parse through the existing `ExpectValid`/`ExpectErrors` helpers instead of hand-rolled parse calls.
- Each behaviour was mutation-checked: dropping the shadow restore, never reporting unused fragment variables, counting a fragment-satisfied usage as an operation usage, and omitting the declared-type push each fail exactly the tests that claim them.
- `src/All.slnx` builds with 0 errors. `Execution.Tests` was clean apart from `SubscriptionEventTimeoutTests`, a load-sensitive timing flake that passes in isolation.
