### PR TITLE
Merge same-named fields across fragments in MCP tool output schemas

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
@@ -557,14 +557,76 @@ internal sealed class OperationToolFactory(ISchemaDefinition schema, McpToolOpti
                 propertyJsonSchemaBuilder.Description(pendingField.Field.Description);
             }
 
-            properties.Add(pendingField.ResponseName, propertyJsonSchemaBuilder.Build());
+            var propertySchema = propertyJsonSchemaBuilder.Build();
 
-            if (pendingField.SelectionState is SelectionState.Included)
+            // Multiple selections can share one response name (duplicate fields, or fields
+            // selected in different fragments), so merge on collision.
+            if (!properties.TryAdd(pendingField.ResponseName, propertySchema))
+            {
+                properties[pendingField.ResponseName] =
+                    MergeProperties(properties[pendingField.ResponseName], propertySchema);
+            }
+
+            if (pendingField.SelectionState is SelectionState.Included
+                && !requiredProperties.Contains(pendingField.ResponseName))
             {
                 requiredProperties.Add(pendingField.ResponseName);
             }
 
             return Continue;
+        }
+
+        /// <summary>
+        /// Merges two JSON schemas built for the same response name into one. Object schemas
+        /// merge to the union of their properties, with only the properties required by both
+        /// sides staying required; array schemas merge their item schemas the same way; all
+        /// other keywords are taken from <paramref name="first"/>.
+        /// </summary>
+        private static JsonSchema MergeProperties(JsonSchema first, JsonSchema second)
+        {
+            var builder = new JsonSchemaBuilder();
+            var mergeProperties =
+                first.GetProperties() is not null && second.GetProperties() is not null;
+            var mergeItems = first.GetItems() is not null && second.GetItems() is not null;
+
+            foreach (var keyword in first.Keywords ?? [])
+            {
+                switch (keyword)
+                {
+                    case PropertiesKeyword or RequiredKeyword when mergeProperties:
+                    case ItemsKeyword when mergeItems:
+                        continue;
+
+                    default:
+                        builder.Add(keyword);
+                        break;
+                }
+            }
+
+            if (mergeProperties)
+            {
+                var properties = new Dictionary<string, JsonSchema>(first.GetProperties()!);
+
+                foreach (var (propertyName, propertySchema) in second.GetProperties()!)
+                {
+                    properties[propertyName] =
+                        properties.TryGetValue(propertyName, out var existingSchema)
+                            ? MergeProperties(existingSchema, propertySchema)
+                            : propertySchema;
+                }
+
+                builder.Properties(properties);
+                builder.Required(
+                    (first.GetRequired() ?? [])
+                        .Intersect(second.GetRequired() ?? [], StringComparer.Ordinal));
+            }
+
+            if (mergeItems)
+            {
+                builder.Items(MergeProperties(first.GetItems()!, second.GetItems()!));
+            }
+
+            return builder.Build();
         }
 
         protected override ISyntaxVisitorAction Enter(

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
@@ -504,6 +504,38 @@ public sealed class OperationToolFactoryTests
     }
 
     [Fact]
+    public void CreateTool_InlineFragmentsWithDivergingListSubSelections_UnionsItemSubSelections()
+    {
+        // arrange
+        var schema = CreateVehicleSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetVehicles {
+                vehicles {
+                    ... on Car {
+                        wheels {
+                            size
+                        }
+                    }
+                    ... on Truck {
+                        wheels {
+                            size
+                            treadDepth
+                        }
+                    }
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
     public void CreateTool_FragmentSpreadsSelectSameField_MergesIntoSingleProperty()
     {
         // arrange
@@ -990,9 +1022,11 @@ public sealed class OperationToolFactoryTests
         string Id { get; }
     }
 
-    public sealed record Car(string Id, Engine? Engine) : IVehicle;
+    public sealed record Car(string Id, Engine? Engine, Wheel[]? Wheels) : IVehicle;
 
-    public sealed record Truck(string Id, Engine? Engine) : IVehicle;
+    public sealed record Truck(string Id, Engine? Engine, Wheel[]? Wheels) : IVehicle;
 
     public sealed record Engine(int Power, string? FuelKind);
+
+    public sealed record Wheel(int Size, double? TreadDepth);
 }

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
@@ -439,6 +439,125 @@ public sealed class OperationToolFactoryTests
     }
 
     [Fact]
+    public void CreateTool_InlineFragmentsOnDifferentTypesSelectSameField_MergesIntoSingleProperty()
+    {
+        // arrange
+        var schema = CreateVehicleSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetVehicles {
+                vehicles {
+                    id
+                    ... on Car {
+                        engine {
+                            power
+                        }
+                    }
+                    ... on Truck {
+                        engine {
+                            power
+                        }
+                    }
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
+    public void CreateTool_InlineFragmentsWithDivergingSubSelections_UnionsSubSelections()
+    {
+        // arrange
+        var schema = CreateVehicleSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetVehicles {
+                vehicles {
+                    id
+                    ... on Car {
+                        engine {
+                            power
+                        }
+                    }
+                    ... on Truck {
+                        engine {
+                            power
+                            fuelKind
+                        }
+                    }
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
+    public void CreateTool_FragmentSpreadsSelectSameField_MergesIntoSingleProperty()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetWithInterfaceType {
+                withInterfaceType {
+                    ...CatFields
+                    ...DogFields
+                }
+            }
+
+            fragment CatFields on Cat {
+                name
+            }
+
+            fragment DogFields on Dog {
+                name
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
+    public void CreateTool_DuplicateFieldSelection_MergesIntoSingleProperty()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetBooks {
+                books {
+                    title
+                    title
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
     public void CreateTool_WithSkipAndInclude_CreatesCorrectOutputSchema()
     {
         // arrange
@@ -834,6 +953,19 @@ public sealed class OperationToolFactoryTests
             .Create();
     }
 
+    private static Schema CreateVehicleSchema()
+    {
+        return SchemaBuilder
+            .New()
+            .AddMcp()
+            .ModifyOptions(o => o.StripLeadingIFromInterface = true)
+            .AddQueryType<VehicleQuery>()
+            .AddInterfaceType<IVehicle>()
+            .AddObjectType<Car>()
+            .AddObjectType<Truck>()
+            .Create();
+    }
+
     public sealed class RecursiveFilterQuery
     {
         public int GetWithRecursiveFilter(RecursiveFilter? filter) => filter is null ? 0 : 1;
@@ -847,4 +979,20 @@ public sealed class OperationToolFactoryTests
 
         public string? Name { get; set; }
     }
+
+    public sealed class VehicleQuery
+    {
+        public IVehicle[] GetVehicles() => [];
+    }
+
+    public interface IVehicle
+    {
+        string Id { get; }
+    }
+
+    public sealed record Car(string Id, Engine? Engine) : IVehicle;
+
+    public sealed record Truck(string Id, Engine? Engine) : IVehicle;
+
+    public sealed record Engine(int Power, string? FuelKind);
 }

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_DuplicateFieldSelection_MergesIntoSingleProperty.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_DuplicateFieldSelection_MergesIntoSingleProperty.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "books": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "books"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadsSelectSameField_MergesIntoSingleProperty.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadsSelectSameField_MergesIntoSingleProperty.json
@@ -1,0 +1,82 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "withInterfaceType": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "withInterfaceType"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsOnDifferentTypesSelectSameField_MergesIntoSingleProperty.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsOnDifferentTypesSelectSameField_MergesIntoSingleProperty.json
@@ -1,0 +1,102 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "vehicles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "engine": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "power": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                  }
+                },
+                "required": [
+                  "power"
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "vehicles"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsWithDivergingListSubSelections_UnionsItemSubSelections.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsWithDivergingListSubSelections_UnionsItemSubSelections.json
@@ -1,0 +1,108 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "vehicles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "wheels": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "size": {
+                      "type": "integer",
+                      "minimum": -2147483648,
+                      "maximum": 2147483647
+                    },
+                    "treadDepth": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "minimum": -79228162514264337593543950335,
+                      "maximum": 79228162514264337593543950335
+                    }
+                  },
+                  "required": [
+                    "size"
+                  ]
+                }
+              }
+            },
+            "required": [],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "vehicles"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsWithDivergingSubSelections_UnionsSubSelections.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentsWithDivergingSubSelections_UnionsSubSelections.json
@@ -1,0 +1,108 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "vehicles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "engine": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "power": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                  },
+                  "fuelKind": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "power"
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "vehicles"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- `OperationToolFactory` threw `ArgumentException` while building a tool's output schema whenever two selections shared a response name — inline fragments on different types selecting the same field (the shape any interface/union with implementation-declared fields forces), fragment spreads doing the same, or a plain duplicate field selection. Because the throw happened during warmup, one such operation took down the whole tool catalogue.
- Colliding response names now merge into a single property: object schemas union their properties, only sub-fields selected in every branch stay required, and array schemas merge their item schemas the same way. A field reached only through a type condition was already optional and stays that way.

## Test plan

- New `OperationToolFactory` snapshot tests cover same-named fields via inline fragments (identical and diverging sub-selections), via fragment spreads, and via duplicate field selections; each previously failed with the reported `ArgumentException`.
- Full `Adapters.Mcp.Tests` suite passes (241 tests).

Closes #10321
