### PR TITLE
Skip Fusion Redis tests from the test body when Redis is unreachable

### DIFF
--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisEventStreamBrokerTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisEventStreamBrokerTests.cs
@@ -12,6 +12,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task Subscribe_Should_DeliverPublishedEvent_When_RedisBrokerPublishes()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         var channel = fixture.NextChannel();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var ready = Channel.CreateUnbounded<bool>();
@@ -44,6 +45,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task Subscribe_Should_MergeAllChannelsIntoOneStream_When_MultipleTopicsSubscribed()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         var channelA = fixture.NextChannel();
         var channelB = fixture.NextChannel();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -75,6 +77,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task Subscribe_Should_DeliverEveryEventToEachSubscriber_When_TwoConcurrentSubscribers()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         var channel = fixture.NextChannel();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var ready = Channel.CreateUnbounded<bool>();
@@ -118,6 +121,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task Subscribe_Should_ThrowInvalidCursor_When_CursorSupplied()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         var channel = fixture.NextChannel();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var services = CreateServices();
@@ -141,6 +145,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task Subscribe_Should_CloseConsumerCleanly_When_CancellationRequested()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         var channel = fixture.NextChannel();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var ready = Channel.CreateUnbounded<bool>();
@@ -177,6 +182,7 @@ public sealed class RedisEventStreamBrokerTests(RedisFixture fixture)
     public async Task DisposeAsync_Should_NotDisposeConnectionMultiplexer_When_CallerSupplied()
     {
         // arrange
+        fixture.SkipWhenUnavailable();
         await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(fixture.ConnectionString);
         var services = new ServiceCollection();
         services.AddRedisEventStreamBroker(

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisFixture.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisFixture.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Fusion.Subscriptions.Redis;
 /// </summary>
 /// <remarks>
 /// The default path starts Redis through Testcontainers. Set REDIS_CONNECTION_STRING to use an
-/// existing Redis instance instead.
+/// existing Redis instance instead; tests skip when that instance cannot be reached.
 /// </remarks>
 public sealed class RedisFixture : IAsyncLifetime
 {
@@ -32,6 +32,8 @@ public sealed class RedisFixture : IAsyncLifetime
 
     public string ConnectionString { get; private set; } = null!;
 
+    public string? SkipReason { get; private set; }
+
     public string NextChannel()
         => "events-" + Guid.NewGuid().ToString("N");
 
@@ -45,9 +47,9 @@ public sealed class RedisFixture : IAsyncLifetime
             }
             catch (Exception ex)
             {
-                Assert.Skip(
+                SkipReason =
                     "REDIS_CONNECTION_STRING did not point to a usable Redis instance: "
-                    + ex.Message);
+                    + ex.Message;
             }
 
             return;
@@ -83,6 +85,18 @@ public sealed class RedisFixture : IAsyncLifetime
             .PublishAsync(CreateRedisChannel(channel), body)
             .WaitAsync(cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Skips the calling test when REDIS_CONNECTION_STRING points at an instance that could not
+    /// be reached.
+    /// </summary>
+    public void SkipWhenUnavailable()
+    {
+        if (SkipReason is not null)
+        {
+            Assert.Skip(SkipReason);
+        }
     }
 
     private async Task<ConnectionMultiplexer> GetPublisherAsync()

--- a/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisSubscriptionTests.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Subscriptions.Redis.Tests/RedisSubscriptionTests.cs
@@ -22,6 +22,7 @@ public sealed class RedisSubscriptionTests
     public async Task Subscribe_Should_DeliverEventWithCrossSchemaData_When_RedisBrokerPublishes()
     {
         // arrange
+        _fixture.SkipWhenUnavailable();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var channel = _fixture.NextChannel();
         var ready = CreateReadyChannel();


### PR DESCRIPTION
## Summary

- `RedisFixture` no longer calls `Assert.Skip` from `InitializeAsync`. xUnit v3 treats a skip thrown during fixture initialization as a failure, so with `REDIS_CONNECTION_STRING` pointing at an unreachable instance every test in `Fusion.Subscriptions.Redis.Tests` failed instead of skipping.
- The fixture records a `SkipReason` and exposes `SkipWhenUnavailable()`, which each test calls as its first arrange step so the skip happens from the test body.

## Test plan

- Default path (Testcontainers): 7/7 pass.
- `REDIS_CONNECTION_STRING=localhost:1`: 7 skipped, 0 failed. The run exits with Microsoft.Testing.Platform code 8 because no test executed, which is the platform's zero-tests behavior and unchanged by this PR.
