### PR TITLE
Validate that directive applications are on valid locations

### DIFF
--- a/src/HotChocolate/Core/src/Types.Validation/Events/ValidationEvents.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Events/ValidationEvents.cs
@@ -1,6 +1,7 @@
 using HotChocolate.Events.Contracts;
 using HotChocolate.Language;
 using HotChocolate.Types;
+using DirectiveLocation = HotChocolate.Types.DirectiveLocation;
 
 namespace HotChocolate.Events;
 
@@ -45,9 +46,13 @@ public readonly record struct DirectiveDefinitionEvent(IDirectiveDefinition Dire
 /// <summary>
 /// Represents an event that is triggered when a directive is encountered during schema validation.
 /// </summary>
+/// <param name="Directive">The applied directive.</param>
+/// <param name="Member">The type system member the directive is applied to.</param>
+/// <param name="Location">The location at which the directive is applied.</param>
 public readonly record struct DirectiveEvent(
     IDirective Directive,
-    ITypeSystemMember Member) : IValidationEvent;
+    ITypeSystemMember Member,
+    DirectiveLocation Location) : IValidationEvent;
 
 /// <summary>
 /// Represents an event that is triggered when an Enum type is encountered during schema validation.

--- a/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryCodes.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryCodes.cs
@@ -36,4 +36,5 @@ internal static class LogEntryCodes
     public const string IncompatibleInputFieldDefaultValue = "HCV0029";
     public const string InvalidObjectDeprecation = "HCV0030";
     public const string DirectiveNotUnique = "HCV0031";
+    public const string DirectiveInInvalidLocation = "HCV0032";
 }

--- a/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryHelper.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Logging/LogEntryHelper.cs
@@ -67,6 +67,23 @@ internal static class LogEntryHelper
             .Build();
     }
 
+    public static LogEntry DirectiveInInvalidLocation(
+        IDirective directive,
+        ITypeSystemMember member,
+        DirectiveLocation location)
+    {
+        return LogEntryBuilder.New()
+            .SetMessage(
+                LogEntryHelper_DirectiveInInvalidLocation,
+                directive.Name,
+                GetDirectiveMemberName(member),
+                location.Format())
+            .SetCode(LogEntryCodes.DirectiveInInvalidLocation)
+            .SetSeverity(LogSeverity.Error)
+            .SetTypeSystemMember(member)
+            .Build();
+    }
+
     public static LogEntry DirectiveNotUnique(IDirective directive, ITypeSystemMember member)
     {
         return LogEntryBuilder.New()

--- a/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.Designer.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.Designer.cs
@@ -186,6 +186,15 @@ namespace HotChocolate.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The directive &apos;@{0}&apos; on &apos;{1}&apos; is not allowed on the location &apos;{2}&apos;..
+        /// </summary>
+        internal static string LogEntryHelper_DirectiveInInvalidLocation {
+            get {
+                return ResourceManager.GetString("LogEntryHelper_DirectiveInInvalidLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The non-repeatable directive &apos;@{0}&apos; on &apos;{1}&apos; is applied more than once..
         /// </summary>
         internal static string LogEntryHelper_DirectiveNotUnique {

--- a/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.resx
+++ b/src/HotChocolate/Core/src/Types.Validation/Properties/ValidationResources.resx
@@ -60,6 +60,9 @@
   <data name="LogEntryHelper_DirectiveDefinitionSelfApplication" xml:space="preserve">
     <value>The directive definition '@{0}' must not reference itself.</value>
   </data>
+  <data name="LogEntryHelper_DirectiveInInvalidLocation" xml:space="preserve">
+    <value>The directive '@{0}' on '{1}' is not allowed on the location '{2}'.</value>
+  </data>
   <data name="LogEntryHelper_DirectiveNotUnique" xml:space="preserve">
     <value>The non-repeatable directive '@{0}' on '{1}' is applied more than once.</value>
   </data>

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsDefinedRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsDefinedRule.cs
@@ -15,7 +15,7 @@ public sealed class DirectiveIsDefinedRule : IValidationEventHandler<DirectiveEv
     /// </summary>
     public void Handle(DirectiveEvent @event, ValidationContext context)
     {
-        var (directive, member) = @event;
+        var (directive, member, _) = @event;
 
         if (DirectiveNames.IsSpecDirective(directive.Name))
         {

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsInValidLocationRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsInValidLocationRule.cs
@@ -17,8 +17,10 @@ public sealed class DirectiveIsInValidLocationRule : IValidationEventHandler<Dir
     {
         var (directive, member, location) = @event;
 
-        // DirectiveIsDefinedRule reports directives without a definition.
-        if (directive.Definition is IMissingDirectiveDefinition)
+        // DirectiveIsDefinedRule reports directives without a definition, and
+        // DirectiveDefinitionIncludesLocationRule reports definitions without locations.
+        if (directive.Definition is IMissingDirectiveDefinition
+            || directive.Definition.Locations == 0)
         {
             return;
         }

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsInValidLocationRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsInValidLocationRule.cs
@@ -1,0 +1,31 @@
+using HotChocolate.Events;
+using HotChocolate.Events.Contracts;
+using HotChocolate.Types;
+using static HotChocolate.Logging.LogEntryHelper;
+
+namespace HotChocolate.Rules;
+
+/// <summary>
+/// Checks that a directive is applied only in locations its definition declares.
+/// </summary>
+public sealed class DirectiveIsInValidLocationRule : IValidationEventHandler<DirectiveEvent>
+{
+    /// <summary>
+    /// Checks that a directive is applied only in locations its definition declares.
+    /// </summary>
+    public void Handle(DirectiveEvent @event, ValidationContext context)
+    {
+        var (directive, member, location) = @event;
+
+        // DirectiveIsDefinedRule reports directives without a definition.
+        if (directive.Definition is IMissingDirectiveDefinition)
+        {
+            return;
+        }
+
+        if ((directive.Definition.Locations & location) != location)
+        {
+            context.Log.Write(DirectiveInInvalidLocation(directive, member, location));
+        }
+    }
+}

--- a/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsUniqueRule.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/Rules/DirectiveIsUniqueRule.cs
@@ -15,7 +15,7 @@ public sealed class DirectiveIsUniqueRule : IValidationEventHandler<DirectiveEve
     /// </summary>
     public void Handle(DirectiveEvent @event, ValidationContext context)
     {
-        var (directive, member) = @event;
+        var (directive, member, _) = @event;
 
         if (directive.Definition.IsRepeatable || member is not IDirectivesProvider provider)
         {

--- a/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
+++ b/src/HotChocolate/Core/src/Types.Validation/SchemaValidator.cs
@@ -4,6 +4,7 @@ using HotChocolate.Language;
 using HotChocolate.Logging.Contracts;
 using HotChocolate.Rules;
 using HotChocolate.Types;
+using DirectiveLocation = HotChocolate.Types.DirectiveLocation;
 
 namespace HotChocolate;
 
@@ -52,6 +53,7 @@ public sealed class SchemaValidator
         _rules.Add(new DirectiveDefinitionIncludesLocationRule());
         _rules.Add(new DirectiveDefinitionNoSelfReferenceRule());
         _rules.Add(new DirectiveIsDefinedRule());
+        _rules.Add(new DirectiveIsInValidLocationRule());
         _rules.Add(new DirectiveIsUniqueRule());
         _rules.Add(new EnumValueIsDefinedRule());
         _rules.Add(new NoInputObjectCycleRule());
@@ -96,12 +98,12 @@ public sealed class SchemaValidator
 
         PublishEvent(new InputObjectTypesEvent(schema.Types.OfType<IInputObjectTypeDefinition>()), context);
 
-        PublishDirectiveEvents(schema, context);
+        PublishDirectiveEvents(schema, DirectiveLocation.Schema, context);
 
         foreach (var type in schema.Types)
         {
             PublishEvent(new TypeEvent(type), context);
-            PublishDirectiveEvents(type, context);
+            PublishDirectiveEvents(type, GetTypeDirectiveLocation(type), context);
 
             if (type is INameProvider namedMember)
             {
@@ -136,10 +138,13 @@ public sealed class SchemaValidator
                             PublishEvent(new NamedMemberEvent(argument), context);
 
                             PublishDefaultValueNodeEvents(argument, context);
-                            PublishDirectiveEvents(argument, context);
+                            PublishDirectiveEvents(
+                                argument,
+                                DirectiveLocation.ArgumentDefinition,
+                                context);
                         }
 
-                        PublishDirectiveEvents(field, context);
+                        PublishDirectiveEvents(field, DirectiveLocation.FieldDefinition, context);
                     }
 
                     break;
@@ -152,7 +157,7 @@ public sealed class SchemaValidator
                         PublishEvent(new EnumValueEvent(value), context);
                         PublishEvent(new NamedMemberEvent(value), context);
 
-                        PublishDirectiveEvents(value, context);
+                        PublishDirectiveEvents(value, DirectiveLocation.EnumValue, context);
                     }
 
                     break;
@@ -168,7 +173,10 @@ public sealed class SchemaValidator
                         PublishEvent(new NamedMemberEvent(field), context);
 
                         PublishDefaultValueNodeEvents(field, context);
-                        PublishDirectiveEvents(field, context);
+                        PublishDirectiveEvents(
+                            field,
+                            DirectiveLocation.InputFieldDefinition,
+                            context);
                     }
 
                     break;
@@ -184,7 +192,10 @@ public sealed class SchemaValidator
             PublishEvent(new DirectiveDefinitionEvent(directiveDefinition), context);
             PublishEvent(new NamedMemberEvent(directiveDefinition), context);
 
-            PublishDirectiveEvents(directiveDefinition, context);
+            PublishDirectiveEvents(
+                directiveDefinition,
+                DirectiveLocation.DirectiveDefinition,
+                context);
 
             foreach (var argument in directiveDefinition.Arguments)
             {
@@ -193,18 +204,19 @@ public sealed class SchemaValidator
                 PublishEvent(new NamedMemberEvent(argument), context);
 
                 PublishDefaultValueNodeEvents(argument, context);
-                PublishDirectiveEvents(argument, context);
+                PublishDirectiveEvents(argument, DirectiveLocation.ArgumentDefinition, context);
             }
         }
     }
 
     private void PublishDirectiveEvents(
         IDirectivesProvider member,
+        DirectiveLocation location,
         ValidationContext context)
     {
         foreach (var directive in member.Directives)
         {
-            PublishEvent(new DirectiveEvent(directive, member), context);
+            PublishEvent(new DirectiveEvent(directive, member, location), context);
 
             foreach (var argumentAssignment in directive.Arguments)
             {
@@ -224,6 +236,21 @@ public sealed class SchemaValidator
                     context);
             }
         }
+    }
+
+    private static DirectiveLocation GetTypeDirectiveLocation(ITypeDefinition type)
+    {
+        return type.Kind switch
+        {
+            TypeKind.Enum => DirectiveLocation.Enum,
+            TypeKind.InputObject => DirectiveLocation.InputObject,
+            TypeKind.Interface => DirectiveLocation.Interface,
+            TypeKind.Object => DirectiveLocation.Object,
+            TypeKind.Scalar => DirectiveLocation.Scalar,
+            TypeKind.Union => DirectiveLocation.Union,
+            TypeKind.Directive or TypeKind.List or TypeKind.NonNull or _ =>
+                throw new InvalidOperationException()
+        };
     }
 
     private void PublishDefaultValueNodeEvents(IInputValueDefinition inputValue, ValidationContext context)

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsInValidLocationRuleTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsInValidLocationRuleTests.cs
@@ -1,0 +1,374 @@
+using HotChocolate.Rules;
+
+namespace HotChocolate.Types.Validation.Rules;
+
+public sealed class DirectiveIsInValidLocationRuleTests : RuleTestBase<DirectiveIsInValidLocationRule>
+{
+    [Fact]
+    public void Validate_DirectiveAppliedAtDeclaredLocations_Succeeds()
+    {
+        AssertValid(
+            """
+            schema @example {
+                query: Query
+            }
+
+            type Query @example {
+                field(argument: Int @example): Int @example
+            }
+
+            scalar Scalar @example
+
+            interface Interface @example {
+                field: Int
+            }
+
+            union Union @example = Query
+
+            enum Enum @example {
+                VALUE @example
+            }
+
+            input Input @example {
+                field: Int @example
+            }
+
+            directive @other(argument: Int @example) @example on OBJECT
+
+            directive @example on ARGUMENT_DEFINITION
+                | DIRECTIVE_DEFINITION
+                | ENUM
+                | ENUM_VALUE
+                | FIELD_DEFINITION
+                | INPUT_FIELD_DEFINITION
+                | INPUT_OBJECT
+                | INTERFACE
+                | OBJECT
+                | SCALAR
+                | SCHEMA
+                | UNION
+            """);
+    }
+
+    [Fact]
+    public void Validate_RepeatableDirectiveAppliedAtDeclaredLocation_Succeeds()
+    {
+        AssertValid(
+            """
+            type Object @example @example {
+                field: Int
+            }
+
+            directive @example repeatable on OBJECT
+            """);
+    }
+
+    [Fact]
+    public void Validate_UndefinedDirective_Succeeds()
+    {
+        AssertValid(
+            """
+            type Object @example {
+                field: Int
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnSchema_Fails()
+    {
+        AssertInvalid(
+            """
+            schema @example {
+                query: Query
+            }
+
+            type Query {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'schema' is not allowed on the location 'SCHEMA'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "member": "default",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnScalar_Fails()
+    {
+        AssertInvalid(
+            """
+            scalar Scalar @example
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Scalar' is not allowed on the location 'SCALAR'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Scalar",
+                "member": "Scalar",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnObject_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object @example {
+                field: Int
+            }
+
+            directive @example on FIELD_DEFINITION
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Object' is not allowed on the location 'OBJECT'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Object",
+                "member": "Object",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnFieldDefinition_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object {
+                field: Int @example
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Object.field' is not allowed on the location 'FIELD_DEFINITION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Object.field",
+                "member": "field",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnArgumentDefinition_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object {
+                field(argument: Int @example): Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Object.field(argument:)' is not allowed on the location 'ARGUMENT_DEFINITION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Object.field(argument:)",
+                "member": "argument",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnInterface_Fails()
+    {
+        AssertInvalid(
+            """
+            interface Interface @example {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Interface' is not allowed on the location 'INTERFACE'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Interface",
+                "member": "Interface",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnUnion_Fails()
+    {
+        AssertInvalid(
+            """
+            type Object {
+                field: Int
+            }
+
+            union Union @example = Object
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Union' is not allowed on the location 'UNION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Union",
+                "member": "Union",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnEnum_Fails()
+    {
+        AssertInvalid(
+            """
+            enum Enum @example {
+                VALUE
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Enum' is not allowed on the location 'ENUM'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Enum",
+                "member": "Enum",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnEnumValue_Fails()
+    {
+        AssertInvalid(
+            """
+            enum Enum {
+                VALUE @example
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Enum.VALUE' is not allowed on the location 'ENUM_VALUE'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Enum.VALUE",
+                "member": "VALUE",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnInputObject_Fails()
+    {
+        AssertInvalid(
+            """
+            input Input @example {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Input' is not allowed on the location 'INPUT_OBJECT'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Input",
+                "member": "Input",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnInputFieldDefinition_Fails()
+    {
+        AssertInvalid(
+            """
+            input Input {
+                field: Int @example
+            }
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on 'Input.field' is not allowed on the location 'INPUT_FIELD_DEFINITION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "Input.field",
+                "member": "field",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnDirectiveDefinition_Fails()
+    {
+        AssertInvalid(
+            """
+            directive @other @example on OBJECT
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on '@other' is not allowed on the location 'DIRECTIVE_DEFINITION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "@other",
+                "member": "@other",
+                "extensions": {}
+            }
+            """);
+    }
+
+    [Fact]
+    public void Validate_DirectiveNotDeclaredOnDirectiveArgumentDefinition_Fails()
+    {
+        AssertInvalid(
+            """
+            directive @other(argument: Int @example) on OBJECT
+
+            directive @example on OBJECT
+            """,
+            """
+            {
+                "message": "The directive '@example' on '@other(argument:)' is not allowed on the location 'ARGUMENT_DEFINITION'.",
+                "code": "HCV0032",
+                "severity": "Error",
+                "coordinate": "@other(argument:)",
+                "member": "argument",
+                "extensions": {}
+            }
+            """);
+    }
+}

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsInValidLocationRuleTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/Rules/DirectiveIsInValidLocationRuleTests.cs
@@ -64,6 +64,21 @@ public sealed class DirectiveIsInValidLocationRuleTests : RuleTestBase<Directive
     }
 
     [Fact]
+    public void Validate_DirectiveDefinitionWithoutLocations_Succeeds()
+    {
+        // DirectiveDefinitionIncludesLocationRule reports the definition itself.
+        AssertValid(
+            """
+            type Object @example {
+                field: Int
+            }
+
+            directive @example on OBJECT
+            """,
+            schema => schema.DirectiveDefinitions["example"].Locations = 0);
+    }
+
+    [Fact]
     public void Validate_UndefinedDirective_Succeeds()
     {
         AssertValid(

--- a/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
+++ b/src/HotChocolate/Core/test/Types.Validation.Tests/SchemaValidatorTests.cs
@@ -25,6 +25,7 @@ public sealed class SchemaValidatorTests
                 "DirectiveDefinitionIncludesLocationRule",
                 "DirectiveDefinitionNoSelfReferenceRule",
                 "DirectiveIsDefinedRule",
+                "DirectiveIsInValidLocationRule",
                 "DirectiveIsUniqueRule",
                 "EnumValueIsDefinedRule",
                 "NoInputObjectCycleRule",

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/GenerateLookupFields.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/GenerateLookupFields.cs
@@ -54,10 +54,10 @@ internal static class GenerateLookupFields
             synthesizedQuery = true;
         }
 
-        var internalDef = new MutableDirectiveDefinition("internal");
-        var lookupDef = new MutableDirectiveDefinition("lookup");
-        var isDef = new MutableDirectiveDefinition("is");
-        var shareableDef = new MutableDirectiveDefinition("shareable");
+        var internalDef = FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.Internal];
+        var lookupDef = FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.Lookup];
+        var isDef = FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.Is];
+        var shareableDef = FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.Shareable];
 
         // Generated input object types are cached by name so that repeated
         // references to the same nested shape share a single input type.

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
@@ -605,7 +605,7 @@ internal static class TransformRequiresToRequire
     }
 
     private static bool IsExternal(MutableOutputFieldDefinition field)
-        => field.Directives.ContainsName(FederationDirectiveNames.External);
+        => field.Directives.ContainsName(WellKnownDirectiveNames.External);
 
     private static void ApplyExternalDirective(MutableOutputFieldDefinition field)
     {

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/ApolloFederation/TransformRequiresToRequire.cs
@@ -35,7 +35,7 @@ internal static class TransformRequiresToRequire
     /// </param>
     public static void Apply(MutableSchemaDefinition schema)
     {
-        var requireDef = new MutableDirectiveDefinition("require");
+        var requireDef = FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.Require];
         var pendingInputTypes = new List<MutableInputObjectTypeDefinition>();
 
         // Snapshot the object types to avoid modifying the collection during iteration.
@@ -612,7 +612,7 @@ internal static class TransformRequiresToRequire
         if (!IsExternal(field))
         {
             var externalDirectiveDefinition =
-                new MutableDirectiveDefinition(FederationDirectiveNames.External);
+                FusionBuiltIns.SourceSchemaDirectives[WellKnownDirectiveNames.External];
 
             field.Directives.Add(new Directive(externalDirectiveDefinition));
         }

--- a/src/HotChocolate/Fusion/src/Fusion.Composition/SourceSchemaParser.cs
+++ b/src/HotChocolate/Fusion/src/Fusion.Composition/SourceSchemaParser.cs
@@ -7,6 +7,7 @@ using HotChocolate.Fusion.Logging.Contracts;
 using HotChocolate.Fusion.Options;
 using HotChocolate.Fusion.Results;
 using HotChocolate.Logging;
+using HotChocolate.Types;
 using HotChocolate.Types.Mutable;
 using HotChocolate.Types.Mutable.Serialization;
 using FusionLogEntryBuilder = HotChocolate.Fusion.Logging.LogEntryBuilder;
@@ -39,20 +40,31 @@ internal sealed class SourceSchemaParser(
             FederationV1DirectiveDefinitions.Apply(schema);
         }
 
-        // Apollo Federation's @requires directive has no Fusion-native definition (the Fusion
-        // equivalent @require differs in name and argument shape). Register it before parsing
-        // federation source schemas so an applied @requires binds to a real definition instead
-        // of a missing one; preprocessing then rewrites it to @require and removes the
-        // definition. A non-federation schema does not get the definition, so an applied
-        // @requires is reported as an unknown directive, steering authors to @require.
         if (!isApolloFederationV1 && IsFederationSourceText(sourceSchemaText))
         {
+            // Apollo Federation's @requires directive has no Fusion-native definition (the Fusion
+            // equivalent @require differs in name and argument shape). Register it before parsing
+            // federation source schemas so an applied @requires binds to a real definition instead
+            // of a missing one; preprocessing then rewrites it to @require and removes the
+            // definition. A non-federation schema does not get the definition, so an applied
+            // @requires is reported as an unknown directive, steering authors to @require.
             if (schema.Types.TryGetType<MutableScalarTypeDefinition>(
                 WellKnownTypeNames.FieldSelectionSet, out var fieldSelectionSetType))
             {
                 schema.DirectiveDefinitions.Add(
                     new RequiresMutableDirectiveDefinition(fieldSelectionSetType));
             }
+
+            // Apollo Federation's @external may also be applied to object types, which the
+            // Fusion @external definition does not allow. Replace it so federation applications
+            // bind to the federation shape; RemoveFederationInfrastructure drops the definition
+            // during preprocessing.
+            schema.DirectiveDefinitions.Remove(WellKnownDirectiveNames.External);
+            schema.DirectiveDefinitions.Add(
+                new MutableDirectiveDefinition(FederationDirectiveNames.External)
+                {
+                    Locations = DirectiveLocation.FieldDefinition | DirectiveLocation.Object
+                });
 
             // @link carries the federation vocabulary a subgraph imports and is applied to the
             // schema itself. RemoveFederationInfrastructure drops the definition and every


### PR DESCRIPTION
## Summary

- Adds `DirectiveIsInValidLocationRule` to `HotChocolate.Types.Validation`: a directive application at a location its definition does not declare is now reported as `HCV0032`. Applications without a definition are skipped, since `DirectiveIsDefinedRule` already reports those.
- `DirectiveEvent` now carries the `DirectiveLocation` at which the directive is applied, supplied by `SchemaValidator` at each publish site, since the location cannot be inferred from the member alone (arguments and input fields are both `IInputValueDefinition`). This is a breaking change to the public `DirectiveEvent` record struct.
- Apollo Federation preprocessing now attaches its synthesized `@internal`, `@lookup`, `@is`, `@shareable`, `@require`, and `@external` applications to the `FusionBuiltIns.SourceSchemaDirectives` definitions instead of detached placeholder definitions, so the applications carry the declared locations the new rule checks.

## Test plan

- New `DirectiveIsInValidLocationRuleTests` with a failing case per type-system location (schema, scalar, object, interface, union, enum, enum value, input object, input field, field, field argument, directive definition, and directive-definition argument), plus declared-locations, repeatable, and undefined-directive controls.
- `dotnet test src/HotChocolate/Core/test/Types.Validation.Tests`: 632/632 pass.
- `dotnet test src/HotChocolate/Fusion/test/Fusion.Composition.Tests`: 3160/3160 pass.
