### PR TITLE
Surface tool creation failures as unavailable MCP tools

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/AggregateMcpDiagnosticEventListener.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/AggregateMcpDiagnosticEventListener.cs
@@ -51,6 +51,14 @@ internal sealed class AggregateMcpDiagnosticEvents(IMcpDiagnosticEventListener[]
         return new AggregateActivityScope(scopes);
     }
 
+    public void ToolCreationFailed(string toolName, Exception exception)
+    {
+        foreach (var listener in listeners)
+        {
+            listener.ToolCreationFailed(toolName, exception);
+        }
+    }
+
     public void ValidationErrors(IReadOnlyList<IError> errors)
     {
         foreach (var listener in listeners)

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/IMcpDiagnosticEvents.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/IMcpDiagnosticEvents.cs
@@ -38,6 +38,13 @@ public interface IMcpDiagnosticEvents
     IDisposable UpdateTools();
 
     /// <summary>
+    /// Called when creating a tool from a validated tool document fails.
+    /// </summary>
+    /// <param name="toolName">The name of the tool.</param>
+    /// <param name="exception">The exception that occurred.</param>
+    void ToolCreationFailed(string toolName, Exception exception);
+
+    /// <summary>
     /// Called when errors occur while validating a tool document.
     /// </summary>
     /// <param name="errors">The validation errors.</param>

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/McpDiagnosticEventListener.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Diagnostics/McpDiagnosticEventListener.cs
@@ -22,6 +22,10 @@ public class McpDiagnosticEventListener : IMcpDiagnosticEventListener
 
     public virtual IDisposable UpdateTools() => EmptyScope;
 
+    public virtual void ToolCreationFailed(string toolName, Exception exception)
+    {
+    }
+
     public virtual void ValidationErrors(IReadOnlyList<IError> errors)
     {
     }

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpStorageObserver.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpStorageObserver.cs
@@ -271,7 +271,18 @@ internal sealed class McpStorageObserver : IDisposable
                 continue;
             }
 
-            tools.Add(toolDefinition.Name, _toolFactory.CreateTool(toolDefinition));
+            try
+            {
+                tools.Add(toolDefinition.Name, _toolFactory.CreateTool(toolDefinition));
+            }
+            catch (Exception exception)
+            {
+                _diagnosticEvents.ToolCreationFailed(toolDefinition.Name, exception);
+                // Treat a definition the tool factory cannot build a tool for like an
+                // invalid one, so a single broken definition does not take down the
+                // remaining tools.
+                invalidFallbacks.TryAdd(toolDefinition.Name, toolDefinition);
+            }
         }
 
         // For names with no valid definition at all, surface the first invalid one so calls

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -973,6 +973,38 @@ public abstract class IntegrationTestBase
     }
 
     [Fact]
+    public async Task ListTools_InitializeToolsToolCreationFails_SurfacesBothToolsAndLogsFailure()
+    {
+        // arrange
+        var storage = new TestMcpStorage();
+        // A document that passes validation but that the tool factory cannot build a tool
+        // for: the operation is anonymous, so no tool title can be derived from it.
+        await storage.AddOrUpdateToolAsync(
+            new OperationToolDefinition(Utf8GraphQLParser.Parse("{ books { title } }"))
+            {
+                Name = "failing"
+            },
+            TestContext.Current.CancellationToken);
+        await storage.AddOrUpdateToolAsync(
+            new OperationToolDefinition(
+                Utf8GraphQLParser.Parse("query Valid { books { title } }")),
+            TestContext.Current.CancellationToken);
+        var listener = new TestMcpDiagnosticEventListener();
+        var server = await CreateTestServerAsync(storage, diagnosticEventListener: listener);
+        var mcpClient = await CreateMcpClientAsync(server.CreateClient());
+
+        // act
+        var result = await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, tool => tool.Name == "valid");
+        Assert.Contains(result, tool => tool.Name == "failing");
+        var (toolName, _) = Assert.Single(listener.ToolCreationFailureLog);
+        Assert.Equal("failing", toolName);
+    }
+
+    [Fact]
     public async Task CallTool_InvalidDocument_ReturnsErrorResult()
     {
         // arrange
@@ -1485,7 +1517,14 @@ public abstract class IntegrationTestBase
 
 public sealed class TestMcpDiagnosticEventListener : McpDiagnosticEventListener
 {
+    public List<(string ToolName, Exception Exception)> ToolCreationFailureLog { get; } = [];
+
     public List<IError> ValidationErrorLog { get; } = [];
+
+    public override void ToolCreationFailed(string toolName, Exception exception)
+    {
+        ToolCreationFailureLog.Add((toolName, exception));
+    }
 
     public override void ValidationErrors(IReadOnlyList<IError> errors)
     {

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -994,14 +994,23 @@ public abstract class IntegrationTestBase
         var mcpClient = await CreateMcpClientAsync(server.CreateClient());
 
         // act
-        var result = await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var listResult = await mcpClient.ListToolsAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+        var callResult = await mcpClient.CallToolAsync(
+            "failing",
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // assert
-        Assert.Equal(2, result.Count);
-        Assert.Contains(result, tool => tool.Name == "valid");
-        Assert.Contains(result, tool => tool.Name == "failing");
+        Assert.Equal(2, listResult.Count);
+        Assert.Contains(listResult, tool => tool.Name == "valid");
+        Assert.Contains(listResult, tool => tool.Name == "failing");
         var (toolName, _) = Assert.Single(listener.ToolCreationFailureLog);
         Assert.Equal("failing", toolName);
+        Assert.Equal(true, callResult.IsError);
+        var content = Assert.Single(callResult.Content);
+        Assert.Equal(
+            "The tool 'failing' is currently unavailable.",
+            Assert.IsType<TextContentBlock>(content).Text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- A tool definition that passes document validation but makes `OperationToolFactory.CreateTool` throw no longer takes down the whole tool catalogue — or, on the warmup path, the host process (the containment gap noted in #10321). The failed definition now degrades the same way a schema-invalid one does: it is surfaced as an unavailable tool unless a valid same-named duplicate exists, and calls to it return the "currently unavailable" error.
- A new `ToolCreationFailed(toolName, exception)` diagnostic event reports the failure through `IMcpDiagnosticEvents`, alongside the existing `ValidationErrors` event.

## Test plan

- New integration test (runs in both the Core and Fusion flavors): storage holds a healthy tool plus a validated document the factory cannot build a tool for; both tools are listed, the broken one as unavailable, and the failure is logged once. Without the containment, the test reproduces the reported behavior: the unhandled exception fails application startup.
- Full `Adapters.Mcp.Tests` suite passes (244 tests).
