### PR TITLE
[Website] Clear the remaining ESLint warnings

### DIFF
--- a/website/eslint.config.mjs
+++ b/website/eslint.config.mjs
@@ -18,6 +18,21 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
   ]),
   ...storybook.configs["flat/recommended"],
+  {
+    rules: {
+      // Guards a Pages Router constraint: `beforeInteractive` belongs in
+      // `pages/_document.js`. This site is App Router only, and the rule
+      // already exempts files under `app/`, so it only ever fires on
+      // components that live in `src/` by convention.
+      "@next/next/no-before-interactive-script-outside-document": "off",
+      // A leading underscore marks a binding that exists only to be skipped: a
+      // marker component's unread props, or a key destructured to omit it.
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/website/src/image-optimization/generate.mjs
+++ b/website/src/image-optimization/generate.mjs
@@ -320,7 +320,7 @@ async function ensureShareVariant(
     } catch {
       // best-effort
     }
-    const { shareSrc, shareHash: _stale, ...rest } = entry;
+    const { shareSrc: _shareSrc, shareHash: _shareHash, ...rest } = entry;
     return rest;
   }
 


### PR DESCRIPTION
## Summary

- `yarn lint` reported four warnings. Two came from bindings the code deliberately does not read, one from a binding that needed renaming to say so, and one from a rule that cannot apply to this site at all. Lint is now clean, so any future warning is a real signal rather than noise on top of a known baseline.
- `@typescript-eslint/no-unused-vars` gains `argsIgnorePattern` and `varsIgnorePattern` of `^_`, matching the convention already used for `Tab`'s unread props in `src/design-system/Tabs.tsx` and for the discarded key in `src/image-optimization/generate.mjs`.
- `ensureShareVariant` now writes `const { shareSrc: _shareSrc, shareHash: _shareHash, ...rest }`. Both keys exist in that pattern only to be excluded from `rest`.
- `@next/next/no-before-interactive-script-outside-document` is turned off. It guards a Pages Router constraint — `beforeInteractive` belongs in `pages/_document.js` — and this site has no `pages/` directory. The rule skips any file under `app/`, but reusable components live in `src/components/` here, so it fires on those instead. Its only report was `AnalyticsScripts`, which is rendered from `app/layout.tsx`.

## Test plan

- `yarn lint` exits 0 and reports 0 errors and 0 warnings, confirmed against `--format json` counts.
- `yarn format:check` passes.
- `yarn build` passes, which exercises `generate.mjs` rather than only type-checking it.
