### PR TITLE
Fix the mail wake coordinator test's dropped cancellation event

### DIFF
--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/MailWakeDaemonCoordinatorTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/MailWakeDaemonCoordinatorTests.cs
@@ -827,7 +827,7 @@ internal sealed class BusyReleaseLeaderStore(
 /// its own cancellation callback, then returns a pending, access-denied
 /// receipt; every other actor hangs until its <see cref="CancellationToken"/>
 /// fires, recording <c>"{actor}-cancelled"</c> into <paramref name="events"/>
-/// from that callback, before observing the cancellation itself.
+/// from that callback, and returns only after the callback has run.
 /// </summary>
 internal sealed class DeniedThenHangingDispatcher(string deniedActor, ConcurrentQueue<string> events)
     : IActorWakeDispatcher
@@ -852,7 +852,13 @@ internal sealed class DeniedThenHangingDispatcher(string deniedActor, Concurrent
                 [new ActorWakeTargetReceipt(target, MailWakeTargetStatus.Pending, null, null, "access-denied")]);
         }
 
-        await using var registration = cancellationToken.Register(() => events.Enqueue($"{actor}-cancelled"));
+        var cancelled = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var registration = cancellationToken.Register(() =>
+        {
+            events.Enqueue($"{actor}-cancelled");
+            cancelled.TrySetResult();
+        });
         _hungRegistered.TrySetResult();
 
         try
@@ -862,6 +868,9 @@ internal sealed class DeniedThenHangingDispatcher(string deniedActor, Concurrent
         catch (OperationCanceledException)
         {
         }
+
+        // Keep the registration alive until its callback has recorded the event.
+        await cancelled.Task;
 
         return null;
     }


### PR DESCRIPTION
## Summary

- `MailWakeDaemonCoordinatorTests.RunningLeader_Should_ReleaseLeadership_And_CancelSiblings_When_AccessDeniedReleaseIsBusy` intermittently failed in CI (for example [run 33753963774](https://github.com/ChilliCream/graphql-platform/actions/runs/33753963774), net11.0 with `--coverage`) with `Expected "hung-actor-cancelled" before "release-attempted". Events: [release-attempted, release-attempted]`.
- The `DeniedThenHangingDispatcher` fake recorded that event from a `CancellationToken.Register` callback held by `await using`, then awaited an infinite `Task.Delay` on the same token. Callbacks run in LIFO order, so `Task.Delay`'s later registration fired first, the method unwound, and disposing the registration unregistered the fake's callback before it had run.
- The callback now also completes a `TaskCompletionSource`, and the fake awaits it before returning, so the registration is disposed only after the event is recorded. `MailWakeDaemonCoordinator` is unchanged; it already awaits `CancelAsync` before releasing the lease.

## Test plan

- Built `Nitro.CommandLine.Tests` for net11.0 with `CI_BUILD=true` and ran the single test 40 times with `--coverage` under 24 busy-loop processes: 40 passes. The same setup reproduced the failure without the change.
- Ran the full `Nitro.CommandLine.Tests` suite on net11.0: 3599 passed, 0 failed.
