### PR TITLE
Update Testcontainers to clear the SSH.NET vulnerability

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -83,9 +83,9 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.LocalStack" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.ServiceBus" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.LocalStack" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.ServiceBus" Version="4.14.0" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3" />


### PR DESCRIPTION
## Summary

- Bumps `Testcontainers`, `Testcontainers.LocalStack`, and `Testcontainers.ServiceBus` from 4.13.0 to 4.14.0.
- Testcontainers 4.14.0 raises its SSH.NET floor to 2026.0.0, which clears [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) (CVE-2026-48798, high — `ScpClient` recursive download allows arbitrary file write) for the test projects that reference Testcontainers directly. Nothing in the repo calls SSH.NET, and no shipped package resolves it.
- The test projects that get Testcontainers through Squadron 2.0.0-p.1 still resolve SSH.NET 2025.1.0; a follow-up Squadron bump to 2.0.0-p.3 clears those.

## Test plan

- Restored the affected solutions (AspNetCore, Fusion, and Mocha) with `--force-evaluate` and built all three.
- Re-ran `dotnet list package --vulnerable --include-transitive`: AspNetCore and Fusion report no vulnerable packages on any target framework; Mocha reports SSH.NET only in the Squadron-fed projects.
- Ran the OPA authorization test project as a live container smoke test: 17/17 passing on net10.0.
