### PR TITLE
Pin MCP server versions and remove Lighthouse server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,17 +2,13 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
-    },
-    "lighthouse": {
-      "command": "npx",
-      "args": ["-y", "@danielsogl/lighthouse-mcp@latest"]
+      "args": ["--yes", "@playwright/mcp@0.0.79"]
     },
     "nuget": {
       "command": "dotnet",
       "args": [
         "dnx",
-        "NuGet.Mcp.Server",
+        "NuGet.Mcp.Server@1.4.16",
         "--source",
         "https://api.nuget.org/v3/index.json",
         "--yes"


### PR DESCRIPTION
## Summary

- Pin the two locally-launched MCP servers to exact versions: `@playwright/mcp@0.0.79` and `NuGet.Mcp.Server@1.4.16`. Both were floating before (`@latest` and a bare package ID), so every launch re-resolved to whatever was newest at that moment. There is no lockfile, no integrity hash, and no minimum-release-age setting behind a launcher spec, and an MCP server runs on the host as the developer's own account rather than inside the devcontainer, so a compromised release would execute unsandboxed. Pinning to a published version also makes the content stable, since neither npm nor NuGet permits republishing a version.
- Remove the `lighthouse` server. It is a single-maintainer package at roughly 2,000 weekly downloads, and its current release was six days old at review time. Cooldown-style protection relies on someone else installing a bad release first and reporting it, which does not hold at that volume, and a tracked `.mcp.json` imposes the server on every contributor rather than the one person doing website performance work.
- Spell npx's flag as `--yes` rather than `-y`, so both local entries use the same form. `microsoft.docs.mcp` is unchanged: it is an HTTP endpoint with no version to pin.

## Test plan

- `python3 -c 'import json; json.load(open(".mcp.json"))'` parses cleanly.
- Verified against the npm and NuGet registries that `@playwright/mcp@0.0.79` (published 2026-08-06) and `NuGet.Mcp.Server@1.4.16` (published 2026-06-30, listed) both exist, and that both are more than seven days old. Both are published through GitHub Actions OIDC trusted publishing with provenance attestations present.
- Verified `dotnet dnx` accepts the `<packageId>@<version>` form on SDK 11.0.100-preview.6 and still accepts `--yes`, so the NuGet entry's remaining flags are untouched.
- Verified `--yes` is npm's registered long form for `-y` (`yes` config, `short: 'y'`).
- Reconnect with `/mcp`, or restart, to pick the pinned versions up. An already-running server process keeps the version it launched with.
