### PR TITLE
Remove stale project entry from the Primitives solution

### DIFF
--- a/src/HotChocolate/Primitives/HotChocolate.Primitives.slnx
+++ b/src/HotChocolate/Primitives/HotChocolate.Primitives.slnx
@@ -1,6 +1,5 @@
 <Solution>
   <Folder Name="/src/">
-    <Project Path="src/Primitives.Data/HotChocolate.Data.Primitives.csproj" />
     <Project Path="src/Primitives/HotChocolate.Primitives.csproj" />
   </Folder>
   <Folder Name="/test/">


### PR DESCRIPTION
## Summary

- Removes the `src/Primitives.Data/HotChocolate.Data.Primitives.csproj` entry from `HotChocolate.Primitives.slnx`; the project does not exist on disk, so any restore or build of the solution failed with MSB3202. `All.slnx` and `Build.Pack.slnx` already list only the two real Primitives projects.

## Test plan

- `dotnet restore src/HotChocolate/Primitives/HotChocolate.Primitives.slnx` succeeds.
