### PR TITLE
Honor client preference order in WebSocket sub-protocol negotiation

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Subscriptions/WebSocketConnection.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Subscriptions/WebSocketConnection.cs
@@ -56,15 +56,14 @@ internal sealed class WebSocketConnection : ISocketConnection
 
         var webSocketManager = HttpContext.WebSockets;
 
-        if (webSocketManager.WebSocketRequestedProtocols.Count > 0)
+        // The client lists its sub-protocols in preference order (RFC 6455 4.1), so the
+        // first requested protocol that has a registered handler is accepted.
+        foreach (var requestedProtocol in webSocketManager.WebSocketRequestedProtocols)
         {
-            foreach (var protocolHandler in _protocolHandlers)
+            if (TryGetProtocolHandler(requestedProtocol, out var protocolHandler))
             {
-                if (webSocketManager.WebSocketRequestedProtocols.Contains(protocolHandler.Name))
-                {
-                    _webSocket = await webSocketManager.AcceptWebSocketAsync(protocolHandler.Name);
-                    return protocolHandler;
-                }
+                _webSocket = await webSocketManager.AcceptWebSocketAsync(protocolHandler.Name);
+                return protocolHandler;
             }
         }
 
@@ -257,6 +256,24 @@ internal sealed class WebSocketConnection : ISocketConnection
             ConnectionCloseReason.ProtocolError => WebSocketCloseStatus.ProtocolError,
             _ => WebSocketCloseStatus.Empty
         };
+
+    private bool TryGetProtocolHandler(
+        string protocolName,
+        [NotNullWhen(true)] out IProtocolHandler? protocolHandler)
+    {
+        foreach (var handler in _protocolHandlers)
+        {
+            if (string.Equals(handler.Name, protocolName, StringComparison.Ordinal))
+            {
+                protocolHandler = handler;
+                return true;
+            }
+        }
+
+        protocolHandler = null;
+
+        return false;
+    }
 
     public void Dispose()
     {

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/WebSocketConnectionTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/Subscriptions/WebSocketConnectionTests.cs
@@ -1,0 +1,64 @@
+using System.Net.WebSockets;
+using HotChocolate.AspNetCore.Tests.Utilities;
+using Microsoft.AspNetCore.TestHost;
+
+namespace HotChocolate.AspNetCore.Subscriptions;
+
+public class WebSocketConnectionTests(TestServerFactory serverFactory)
+    : ServerTestBase(serverFactory)
+{
+    private static readonly Uri s_subscriptionUri = new("ws://localhost:5000/graphql");
+
+    [Theory]
+    [InlineData(new[] { "graphql-transport-ws", "graphql-ws" }, "graphql-transport-ws")]
+    [InlineData(new[] { "graphql-ws", "graphql-transport-ws" }, "graphql-ws")]
+    [InlineData(new[] { "foo", "graphql-ws" }, "graphql-ws")]
+    [InlineData(new[] { "graphql-transport-ws" }, "graphql-transport-ws")]
+    [InlineData(new[] { "graphql-ws" }, "graphql-ws")]
+    public async Task TryAcceptConnection_Should_AcceptFirstSupportedProtocol_When_AnySupported(
+        string[] protocols,
+        string expectedProtocol)
+    {
+        // arrange
+        using var testServer = CreateStarWarsServer();
+        var client = CreateWebSocketClient(testServer, protocols);
+
+        // act
+        using var webSocket = await client.ConnectAsync(
+            s_subscriptionUri,
+            TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal(expectedProtocol, webSocket.SubProtocol);
+    }
+
+    [Fact]
+    public async Task TryAcceptConnection_Should_CloseWithProtocolError_When_NoneSupported()
+    {
+        // arrange
+        var ct = TestContext.Current.CancellationToken;
+        using var testServer = CreateStarWarsServer();
+        var client = CreateWebSocketClient(testServer, ["foo", "bar"]);
+
+        // act
+        using var webSocket = await client.ConnectAsync(s_subscriptionUri, ct);
+        await webSocket.ReceiveAsync(new byte[1024], ct);
+
+        // assert
+        Assert.Equal(WebSocketCloseStatus.ProtocolError, webSocket.CloseStatus);
+    }
+
+    private static WebSocketClient CreateWebSocketClient(
+        TestServer testServer,
+        string[] protocols)
+    {
+        var client = testServer.CreateWebSocketClient();
+
+        foreach (var protocol in protocols)
+        {
+            client.SubProtocols.Add(protocol);
+        }
+
+        return client;
+    }
+}

--- a/website/content/docs/hotchocolate/server/http-transport.md
+++ b/website/content/docs/hotchocolate/server/http-transport.md
@@ -355,7 +355,7 @@ Hot Chocolate supports two WebSocket sub-protocols:
 | `graphql-transport-ws` | The modern protocol defined by the [graphql-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) library. This is the recommended protocol for new projects.                                       |
 | `graphql-ws`           | The legacy protocol defined by Apollo's [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md). Use this for backward compatibility with older clients. |
 
-The client selects its preferred sub-protocol via the standard WebSocket `Sec-WebSocket-Protocol` header during the handshake. Hot Chocolate negotiates and accepts whichever protocol the client requests.
+The client lists the sub-protocols it supports in the standard WebSocket `Sec-WebSocket-Protocol` header during the handshake, ordered by preference. Hot Chocolate accepts the first listed sub-protocol it supports. If none of the listed sub-protocols is supported, the server closes the connection with close code `1002` (protocol error).
 
 ## Enabling WebSocket Support
 
@@ -413,7 +413,7 @@ app.MapGraphQLWebSocket("/graphql/ws")
 
 A WebSocket connection follows this sequence:
 
-1. The client opens a WebSocket connection and specifies the sub-protocol.
+1. The client opens a WebSocket connection and lists the sub-protocols it supports.
 2. The client sends a `connection_init` message within the `ConnectionInitializationTimeout` window.
 3. The server responds with `connection_ack`.
 4. The client subscribes to operations by sending `subscribe` messages.


### PR DESCRIPTION
## Summary

- `WebSocketConnection.TryAcceptConnection` walks the client's `Sec-WebSocket-Protocol` list in the order it was sent and accepts the first sub-protocol that has a registered handler, so a client offering `graphql-transport-ws, graphql-ws` is answered with `graphql-transport-ws`. Handler registration and the `ProtocolError` close for unsupported protocols are unchanged.
- The HTTP transport docs describe preference-ordered negotiation and the `1002` close.

## Test plan

- New `WebSocketConnectionTests` cover both preference orders, an unsupported protocol listed ahead of a supported one, each protocol offered alone, and unsupported-only offers closing with `ProtocolError`.
- `HotChocolate.AspNetCore.Tests` and `HotChocolate.Transport.Sockets.Client.Tests` pass on net10.0.
