### PR TITLE
Retry the Fusion archive open when a concurrent reader holds it

### DIFF
--- a/src/Nitro/CommandLine/src/CommandLine/Commands/Fusion/FusionComposeCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Commands/Fusion/FusionComposeCommand.cs
@@ -683,9 +683,10 @@ internal sealed class FusionComposeCommand : Command
     }
 
     /// <summary>
-    /// Opens the archive for update, or creates it when it does not exist. A concurrent
-    /// reader, such as a gateway reloading the archive, holds the file only briefly, so
-    /// a locked archive is retried until the reader releases its handle.
+    /// Opens the archive for update, or creates it when it does not exist. An attempt
+    /// that fails with an <see cref="IOException"/>, such as a sharing violation from a
+    /// concurrent reader, is retried at a fixed delay; after
+    /// <see cref="MaxArchiveOpenAttempts"/> attempts the exception propagates.
     /// </summary>
     private static async Task<FusionArchive> OpenOrCreateArchiveAsync(
         IFileSystem fileSystem,
@@ -702,6 +703,7 @@ internal sealed class FusionComposeCommand : Command
             }
             catch (IOException) when (attempt < MaxArchiveOpenAttempts)
             {
+                // Retry: the archive is briefly locked by a concurrent reader.
             }
 
             await Task.Delay(s_archiveOpenRetryDelay, cancellationToken);

--- a/src/Nitro/CommandLine/src/CommandLine/Commands/Fusion/FusionComposeCommand.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Commands/Fusion/FusionComposeCommand.cs
@@ -10,6 +10,9 @@ namespace ChilliCream.Nitro.CommandLine.Commands.Fusion;
 
 internal sealed class FusionComposeCommand : Command
 {
+    private const int MaxArchiveOpenAttempts = 50;
+    private static readonly TimeSpan s_archiveOpenRetryDelay = TimeSpan.FromMilliseconds(100);
+
     public FusionComposeCommand() : base("compose")
     {
         Description = "Compose multiple source schemas into a single composite schema.";
@@ -599,9 +602,10 @@ internal sealed class FusionComposeCommand : Command
                 }
             }
 
-            using var archive = fileSystem.FileExists(archiveFile) || File.Exists(archiveFile)
-                ? FusionArchive.Open(archiveFile, mode: FusionArchiveMode.Update)
-                : FusionArchive.Create(archiveFile);
+            using var archive = await OpenOrCreateArchiveAsync(
+                fileSystem,
+                archiveFile,
+                cancellationToken);
 
             if (removeSourceSchemas.Count > 0)
             {
@@ -675,6 +679,32 @@ internal sealed class FusionComposeCommand : Command
             {
                 settings.Dispose();
             }
+        }
+    }
+
+    /// <summary>
+    /// Opens the archive for update, or creates it when it does not exist. A concurrent
+    /// reader, such as a gateway reloading the archive, holds the file only briefly, so
+    /// a locked archive is retried until the reader releases its handle.
+    /// </summary>
+    private static async Task<FusionArchive> OpenOrCreateArchiveAsync(
+        IFileSystem fileSystem,
+        string archiveFile,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return fileSystem.FileExists(archiveFile) || File.Exists(archiveFile)
+                    ? FusionArchive.Open(archiveFile, mode: FusionArchiveMode.Update)
+                    : FusionArchive.Create(archiveFile);
+            }
+            catch (IOException) when (attempt < MaxArchiveOpenAttempts)
+            {
+            }
+
+            await Task.Delay(s_archiveOpenRetryDelay, cancellationToken);
         }
     }
 

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Fusion/FusionRemoteComposeCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Fusion/FusionRemoteComposeCommandTests.cs
@@ -1019,6 +1019,65 @@ public sealed class FusionRemoteComposeCommandTests(NitroCommandFixture fixture)
         Assert.False(File.Exists(archiveFile));
     }
 
+    [Fact]
+    public async Task Compose_Should_Succeed_When_ArchiveIsTemporarilyLockedByReader()
+    {
+        const string initialSourceSchema = "type Query { initial: String }";
+        const string updatedSourceSchema = "type Query { updated: String }";
+        const string settingsJson =
+            """{ "name": "Remote", "transports": { "http": { "url": "http://runtime/graphql" } } }""";
+        var archiveFile = CreateTempFile();
+        SetupFile("remote/schema-settings.json", settingsJson);
+        using var initialClient =
+            CreateClient(_ => Response(HttpStatusCode.OK, initialSourceSchema));
+        SetupHttpClient(initialClient);
+        string[] arguments =
+        [
+            "fusion",
+            "compose",
+            "--source-schema-url",
+            "https://composition.example/graphql/schema.graphql",
+            "--source-schema-settings-file",
+            "remote/schema-settings.json",
+            "--archive",
+            archiveFile
+        ];
+        var initialResult = await ExecuteCommandAsync(arguments);
+        Assert.Equal(0, initialResult.ExitCode);
+        using var updatedClient =
+            CreateClient(_ => Response(HttpStatusCode.OK, updatedSourceSchema));
+        SetupHttpClient(updatedClient);
+        await using var reader = File.OpenRead(archiveFile);
+
+        try
+        {
+            await using var probe = File.Open(archiveFile, FileMode.Open, FileAccess.ReadWrite);
+            Assert.Skip("This environment does not enforce file sharing.");
+        }
+        catch (IOException)
+        {
+            // The reader blocks opening the archive for update until it is disposed.
+        }
+
+        var commandTask = ExecuteCommandAsync(arguments);
+        await Task.Delay(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
+        await reader.DisposeAsync();
+        var result = await commandTask;
+
+        Assert.Equal(0, result.ExitCode);
+        using var archive = FusionArchive.Open(archiveFile);
+        using var configuration = await archive.TryGetSourceSchemaConfigurationAsync(
+            "Remote",
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(configuration);
+        await using var schemaStream = await configuration.OpenReadSchemaAsync(
+            TestContext.Current.CancellationToken);
+        using var streamReader = new StreamReader(schemaStream);
+        Assert.Equal(
+            updatedSourceSchema,
+            await streamReader.ReadToEndAsync(TestContext.Current.CancellationToken));
+    }
+
     private string CreateTempFile()
     {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());


### PR DESCRIPTION
## Summary

- `nitro fusion compose` now retries opening the archive (bounded: 50 attempts, 100 ms apart) when the open fails with an `IOException`, instead of failing the composition outright.
- Opening the archive for update conflicts with any concurrently held read handle, and .NET enforces `FileShare` on Linux as well (flock emulation), so a reader that briefly holds the file — a gateway hot-reloading the archive, or a test polling it — could make a `--watch` recomposition fail with exit 1 and silently drop the change, since nothing re-triggers the composition afterwards. This was the root cause of the flaky `ComposeWatch_Should_RefetchRemoteSchema_When_SettingsChangeWithoutRenaming` CI failures.
- The retry mirrors the existing `CopyArchiveWithRetryAsync` pattern in Fusion.Aspire.

## Test plan

- New `Compose_Should_Succeed_When_ArchiveIsTemporarilyLockedByReader` reproduces the race deterministically: it holds a read handle on the archive, starts a compose, and releases the handle 500 ms in (with a skip guard for environments that do not enforce file sharing). Verified red against the previous code, then green.
- Stress-ran the previously flaky watch test 15 times: all passed.
- Full Nitro.CommandLine.Tests suite: 3599/3599 passed.
