### PR TITLE
Share test containers per assembly via xUnit assembly fixtures

### DIFF
--- a/src/CookieCrumble/src/CookieCrumble.Resources.Mongo/MongoResource.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.Mongo/MongoResource.cs
@@ -5,9 +5,14 @@ namespace CookieCrumble.Resources;
 
 public class MongoResource : ContainerResource<MongoDbContainer>
 {
-    private MongoClient? _client;
+    private readonly Lazy<MongoClient> _client;
 
-    public IMongoClient Client => _client ??= new MongoClient(ConnectionString);
+    public MongoResource()
+    {
+        _client = new(() => new MongoClient(ConnectionString));
+    }
+
+    public IMongoClient Client => _client.Value;
 
     public string ConnectionString => Container.GetConnectionString();
 
@@ -29,4 +34,14 @@ public class MongoResource : ContainerResource<MongoDbContainer>
         => Configure(new MongoDbBuilder("mongo:6.0")).Build();
 
     protected virtual MongoDbBuilder Configure(MongoDbBuilder builder) => builder;
+
+    protected override ValueTask DisposeAsyncCore()
+    {
+        if (_client.IsValueCreated)
+        {
+            _client.Value.Dispose();
+        }
+
+        return ValueTask.CompletedTask;
+    }
 }

--- a/src/CookieCrumble/src/CookieCrumble.Resources.Nats/CookieCrumble.Resources.Nats.csproj
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.Nats/CookieCrumble.Resources.Nats.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NATS.Client.Core" />
+    <PackageReference Include="NATS.Client.JetStream" />
     <PackageReference Include="Testcontainers.Nats" />
   </ItemGroup>
 

--- a/src/CookieCrumble/src/CookieCrumble.Resources.Nats/NatsResource.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.Nats/NatsResource.cs
@@ -1,13 +1,52 @@
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
 using Testcontainers.Nats;
 
 namespace CookieCrumble.Resources;
 
 public class NatsResource : ContainerResource<NatsContainer>
 {
+    private readonly Lazy<NatsConnection> _connection;
+
+    public NatsResource()
+    {
+        _connection = new(() => new NatsConnection(new NatsOpts { Url = NatsConnectionString }));
+    }
+
     public string NatsConnectionString => Container.GetConnectionString();
+
+    /// <summary>
+    /// Creates a uniquely named JetStream stream over <paramref name="subjects"/>.
+    /// Disposing the returned stream deletes it.
+    /// </summary>
+    public async Task<NatsStream> CreateStreamAsync(
+        IReadOnlyList<string> subjects,
+        CancellationToken cancellationToken)
+    {
+        var name = $"S{Guid.NewGuid():N}";
+        var jetStream = new NatsJSContext(_connection.Value);
+        await jetStream.CreateStreamAsync(
+            new StreamConfig
+            {
+                Name = name,
+                Subjects = [.. subjects]
+            },
+            cancellationToken);
+
+        return new NatsStream(jetStream, name);
+    }
 
     protected override NatsContainer Build()
         => Configure(new NatsBuilder("nats:2.10-alpine")).Build();
 
     protected virtual NatsBuilder Configure(NatsBuilder builder) => builder;
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        if (_connection.IsValueCreated)
+        {
+            await _connection.Value.DisposeAsync();
+        }
+    }
 }

--- a/src/CookieCrumble/src/CookieCrumble.Resources.Nats/NatsStream.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.Nats/NatsStream.cs
@@ -1,0 +1,22 @@
+using NATS.Client.JetStream;
+
+namespace CookieCrumble.Resources;
+
+/// <summary>
+/// A JetStream stream created by <see cref="NatsResource.CreateStreamAsync"/>.
+/// Disposing it deletes the stream.
+/// </summary>
+public sealed class NatsStream : IAsyncDisposable
+{
+    private readonly NatsJSContext _jetStream;
+
+    internal NatsStream(NatsJSContext jetStream, string name)
+    {
+        _jetStream = jetStream;
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public async ValueTask DisposeAsync() => await _jetStream.DeleteStreamAsync(Name);
+}

--- a/src/CookieCrumble/src/CookieCrumble.Resources.Redis/RedisResource.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.Redis/RedisResource.cs
@@ -5,11 +5,30 @@ namespace CookieCrumble.Resources;
 
 public class RedisResource : ContainerResource<RedisContainer>
 {
+    private readonly Lazy<ConnectionMultiplexer> _connection;
+
+    public RedisResource()
+    {
+        _connection = new(() => ConnectionMultiplexer.Connect(ConnectionString));
+    }
+
     public string ConnectionString => Container.GetConnectionString();
 
-    public ConnectionMultiplexer GetConnection() => ConnectionMultiplexer.Connect(ConnectionString);
+    /// <summary>
+    /// Gets the connection shared by every caller of this resource. The resource owns it
+    /// and disposes it together with the container.
+    /// </summary>
+    public ConnectionMultiplexer GetConnection() => _connection.Value;
 
     protected override RedisContainer Build() => Configure(new RedisBuilder("redis:7.0")).Build();
 
     protected virtual RedisBuilder Configure(RedisBuilder builder) => builder;
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        if (_connection.IsValueCreated)
+        {
+            await _connection.Value.DisposeAsync();
+        }
+    }
 }

--- a/src/CookieCrumble/src/CookieCrumble.Resources/ContainerResource.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources/ContainerResource.cs
@@ -25,11 +25,24 @@ public abstract class ContainerResource<TContainer> : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        if (_container is not null)
+        try
         {
-            await _container.DisposeAsync();
+            await DisposeAsyncCore();
+        }
+        finally
+        {
+            if (_container is not null)
+            {
+                await _container.DisposeAsync();
+            }
         }
     }
 
     protected abstract TContainer Build();
+
+    /// <summary>
+    /// Releases the clients this resource created on top of the container.
+    /// Runs before the container itself is disposed.
+    /// </summary>
+    protected virtual ValueTask DisposeAsyncCore() => ValueTask.CompletedTask;
 }

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/Assembly.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(PostgreSqlResource))]

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelTests.cs
@@ -6,8 +6,7 @@ using Npgsql;
 namespace HotChocolate.Subscriptions.Postgres;
 
 public class PostgresChannelTests
-    : IClassFixture<PostgreSqlResource>
-    , IAsyncLifetime
+    : IAsyncLifetime
 {
     private readonly PostgreSqlResource _resource;
     private readonly string _dbName = $"DB_{Guid.NewGuid():N}";

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresChannelWriterTests.cs
@@ -6,8 +6,7 @@ using Npgsql;
 namespace HotChocolate.Subscriptions.Postgres;
 
 public class PostgresChannelWriterTests
-    : IClassFixture<PostgreSqlResource>
-    , IAsyncLifetime
+    : IAsyncLifetime
 {
     private readonly PostgreSqlResource _resource;
     private readonly string _dbName = $"DB_{Guid.NewGuid():N}";

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresPubSubIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/PostgresPubSubIntegrationTests.cs
@@ -6,7 +6,6 @@ namespace HotChocolate.Subscriptions.Postgres;
 
 public class PostgresPubSubIntegrationTests
     : SubscriptionIntegrationTestBase
-    , IClassFixture<PostgreSqlResource>
     , IAsyncLifetime
 {
     private readonly PostgreSqlResource _resource;

--- a/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/ResilientNpgsqlConnectionTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Postgres.Tests/ResilientNpgsqlConnectionTests.cs
@@ -4,7 +4,7 @@ using Npgsql;
 
 namespace HotChocolate.Subscriptions.Postgres;
 
-public class ResilientNpgsqlConnectionTests : IClassFixture<PostgreSqlResource>
+public class ResilientNpgsqlConnectionTests
 {
     private readonly PostgreSqlResource _resource;
     private readonly SubscriptionTestDiagnostics _events;

--- a/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/Assembly.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(RedisResource))]

--- a/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/RedisIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/RedisIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using CookieCrumble.Resources;
 using HotChocolate.Execution;
 using HotChocolate.Execution.Configuration;
@@ -6,8 +7,12 @@ using StackExchange.Redis;
 
 namespace HotChocolate.Subscriptions.Redis;
 
-public class RedisIntegrationTests : SubscriptionIntegrationTestBase, IClassFixture<RedisResource>
+public class RedisIntegrationTests : SubscriptionIntegrationTestBase
 {
+    // Redis channel names are the hex MD5 of the topic name.
+    private static readonly string s_onMessageChannel =
+        Convert.ToHexString(MD5.HashData("OnMessage"u8));
+
     private readonly RedisResource _redisResource;
 
     public RedisIntegrationTests(RedisResource redisResource, ITestOutputHelper output)
@@ -97,7 +102,10 @@ public class RedisIntegrationTests : SubscriptionIntegrationTestBase, IClassFixt
 
     private async Task<RedisResult[]> GetActiveChannelsAsync()
     {
-        return (RedisResult[])(await _redisResource.GetConnection().GetDatabase().ExecuteAsync("PUBSUB", "CHANNELS"))!;
+        var database = _redisResource.GetConnection().GetDatabase();
+        var channels = await database.ExecuteAsync("PUBSUB", "CHANNELS", s_onMessageChannel);
+
+        return (RedisResult[])channels!;
     }
 
     protected override void ConfigurePubSub(IRequestExecutorBuilder graphqlBuilder)

--- a/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/RedisTopicPrefixIntegrationTests.cs
+++ b/src/HotChocolate/Core/test/Subscriptions.Redis.Tests/RedisTopicPrefixIntegrationTests.cs
@@ -7,7 +7,7 @@ using StackExchange.Redis;
 namespace HotChocolate.Subscriptions.Redis;
 
 public class RedisTopicPrefixIntegrationTests(RedisResource redisResource, ITestOutputHelper output)
-    : SubscriptionIntegrationTestBase(output), IClassFixture<RedisResource>
+    : SubscriptionIntegrationTestBase(output)
 {
     private const string TopicPrefix = "prefix:";
 

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/EventStreamEnrichmentErrorOverHttpTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/EventStreamEnrichmentErrorOverHttpTests.cs
@@ -8,7 +8,6 @@ using HotChocolate.Types.Relay;
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
-using NATS.Client.JetStream.Models;
 using OperationRequest = HotChocolate.Transport.OperationRequest;
 using OperationResult = HotChocolate.Transport.OperationResult;
 
@@ -23,7 +22,8 @@ namespace HotChocolate.Fusion;
 /// errors; the subscription must surface that as a per-event error result (subgraph error plus
 /// standard non-null propagation) and stay alive, not silently close.
 /// </summary>
-public class EventStreamEnrichmentErrorOverHttpTests : FusionTestBase
+[Collection(NatsCollectionFixture.DefinitionName)]
+public class EventStreamEnrichmentErrorOverHttpTests(NatsResource nats) : FusionTestBase
 {
     private const string BrokerName = "nats";
     private const string Topic = "onCreateReview";
@@ -33,12 +33,9 @@ public class EventStreamEnrichmentErrorOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_ReturnErrorAndStayAlive_When_EnrichmentLookupRejectsEventId()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var events = CreateSourceSchema(
             "EVENTS",
@@ -55,7 +52,7 @@ public class EventStreamEnrichmentErrorOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -85,7 +82,11 @@ public class EventStreamEnrichmentErrorOverHttpTests : FusionTestBase
         // The first event carries the raw database key (not a valid global id), so the node lookup
         // that fetches `body` fails. The second event carries the encoded global id and resolves.
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"review":{"id":1}}""", cts.Token);
         await PublishAsync(
             nats.NatsConnectionString,
@@ -147,13 +148,6 @@ public class EventStreamEnrichmentErrorOverHttpTests : FusionTestBase
                 }
                 """
             ]);
-    }
-
-    private static async Task CreateStreamAsync(string url, string stream, string subject, CancellationToken ct)
-    {
-        await using var connection = new NatsConnection(new NatsOpts { Url = url });
-        var js = new NatsJSContext(connection);
-        await js.CreateStreamAsync(new StreamConfig { Name = stream, Subjects = [subject] }, ct);
     }
 
     private static async Task PublishAsync(string url, string subject, string body, CancellationToken ct)

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/NatsCollectionFixture.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/NatsCollectionFixture.cs
@@ -1,0 +1,9 @@
+using CookieCrumble.Resources;
+
+namespace HotChocolate.Fusion;
+
+[CollectionDefinition(DefinitionName)]
+public class NatsCollectionFixture : ICollectionFixture<NatsResource>
+{
+    internal const string DefinitionName = "Nats";
+}

--- a/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/NatsEventStreamOverHttpTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.AspNetCore.Tests/NatsEventStreamOverHttpTests.cs
@@ -9,7 +9,6 @@ using HotChocolate.Types.Composite;
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
-using NATS.Client.JetStream.Models;
 
 namespace HotChocolate.Fusion;
 
@@ -21,7 +20,8 @@ namespace HotChocolate.Fusion;
 /// the executor-level event-stream tests, these tests prove the reception, cross-schema entity
 /// resolution, and operation-plan extension behavior on the wire.
 /// </summary>
-public class NatsEventStreamOverHttpTests : FusionTestBase
+[Collection(NatsCollectionFixture.DefinitionName)]
+public class NatsEventStreamOverHttpTests(NatsResource nats) : FusionTestBase
 {
     private const string BrokerName = "nats";
 
@@ -34,12 +34,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_DeliverEvent_When_PublishedToNatsOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var events = CreateSourceSchema(
             "EVENTS",
@@ -55,7 +52,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -75,7 +72,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // Open the SSE response first so the gateway has subscribed to NATS, then publish a single
         // event. The first stream sequence is 1, whose base64 cursor is deterministically "MQ==".
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"user":{"id":"u1"}}""", cts.Token);
 
         // assert
@@ -106,12 +107,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_ResolveConcreteTypename_When_QueriedOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var events = CreateSourceSchema(
             "EVENTS",
@@ -127,7 +125,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -151,7 +149,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // The published payload carries no __typename, so the concrete type names below are
         // synthesized by the gateway at every nesting level rather than echoed from the broker.
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"user":{"id":"u1"}}""", cts.Token);
 
         // assert
@@ -184,12 +186,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_ResolveCrossSchemaEntityField_When_QueriedOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var eventsServer = CreateSourceSchema(
             "EVENTS",
@@ -212,7 +211,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -235,7 +234,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // EVENTS emits only the entity key (id); the gateway fetches name from ACCOUNTS by lookup
         // for each event, so name must resolve non-null over the wire.
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"user":{"id":"u1"}}""", cts.Token);
 
         // assert
@@ -267,12 +270,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_ResolveNestedAbstractEntityTypename_When_PerTypeLookupOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var eventsServer = CreateSourceSchema(
             "EVENTS",
@@ -300,7 +300,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -326,7 +326,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // and the gateway must fire the per-concrete-type lookup against CONTENT to fetch the
         // type-owned field (headline/caption) at the nested level.
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(
             nats.NatsConnectionString,
             Topic,
@@ -395,12 +399,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_ResolveRootAbstractEntityTypename_When_PerTypeLookupOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var eventsServer = CreateSourceSchema(
             "EVENTS",
@@ -428,7 +429,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -450,7 +451,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // Each event resolves to a different concrete entity (Author then Book), and the gateway must
         // fire that type's lookup against DETAILS to fetch the type-owned field (name/title).
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(
             nats.NatsConnectionString,
             Topic,
@@ -509,12 +514,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_IncludeOperationPlanExtension_When_OptedInOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var events = CreateSourceSchema(
             "EVENTS",
@@ -532,7 +534,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }));
 
         var httpClient = gateway.CreateClient();
@@ -551,7 +553,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
 
         // act
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"user":{"id":"u1"}}""", cts.Token);
 
         // assert
@@ -576,12 +582,9 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
     public async Task Subscribe_Should_OmitOperationPlanExtension_When_NotAllowedOverHttp()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
         using var events = CreateSourceSchema(
             "EVENTS",
@@ -597,7 +600,7 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
                 o =>
                 {
                     o.Url = nats.NatsConnectionString;
-                    o.JetStream = new NatsJetStreamOptions { Stream = stream };
+                    o.JetStream = new NatsJetStreamOptions { Stream = stream.Name };
                 }),
             configureGatewayBuilder: b => b.ModifyRequestOptions(o => o.AllowOperationPlanRequests = false));
 
@@ -619,7 +622,11 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         // The Fusion-Operation-Plan header is sent, but the schema disallows operation-plan
         // requests, so the plan must not appear regardless of the header.
         using var response = await client.PostAsync(request, new Uri(GatewayUrl), cts.Token);
-        await WaitForConsumerAsync(nats.NatsConnectionString, stream, expectedCount: 1, cts.Token);
+        await WaitForConsumerAsync(
+            nats.NatsConnectionString,
+            stream.Name,
+            expectedCount: 1,
+            cts.Token);
         await PublishAsync(nats.NatsConnectionString, Topic, """{"user":{"id":"u1"}}""", cts.Token);
 
         // assert
@@ -634,23 +641,6 @@ public class NatsEventStreamOverHttpTests : FusionTestBase
         }
 
         Assert.True(received, "Expected at least one SSE event over the wire.");
-    }
-
-    private static async Task CreateStreamAsync(
-        string url,
-        string stream,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await using var connection = new NatsConnection(new NatsOpts { Url = url });
-        var js = new NatsJSContext(connection);
-        await js.CreateStreamAsync(
-            new StreamConfig
-            {
-                Name = stream,
-                Subjects = [subject]
-            },
-            cancellationToken);
     }
 
     private static async Task PublishAsync(

--- a/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Subscriptions/NatsEventStreamGatewayTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Execution.Tests/Execution/Subscriptions/NatsEventStreamGatewayTests.cs
@@ -9,7 +9,6 @@ using HotChocolate.Types.Mutable;
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
-using NATS.Client.JetStream.Models;
 
 namespace HotChocolate.Fusion;
 
@@ -34,12 +33,11 @@ public sealed class NatsEventStreamGatewayTests
         // arrange
         await using var nats = new NatsResource();
         await nats.InitializeAsync();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, Topic, cts.Token);
+        await using var stream = await nats.CreateStreamAsync([Topic], cts.Token);
 
-        var executor = await BuildGatewayAsync(nats.NatsConnectionString, stream);
+        var executor = await BuildGatewayAsync(nats.NatsConnectionString, stream.Name);
 
         // act
         // Drive the initial subscription, publish two events to the single NATS subject, and receive
@@ -60,7 +58,7 @@ public sealed class NatsEventStreamGatewayTests
             {
                 await WaitForConsumerAsync(
                     nats.NatsConnectionString,
-                    stream,
+                    stream.Name,
                     expectedCount: 1,
                     cts.Token);
                 await PublishAsync(
@@ -262,23 +260,6 @@ public sealed class NatsEventStreamGatewayTests
                 }
             }
         }
-    }
-
-    private static async Task CreateStreamAsync(
-        string url,
-        string stream,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await using var connection = new NatsConnection(new NatsOpts { Url = url });
-        var js = new NatsJSContext(connection);
-        await js.CreateStreamAsync(
-            new StreamConfig
-            {
-                Name = stream,
-                Subjects = [subject]
-            },
-            cancellationToken);
     }
 
     private static async Task PublishAsync(

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/Assembly.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(NatsResource))]

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsEventStreamBrokerTests.cs
@@ -5,11 +5,10 @@ using HotChocolate.Language;
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
-using NATS.Client.JetStream.Models;
 
 namespace HotChocolate.Fusion.Subscriptions.NATS;
 
-public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
+public sealed class NatsEventStreamBrokerTests
 {
     private readonly NatsResource _natsResource;
 
@@ -170,21 +169,20 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
     public async Task Subscribe_Should_ResumeFromCursor_When_JetStreamCursorProvided()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
         var subjectA = CreateSubject();
         var subjectB = CreateSubject();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, [subjectA, subjectB], cts.Token);
+        await using var stream = await _natsResource.CreateStreamAsync(
+            [subjectA, subjectB],
+            cts.Token);
         var services = new ServiceCollection();
         services.AddNatsEventStreamBroker(configure: o =>
         {
-            o.Url = nats.NatsConnectionString;
+            o.Url = _natsResource.NatsConnectionString;
             o.JetStream = new NatsJetStreamOptions
             {
-                Stream = stream
+                Stream = stream.Name
             };
         });
         await using var provider = services.BuildServiceProvider();
@@ -205,12 +203,12 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
                 .GetAsyncEnumerator(cts.Token);
             var first = enumerator.MoveNextAsync().AsTask();
             await WaitForConsumerAsync(
-                nats.NatsConnectionString,
-                stream,
+                _natsResource.NatsConnectionString,
+                stream.Name,
                 expectedCount: 1,
                 cts.Token);
             await PublishJetStreamAsync(
-                nats.NatsConnectionString,
+                _natsResource.NatsConnectionString,
                 subjectA,
                 """{"id":1}"""u8.ToArray(),
                 cts.Token);
@@ -223,7 +221,7 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
 
         // publish a gap event while no subscriber is connected.
         await PublishJetStreamAsync(
-            nats.NatsConnectionString,
+            _natsResource.NatsConnectionString,
             subjectB,
             """{"id":2}"""u8.ToArray(),
             cts.Token);
@@ -250,17 +248,14 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
     public async Task Subscribe_Should_OnlyDeliverNewEvents_When_FreshJetStreamSubscribe()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
         var subject = CreateSubject();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, [subject], cts.Token);
+        await using var stream = await _natsResource.CreateStreamAsync([subject], cts.Token);
 
         // a historic event is retained before the subscription is established.
         await PublishJetStreamAsync(
-            nats.NatsConnectionString,
+            _natsResource.NatsConnectionString,
             subject,
             """{"id":1}"""u8.ToArray(),
             cts.Token);
@@ -268,10 +263,10 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
         var services = new ServiceCollection();
         services.AddNatsEventStreamBroker(configure: o =>
         {
-            o.Url = nats.NatsConnectionString;
+            o.Url = _natsResource.NatsConnectionString;
             o.JetStream = new NatsJetStreamOptions
             {
-                Stream = stream
+                Stream = stream.Name
             };
         });
         await using var provider = services.BuildServiceProvider();
@@ -288,12 +283,12 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
             .GetAsyncEnumerator(cts.Token);
         var next = enumerator.MoveNextAsync().AsTask();
         await WaitForConsumerAsync(
-            nats.NatsConnectionString,
-            stream,
+            _natsResource.NatsConnectionString,
+            stream.Name,
             expectedCount: 1,
             cts.Token);
         await PublishJetStreamAsync(
-            nats.NatsConnectionString,
+            _natsResource.NatsConnectionString,
             subject,
             """{"id":2}"""u8.ToArray(),
             cts.Token);
@@ -309,20 +304,17 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
     public async Task Subscribe_Should_FanOutToAllSubscribers_When_MultipleConcurrentJetStreamSubscriptions()
     {
         // arrange
-        await using var nats = new NatsResource();
-        await nats.InitializeAsync();
         var subject = CreateSubject();
-        var stream = "S" + Guid.NewGuid().ToString("N");
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await CreateStreamAsync(nats.NatsConnectionString, stream, [subject], cts.Token);
+        await using var stream = await _natsResource.CreateStreamAsync([subject], cts.Token);
         var services = new ServiceCollection();
         services.AddNatsEventStreamBroker(configure: o =>
         {
-            o.Url = nats.NatsConnectionString;
+            o.Url = _natsResource.NatsConnectionString;
             o.JetStream = new NatsJetStreamOptions
             {
-                Stream = stream
+                Stream = stream.Name
             };
         });
         await using var provider = services.BuildServiceProvider();
@@ -347,19 +339,19 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
         var firstA = enumeratorA.MoveNextAsync().AsTask();
         var firstB = enumeratorB.MoveNextAsync().AsTask();
         await WaitForConsumerAsync(
-            nats.NatsConnectionString,
-            stream,
+            _natsResource.NatsConnectionString,
+            stream.Name,
             expectedCount: 2,
             cts.Token);
 
         // act
         await PublishJetStreamAsync(
-            nats.NatsConnectionString,
+            _natsResource.NatsConnectionString,
             subject,
             """{"id":1}"""u8.ToArray(),
             cts.Token);
         await PublishJetStreamAsync(
-            nats.NatsConnectionString,
+            _natsResource.NatsConnectionString,
             subject,
             """{"id":2}"""u8.ToArray(),
             cts.Token);
@@ -439,23 +431,6 @@ public sealed class NatsEventStreamBrokerTests : IClassFixture<NatsResource>
             using var message = enumerator.Current;
             Assert.Equal("""{"id":4}""", Encoding.UTF8.GetString(message.Body));
         }
-    }
-
-    private static async Task CreateStreamAsync(
-        string url,
-        string stream,
-        ICollection<string> subjects,
-        CancellationToken cancellationToken)
-    {
-        await using var connection = new NatsConnection(new NatsOpts { Url = url });
-        var js = new NatsJSContext(connection);
-        await js.CreateStreamAsync(
-            new StreamConfig
-            {
-                Name = stream,
-                Subjects = subjects
-            },
-            cancellationToken);
     }
 
     private static async Task PublishJetStreamAsync(

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsSubscriptionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.NATS.Tests/NatsSubscriptionTests.cs
@@ -14,7 +14,7 @@ using NATS.Client.Core;
 
 namespace HotChocolate.Fusion.Subscriptions.NATS;
 
-public sealed class NatsSubscriptionTests : IClassFixture<NatsResource>
+public sealed class NatsSubscriptionTests
 {
     private readonly NatsResource _natsResource;
 

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/Assembly.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using HotChocolate.Fusion.Subscriptions.Redis;
+
+[assembly: AssemblyFixture(typeof(RedisFixture))]

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisEventStreamBrokerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisEventStreamBrokerTests.cs
@@ -7,7 +7,6 @@ using StackExchange.Redis;
 namespace HotChocolate.Fusion.Subscriptions.Redis;
 
 public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
-    : IClassFixture<RedisFixture>
 {
     [Fact]
     public async Task Subscribe_Should_DeliverPublishedEvent_When_RedisBrokerPublishes()

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisSubscriptionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisSubscriptionTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 namespace HotChocolate.Fusion.Subscriptions.Redis;
 
 public sealed class RedisSubscriptionTests
-    : IClassFixture<RedisFixture>
 {
     private readonly RedisFixture _fixture;
 

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/Assembly.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(MongoResource))]

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbAggregateFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbAggregateFluentTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Filters;
 
-public class MongoDbAggregateFluentTests : IClassFixture<MongoResource>
+public class MongoDbAggregateFluentTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbCollectionTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbCollectionTests.cs
@@ -10,7 +10,7 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace HotChocolate.Data.MongoDb.Filters;
 
-public class MongoDbCollectionTests : IClassFixture<MongoResource>
+public class MongoDbCollectionTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterCombinatorTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterCombinatorTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterCombinatorTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorBooleanTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorBooleanTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorBooleanTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorComparableTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorComparableTests.cs
@@ -9,7 +9,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorComparableTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorDateOnlyTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorDateOnlyTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorDateOnlyTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorEnumTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorEnumTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorEnumTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorListTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorListTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorListTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorObjectIdTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorObjectIdTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorObjectIdTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorObjectTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorObjectTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorObjectTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Bar[] s_barEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorStringTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorStringTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorStringTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorTimeOnlyTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFilterVisitorTimeOnlyTests.cs
@@ -8,7 +8,6 @@ namespace HotChocolate.Data.MongoDb.Filters;
 
 public class MongoDbFilterVisitorTimeOnlyTests
     : SchemaCache
-    , IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFindFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Filters.Tests/MongoDbFindFluentTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Filters;
 
-public class MongoDbFindFluentTests : IClassFixture<MongoResource>
+public class MongoDbFindFluentTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/Assembly.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(MongoResource))]

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbCursorPagingAggregateFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbCursorPagingAggregateFluentTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Paging;
 
-public class MongoDbCursorPagingAggregateFluentTests : IClassFixture<MongoResource>
+public class MongoDbCursorPagingAggregateFluentTests
 {
     private readonly List<Foo> _foos =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbCursorPagingFindFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbCursorPagingFindFluentTests.cs
@@ -10,7 +10,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace HotChocolate.Data.MongoDb.Paging;
 
-public class MongoDbCursorPagingFindFluentTests : IClassFixture<MongoResource>
+public class MongoDbCursorPagingFindFluentTests
 {
     private readonly List<Foo> _foos =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbOffsetPagingAggregateTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbOffsetPagingAggregateTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Paging;
 
-public class MongoDbOffsetPagingAggregateTests : IClassFixture<MongoResource>
+public class MongoDbOffsetPagingAggregateTests
 {
     private readonly List<Foo> _foos =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbOffsetPagingFindFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Paging.Tests/MongoDbOffsetPagingFindFluentTests.cs
@@ -10,7 +10,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace HotChocolate.Data.MongoDb.Paging;
 
-public class MongoDbOffsetPagingFindFluentTests : IClassFixture<MongoResource>
+public class MongoDbOffsetPagingFindFluentTests
 {
     private readonly List<Foo> _foos =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/Assembly.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(MongoResource))]

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionObjectTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionObjectTests.cs
@@ -5,7 +5,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace HotChocolate.Data.MongoDb.Projections;
 
-public class MongoDbProjectionObjectTests(MongoResource resource) : IClassFixture<MongoResource>
+public class MongoDbProjectionObjectTests(MongoResource resource)
 {
     private static readonly BarNullable[] s_barWithoutRelation =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorIsProjectedTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorIsProjectedTests.cs
@@ -6,7 +6,6 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Projections;
 
 public class MongoDbProjectionVisitorIsProjectedTests(MongoResource resource)
-    : IClassFixture<MongoResource>
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorPagingTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorPagingTests.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace HotChocolate.Data.MongoDb.Projections;
 
-public class MongoDbProjectionVisitorPagingTests : IClassFixture<MongoResource>
+public class MongoDbProjectionVisitorPagingTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorScalarTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Projections.Tests/MongoDbProjectionVisitorScalarTests.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace HotChocolate.Data.MongoDb.Projections;
 
-public class MongoDbProjectionVisitorScalarTests : IClassFixture<MongoResource>
+public class MongoDbProjectionVisitorScalarTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/Assembly.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(MongoResource))]

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbAggregateFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbAggregateFluentTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Sorting;
 
-public class MongoDbAggregateFluentTests(MongoResource resource) : IClassFixture<MongoResource>
+public class MongoDbAggregateFluentTests(MongoResource resource)
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbFindFluentTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbFindFluentTests.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 
 namespace HotChocolate.Data.MongoDb.Sorting;
 
-public class MongoDbFindFluentTests : IClassFixture<MongoResource>
+public class MongoDbFindFluentTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortCollectionTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortCollectionTests.cs
@@ -10,7 +10,7 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace HotChocolate.Data.MongoDb.Sorting;
 
-public class MongoDbSortCollectionTests : IClassFixture<MongoResource>
+public class MongoDbSortCollectionTests
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorBooleanTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorBooleanTests.cs
@@ -7,8 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Sorting;
 
 public class MongoDbSortVisitorBooleanTests
-    : SchemaCache,
-      IClassFixture<MongoResource>
+    : SchemaCache
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorComparableTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorComparableTests.cs
@@ -7,8 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Sorting;
 
 public class MongoDbSortVisitorComparableTests
-    : SchemaCache,
-      IClassFixture<MongoResource>
+    : SchemaCache
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorEnumTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorEnumTests.cs
@@ -7,8 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Sorting;
 
 public class MongoDbSortVisitorEnumTests
-    : SchemaCache,
-      IClassFixture<MongoResource>
+    : SchemaCache
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorObjectTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorObjectTests.cs
@@ -7,8 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Sorting;
 
 public class MongoDbSortVisitorObjectTests
-    : SchemaCache,
-      IClassFixture<MongoResource>
+    : SchemaCache
 {
     private static readonly Bar[] s_barEntities =
     [

--- a/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorStringTests.cs
+++ b/src/HotChocolate/MongoDb/test/Data.MongoDb.Sorting.Tests/MongoDbSortVisitorStringTests.cs
@@ -7,8 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace HotChocolate.Data.MongoDb.Sorting;
 
 public class MongoDbSortVisitorStringTests
-    : SchemaCache,
-      IClassFixture<MongoResource>
+    : SchemaCache
 {
     private static readonly Foo[] s_fooEntities =
     [

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/Assembly.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(AzureStorageBlobResource))]

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/AzureBlobStorageOperationDocumentStorageTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/AzureBlobStorageOperationDocumentStorageTests.cs
@@ -6,7 +6,7 @@ using HotChocolate.Language.Utilities;
 
 namespace HotChocolate.PersistedOperations.AzureBlobStorage;
 
-public class AzureBlobStorageOperationDocumentStorageTests : IClassFixture<AzureStorageBlobResource>
+public class AzureBlobStorageOperationDocumentStorageTests
 {
     private readonly BlobContainerClient _client;
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/IntegrationTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace HotChocolate.PersistedOperations.AzureBlobStorage;
 
-public class IntegrationTests : IClassFixture<AzureStorageBlobResource>
+public class IntegrationTests
 {
     private readonly BlobContainerClient _client;
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/RequestExecutorBuilderTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/RequestExecutorBuilderTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace HotChocolate.PersistedOperations.AzureBlobStorage;
 
-public class RequestExecutorBuilderTests : IClassFixture<AzureStorageBlobResource>
+public class RequestExecutorBuilderTests
 {
     private readonly BlobContainerClient _client;
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.AzureBlobStorage.Tests/ServiceCollectionExtensionsTests.cs
@@ -5,7 +5,7 @@ using HotChocolate.Utilities;
 
 namespace HotChocolate.PersistedOperations.AzureBlobStorage;
 
-public class ServiceCollectionExtensionsTests : IClassFixture<AzureStorageBlobResource>
+public class ServiceCollectionExtensionsTests
 {
     private readonly BlobContainerClient _client;
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/Assembly.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(RedisResource))]

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/IntegrationTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/IntegrationTests.cs
@@ -7,7 +7,7 @@ using StackExchange.Redis;
 
 namespace HotChocolate.PersistedOperations.Redis;
 
-public class IntegrationTests : IClassFixture<RedisResource>
+public class IntegrationTests
 {
     private readonly IConnectionMultiplexer _multiplexer;
     private readonly IDatabase _database;

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/RedisOperationDocumentStorageTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/RedisOperationDocumentStorageTests.cs
@@ -7,7 +7,6 @@ using StackExchange.Redis;
 namespace HotChocolate.PersistedOperations.Redis;
 
 public class RedisOperationDocumentStorageTests(RedisResource redisResource)
-    : IClassFixture<RedisResource>
 {
     private readonly IDatabase _database = redisResource.GetConnection().GetDatabase();
 

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/RequestExecutorBuilderTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/RequestExecutorBuilderTests.cs
@@ -4,7 +4,7 @@ using StackExchange.Redis;
 
 namespace HotChocolate.PersistedOperations.Redis;
 
-public class RequestExecutorBuilderTests : IClassFixture<RedisResource>
+public class RequestExecutorBuilderTests
 {
     private readonly IConnectionMultiplexer _multiplexer;
     private readonly IDatabase _database;

--- a/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/HotChocolate/PersistedOperations/test/PersistedOperations.Redis.Tests/ServiceCollectionExtensionsTests.cs
@@ -6,7 +6,6 @@ using StackExchange.Redis;
 namespace HotChocolate.PersistedOperations.Redis;
 
 public class ServiceCollectionExtensionsTests
-    : IClassFixture<RedisResource>
 {
     private readonly IDatabase _database;
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Tests/AnnotationBasedTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Tests/AnnotationBasedTests.cs
@@ -9,7 +9,6 @@ using Raven.Client.Documents.Session;
 namespace HotChocolate.Data.Raven.Test;
 
 public class AnnotationBasedTests(RavenDBResource resource)
-    : IClassFixture<RavenDBResource>
 {
     [Fact]
     public async Task Queryable_Should_BeExecuted()

--- a/src/HotChocolate/Raven/test/Data.Raven.Tests/Assembly.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Tests/Assembly.cs
@@ -1,0 +1,3 @@
+using CookieCrumble.Resources;
+
+[assembly: AssemblyFixture(typeof(RavenDBResource))]

--- a/src/HotChocolate/Raven/test/Data.Raven.Tests/DataExtensionsTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Tests/DataExtensionsTests.cs
@@ -9,7 +9,7 @@ using Raven.Client.Documents.Session;
 
 namespace HotChocolate.Data.Raven.Test;
 
-public class DataExtensionsTests : IClassFixture<RavenDBResource>
+public class DataExtensionsTests
 {
     private readonly RavenDBResource _resource;
 

--- a/src/HotChocolate/Raven/test/Data.Raven.Tests/FluentApiTests.cs
+++ b/src/HotChocolate/Raven/test/Data.Raven.Tests/FluentApiTests.cs
@@ -7,7 +7,7 @@ using Raven.Client.Documents;
 
 namespace HotChocolate.Data.Raven.Test;
 
-public class FluentApiTests : IClassFixture<RavenDBResource>
+public class FluentApiTests
 {
     private readonly RavenDBResource _resource;
 


### PR DESCRIPTION
## Summary

- Container-backed test projects declare their CookieCrumble resource as an xUnit `[assembly: AssemblyFixture]`, so a run starts one container per assembly instead of one per test class: `Data.Raven.Tests`, the four `Data.MongoDb.*.Tests` projects, `PersistedOperations.Redis.Tests`, `PersistedOperations.AzureBlobStorage.Tests`, `Subscriptions.Postgres.Tests`, `Subscriptions.Redis.Tests`, `Fusion.Subscriptions.NATS.Tests`, and `Fusion.Subscriptions.Redis.Tests`. The two NATS-over-HTTP classes in `Fusion.AspNetCore.Tests` share one collection fixture instead of starting a container per test.
- `ContainerResource<T>` gains a `DisposeAsyncCore` hook that runs before the container is disposed. `RedisResource` caches one multiplexer and `MongoResource` one client, both owned and disposed by the resource. `NatsResource.CreateStreamAsync` returns a uniquely named JetStream stream that deletes itself on dispose, replacing the per-test stream helpers in three test projects.
- `RedisIntegrationTests` scopes its `PUBSUB CHANNELS` probe to the subscription's own channel so the unsubscribe test holds on a server shared with the topic-prefix class.

## Test plan

- Full suite of every converted project passes: Raven 19, Mongo Projections 30 / Sorting 23 / Paging 39 / Filters 122, PersistedOperations Redis 19 / Azure Blob 12, Subscriptions Postgres 73 / Redis 19 (three consecutive runs), Fusion NATS 9 / Redis 7, Fusion.AspNetCore 546 with the 49 pre-existing skips, Fusion.Execution NATS gateway test 1.
- Container count sampled during each run shows one container per assembly, down from three for Raven, up to thirteen for Mongo Filters, and eight per-test starts for Fusion.AspNetCore.
- The NATS-over-HTTP tests on a shared server without stream cleanup fail six of eight with `subjects overlap with an existing stream`; with the self-deleting stream all eight pass.
