### PR TITLE
Fix ambiguous wait patterns in the Nitro e2e tapes

### DIFF
--- a/src/Nitro/CommandLine/test/e2e/agent-root-flow.tape
+++ b/src/Nitro/CommandLine/test/e2e/agent-root-flow.tape
@@ -54,7 +54,9 @@ Type "y"
 Sleep 500ms
 Type `echo "agent-root-flow: back at the shell"` Enter
 
-Wait+Screen@30s /agent-root-flow: back at the shell/
+# The typed command line itself contains the sentinel, so the wait requires
+# a second occurrence: the echo's own output line.
+Wait+Screen@30s /agent-root-flow: back at the shell[\s\S]*agent-root-flow/
 Sleep 1500ms
 Screenshot agent-root-flow-final.png
 Sleep 500ms

--- a/src/Nitro/CommandLine/test/e2e/detail-flow.tape
+++ b/src/Nitro/CommandLine/test/e2e/detail-flow.tape
@@ -100,17 +100,20 @@ Type "t"
 Type "d"
 Wait+Screen@30s /acme-epic1 · blocking · depended on by/
 
-# Down selects the first child (acme-epic1.1); Enter refocuses the tree on
-# it (DependencyTreeView.Refocus), pushing acme-epic1 onto the breadcrumb
-# stack. Its own Down tree (still Blocking/Down) shows acme-epic1.2, which
-# blocks-depends-on acme-epic1.1 per fixtures/seed.sql, and transitively
-# acme-a1b beneath it. The panel header carries the breadcrumb, but at this
-# fixed geometry the two-id breadcrumb text overflows the header and gets
-# ellipsis-truncated by Spectre's PanelHeader before it reaches " by", so the
-# wait anchors on the unwrapped, untruncated root row instead.
+# Down selects the first child (acme-epic1.1) in the still-rooted tree; the
+# selection cursor moving off the root row is the sync.
 Down
-Enter
 Wait+Screen@30s /> ● \[T\] P2 acme-epic1\.1 Draft new pricing copy/
+
+# Enter refocuses the tree on the selected child (DependencyTreeView.Refocus),
+# pushing acme-epic1 onto the breadcrumb stack. Its own Down tree (still
+# Blocking/Down) shows acme-epic1.2, which blocks-depends-on acme-epic1.1
+# per fixtures/seed.sql, and transitively acme-a1b beneath it. The sync is
+# the breadcrumb header (DependencyTreeView.BuildTitle): its trail now ends
+# in acme-epic1.1 right before the edge-mode suffix, text the tree rooted on
+# acme-epic1 never shows.
+Enter
+Wait+Screen@30s /epic1\.1 · blocking/
 
 # 'u' pops the breadcrumb stack (DependencyTreeView.NavigateBack), back to
 # the tree rooted on acme-epic1 with its two children again -- the tree

--- a/src/Nitro/CommandLine/test/e2e/mail-send-flow.tape
+++ b/src/Nitro/CommandLine/test/e2e/mail-send-flow.tape
@@ -23,7 +23,10 @@
 # when the next command starts typing, producing a stray leading character
 # that differs between recordings -- non-determinism this tier exists to
 # avoid, seen even on short single-line commands during this flow's own
-# development. Message ids are minted from wall-clock time
+# development. Each Wait pattern must match text only the just-run command
+# produces: text already on screen (a typed argument, an earlier command's
+# output) satisfies the Wait instantly, and the next Type then races the
+# still-pending output. Message ids are minted from wall-clock time
 # (MailStore.CreateMessageIdAsync) and dates are real `now`, both
 # non-deterministic across recordings; run.sh's mail-send SCRUBS entry
 # normalizes both before diffing. Needs no auth: mail commands do not call
@@ -81,7 +84,7 @@ Wait+Screen@30s /Sent '/
 Sleep 500ms
 
 Type `nitro agent mail inbox --actor bob` Enter
-Wait+Screen@30s /Status/
+Wait+Screen@30s /message\(s\)/
 Sleep 500ms
 
 # Captures the id from bob's own inbox listing (its first column, see
@@ -93,7 +96,7 @@ Wait+Screen@30s /captured m-/
 Sleep 500ms
 
 Type `nitro agent mail reply --message "$MSG_ID" --actor bob --body Thanks-noted` Enter
-Wait+Screen@30s /Sent '/
+Wait+Screen@30s /Sent '[^']+' to alice\./
 Sleep 500ms
 
 # Read as alice (the original sender, and a recipient of bob's reply
@@ -101,7 +104,7 @@ Sleep 500ms
 # oldest first, marks alice's copy of the reply read, and shows alice's
 # "reviewer" role in the first message's From header.
 Type `nitro agent mail read --message "$MSG_ID" --thread --actor alice` Enter
-Wait+Screen@30s /Thanks-noted/
+Wait+Screen@30s /From: bob[\s\S]*Thanks-noted/
 
 Sleep 1500ms
 Screenshot mail-send-flow-final.png


### PR DESCRIPTION
## Summary

- A VHS `Wait+Screen` pattern that already matches text on screen (a typed argument or an earlier command's output) returns instantly, so the tape stops syncing on the command it just ran; under CI load the next keystrokes then race the still-pending output. The `mail-send` flow failed this way on main ([run 33374317479](https://github.com/ChilliCream/graphql-platform/actions/runs/33374317479)): the reply's `Wait /Sent '/` matched the earlier send's output, and the next command's first keystrokes landed inside the reply's confirmation line.
- `mail-send-flow.tape`: the inbox, reply, and read waits now match only output the just-run command produces, and the tape's determinism comment states the rule.
- `detail-flow.tape`: the `Down` + `Enter` pair now sync separately — `Down` on the selection cursor, `Enter` on the refocused tree's breadcrumb header — so the final wait can no longer match a frame from before the refocus.
- `agent-root-flow.tape`: the final wait requires a second occurrence of the echo sentinel, since the typed command line itself contains it.

All 17 tapes were audited; goldens are unchanged.

## Test plan

- Recorded `mail-send`, `detail`, and `agent-root` locally via `run.sh`; all three PASS against their unchanged goldens, so the new wait patterns match real frames (a wrong pattern would time out and fail the recording).
