### PR TITLE
Narrow fragment spreads to their type condition in MCP tool schemas

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/FieldNodeExtensions.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/FieldNodeExtensions.cs
@@ -8,7 +8,8 @@ internal static class FieldNodeExtensions
     public static SelectionState GetSelectionState(
         this FieldNode fieldNode,
         ISyntaxNode? declaringNode,
-        ITypeDefinition? parentType)
+        ITypeDefinition? parentType,
+        NamedTypeNode? fragmentTypeCondition = null)
     {
         var skipField = fieldNode.GetSkipIfValue();
         var includeField = fieldNode.GetIncludeIfValue();
@@ -22,6 +23,12 @@ internal static class FieldNodeExtensions
             case FragmentSpreadNode fragmentSpread:
                 skipFragment = fragmentSpread.GetSkipIfValue();
                 includeFragment = fragmentSpread.GetIncludeIfValue();
+
+                if (fragmentTypeCondition is not null
+                    && fragmentTypeCondition.Name.Value != parentType?.Name)
+                {
+                    typeConditional = true;
+                }
 
                 break;
 

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
@@ -437,7 +437,7 @@ internal sealed class OperationToolFactory(ISchemaDefinition schema, McpToolOpti
 
             var parentType =
                 context.PendingFields.Count == 0
-                    ? null
+                    ? context.Schema.GetOperationType(context.OperationType)
                     : context.PendingFields.Peek().Field.Type.NamedType();
 
             var declaringNode = context.Nodes.ElementAtOrDefault(2);

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/OperationToolFactory.cs
@@ -440,9 +440,19 @@ internal sealed class OperationToolFactory(ISchemaDefinition schema, McpToolOpti
                     ? null
                     : context.PendingFields.Peek().Field.Type.NamedType();
 
+            var declaringNode = context.Nodes.ElementAtOrDefault(2);
+
+            NamedTypeNode? fragmentTypeCondition = null;
+            if (declaringNode is FragmentSpreadNode spreadNode
+                && context.Fragments.TryGetValue(spreadNode.Name.Value, out var fragmentNode))
+            {
+                fragmentTypeCondition = fragmentNode.TypeCondition;
+            }
+
             var selectionState = fieldNode.GetSelectionState(
-                declaringNode: context.Nodes.ElementAtOrDefault(2),
-                parentType);
+                declaringNode,
+                parentType,
+                fragmentTypeCondition);
 
             if (selectionState is SelectionState.Excluded)
             {
@@ -635,7 +645,14 @@ internal sealed class OperationToolFactory(ISchemaDefinition schema, McpToolOpti
         {
             if (context.Fragments.TryGetValue(fragmentSpreadNode.Name.Value, out var fragmentNode))
             {
+                // Narrow the type for the duration of this fragment.
+                var parent = context.Frames.Peek();
+                var typeCondition = fragmentNode.TypeCondition.Name.Value;
+                var narrowed = (IOutputTypeDefinition)context.Schema.Types[typeCondition];
+
+                context.Frames.Push(parent with { Type = narrowed });
                 Visit(fragmentNode.SelectionSet, context);
+                context.Frames.Pop();
             }
 
             return Skip;

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
@@ -620,6 +620,56 @@ public sealed class OperationToolFactoryTests
     }
 
     [Fact]
+    public void CreateTool_FragmentSpreadOnOperationType_KeepsFieldsRequired()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetBooks {
+                ...QueryFields
+            }
+
+            fragment QueryFields on Query {
+                books {
+                    title
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
+    public void CreateTool_InlineFragmentOnOperationType_KeepsFieldsRequired()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetBooks {
+                ... on Query {
+                    books {
+                        title
+                    }
+                }
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
     public void CreateTool_DuplicateFieldSelection_MergesIntoSingleProperty()
     {
         // arrange

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/OperationToolFactoryTests.cs
@@ -567,6 +567,59 @@ public sealed class OperationToolFactoryTests
     }
 
     [Fact]
+    public void CreateTool_FragmentSpreadSelectsImplementationDeclaredField_NarrowsToTypeCondition()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetWithInterfaceType {
+                withInterfaceType {
+                    name
+                    ...CatFields
+                }
+            }
+
+            fragment CatFields on Cat {
+                isPurring
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
+    public void CreateTool_FragmentSpreadOnParentType_KeepsFieldsRequired()
+    {
+        // arrange
+        var schema = CreateSchema();
+        var document = Utf8GraphQLParser.Parse(
+            """
+            query GetWithInterfaceType {
+                withInterfaceType {
+                    ...PetFields
+                }
+            }
+
+            fragment PetFields on Pet {
+                name
+            }
+            """);
+        var toolDefinition = new OperationToolDefinition(document);
+
+        // act
+        var tool = new OperationToolFactory(schema, new McpToolOptions()).CreateTool(toolDefinition);
+
+        // assert
+        tool.Tool.OutputSchema.MatchSnapshot(extension: ".json");
+    }
+
+    [Fact]
     public void CreateTool_DuplicateFieldSelection_MergesIntoSingleProperty()
     {
         // arrange

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadOnOperationType_KeepsFieldsRequired.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadOnOperationType_KeepsFieldsRequired.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "books": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "books"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadOnParentType_KeepsFieldsRequired.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadOnParentType_KeepsFieldsRequired.json
@@ -14,7 +14,9 @@
               "type": "string"
             }
           },
-          "required": [],
+          "required": [
+            "name"
+          ],
           "additionalProperties": false
         }
       },

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadSelectsImplementationDeclaredField_NarrowsToTypeCondition.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_FragmentSpreadSelectsImplementationDeclaredField_NarrowsToTypeCondition.json
@@ -12,9 +12,14 @@
           "properties": {
             "name": {
               "type": "string"
+            },
+            "isPurring": {
+              "type": "boolean"
             }
           },
-          "required": [],
+          "required": [
+            "name"
+          ],
           "additionalProperties": false
         }
       },

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentOnOperationType_KeepsFieldsRequired.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/OperationToolFactoryTests.CreateTool_InlineFragmentOnOperationType_KeepsFieldsRequired.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "books": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "books"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "locations": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "line": {
+                  "type": "integer"
+                },
+                "column": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "path": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "extensions": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- `OperationToolFactory` visited a named fragment's selection set without narrowing to the fragment's type condition, so a fragment on a concrete type selecting an implementation-declared field failed the field lookup on the abstract parent type (`KeyNotFoundException` from `CreateTool`). Fragment spreads now push a narrowed frame for the duration of the fragment, exactly like inline fragments.
- A spread's type condition now also feeds the output schema's requiredness: a field reached through a fragment whose type condition does not match the parent type is optional, matching the existing inline-fragment rule. This changes emitted output schemas for such operations — previously those fields were marked `required`.

## Test plan

- New snapshot tests: a fragment on an implementation selecting an implementation-declared field resolves and is optional (previously threw), and a fragment on the parent type itself keeps its fields required.
- One existing snapshot updated deliberately: fields selected only through fragments on concrete types are no longer `required`, aligning spread and inline-fragment semantics.
- Full `Adapters.Mcp.Tests` suite passes (246 tests).
