### PR TITLE
Stabilize feature-factory deadlock guard test under CI load

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/Processing/OperationFeatureCollectionTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Processing/OperationFeatureCollectionTests.cs
@@ -5,8 +5,8 @@ namespace HotChocolate.Execution.Processing;
 
 public class OperationFeatureCollectionTests
 {
-    private static readonly TimeSpan s_handshakeTimeout = TimeSpan.FromSeconds(5);
-    private static readonly TimeSpan s_completionTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan s_handshakeTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan s_completionTimeout = TimeSpan.FromSeconds(60);
 
     [Fact]
     public async Task GetOrSetSafe_Should_NotDeadlock_When_FactoryRacesLazySelectionSetCompilation()
@@ -36,8 +36,14 @@ public class OperationFeatureCollectionTests
         // act
         // the optimizer of `first` runs while the operation lock is held and writes its selection
         // feature only after the feature factory of `second` has started to compile a selection set.
-        var compilation = Task.Run(() => operation.GetSelectionSet(first), cancellationToken);
-        var featureFactory = Task.Run(
+        // both sides run on dedicated threads to keep the handshake independent of thread-pool
+        // scheduling.
+        var compilation = Task.Factory.StartNew(
+            () => operation.GetSelectionSet(first),
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+        var featureFactory = Task.Factory.StartNew(
             () =>
             {
                 if (!compilationStarted.Wait(s_handshakeTimeout, cancellationToken))
@@ -52,7 +58,9 @@ public class OperationFeatureCollectionTests
                         return new SelectorFeature(operation.GetSelectionSet(second));
                     });
             },
-            cancellationToken);
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
         var deadlocked = false;
 


### PR DESCRIPTION
## Summary

- `GetOrSetSafe_Should_NotDeadlock_When_FactoryRacesLazySelectionSetCompilation` intermittently hit its deadlock guard in the Main Branch Coverage workflow: under coverage instrumentation and parallel test load, thread-pool scheduling can delay one side of the test's handshake past its 5s window, and the stalled handshake was then reported as a deadlock.
- The two racing sides now run on dedicated threads (`TaskCreationOptions.LongRunning`), making the handshake independent of thread-pool scheduling, and the handshake/completion timeouts are raised to 30s/60s. A genuine deadlock still fails the test at the completion timeout.

## Test plan

- Ran the test against the current product code: passes in under a second.
- Temporarily reverted the product fix from #10168 and confirmed the reworked test still detects the original deadlock, then restored the product code.
