### PR TITLE
Fix Spatial fragment tests snapshotting unknown type errors

### DIFF
--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonLineStringTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonLineStringTypeTests.cs
@@ -55,7 +55,7 @@ public class GeoJsonLineStringTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on LineString { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONLineStringType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiLineStringTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiLineStringTypeTests.cs
@@ -65,7 +65,7 @@ public class GeoJsonMultiLineStringTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on MultiLineString { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONMultiLineStringType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiPointTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiPointTypeTests.cs
@@ -57,7 +57,7 @@ public class GeoJsonMultiPointTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on MultiPoint { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONMultiPointType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiPolygonTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonMultiPolygonTypeTests.cs
@@ -127,7 +127,7 @@ public class GeoJsonMultiPolygonTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on MultiPolygon { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONMultiPolygonType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointTypeTests.cs
@@ -72,7 +72,7 @@ public class GeoJsonPointTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on Point { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONPointType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPolygonTypeTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPolygonTypeTests.cs
@@ -114,7 +114,7 @@ public class GeoJsonPolygonTypeTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test { ... on Polygon { type coordinates bbox crs }}}",
+            "{ test { ... on GeoJSONPolygonType { type coordinates bbox crs }}}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonLineStringTypeTests.LineString_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonLineStringTypeTests.LineString_Execution_With_Fragments.snap
@@ -1,20 +1,28 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `LineString`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "LineString",
+      "coordinates": [
+        [
+          30,
+          10
+        ],
+        [
+          10,
+          30
+        ],
+        [
+          40,
+          40
+        ]
       ],
-      "path": [
-        "test"
+      "bbox": [
+        10,
+        10,
+        40,
+        40
       ],
-      "extensions": {
-        "typeCondition": "LineString",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiLineStringTypeTests.MultiLineString_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiLineStringTypeTests.MultiLineString_Execution_With_Fragments.snap
@@ -1,20 +1,48 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `MultiLineString`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "MultiLineString",
+      "coordinates": [
+        [
+          [
+            10,
+            10
+          ],
+          [
+            20,
+            20
+          ],
+          [
+            10,
+            40
+          ]
+        ],
+        [
+          [
+            40,
+            40
+          ],
+          [
+            30,
+            30
+          ],
+          [
+            40,
+            20
+          ],
+          [
+            30,
+            10
+          ]
+        ]
       ],
-      "path": [
-        "test"
+      "bbox": [
+        10,
+        10,
+        40,
+        40
       ],
-      "extensions": {
-        "typeCondition": "MultiLineString",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPointTypeTests.MultiPoint_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPointTypeTests.MultiPoint_Execution_With_Fragments.snap
@@ -1,20 +1,32 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `MultiPoint`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "MultiPoint",
+      "coordinates": [
+        [
+          10,
+          40
+        ],
+        [
+          40,
+          30
+        ],
+        [
+          20,
+          20
+        ],
+        [
+          30,
+          10
+        ]
       ],
-      "path": [
-        "test"
+      "bbox": [
+        10,
+        10,
+        40,
+        40
       ],
-      "extensions": {
-        "typeCondition": "MultiPoint",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPolygonTypeTests.MultiPolygon_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonMultiPolygonTypeTests.MultiPolygon_Execution_With_Fragments.snap
@@ -1,20 +1,60 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `MultiPolygon`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "MultiPolygon",
+      "coordinates": [
+        [
+          [
+            [
+              30,
+              20
+            ],
+            [
+              45,
+              40
+            ],
+            [
+              10,
+              40
+            ],
+            [
+              30,
+              20
+            ]
+          ]
+        ],
+        [
+          [
+            [
+              15,
+              5
+            ],
+            [
+              40,
+              10
+            ],
+            [
+              10,
+              20
+            ],
+            [
+              5,
+              15
+            ],
+            [
+              15,
+              5
+            ]
+          ]
+        ]
       ],
-      "path": [
-        "test"
+      "bbox": [
+        5,
+        5,
+        45,
+        40
       ],
-      "extensions": {
-        "typeCondition": "MultiPolygon",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPointTypeTests.Point_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPointTypeTests.Point_Execution_With_Fragments.snap
@@ -1,20 +1,18 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `Point`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "Point",
+      "coordinates": [
+        30,
+        10
       ],
-      "path": [
-        "test"
+      "bbox": [
+        30,
+        10,
+        30,
+        10
       ],
-      "extensions": {
-        "typeCondition": "Point",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonTypeTests.Polygon_Execution_With_Fragments.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonTypeTests.Polygon_Execution_With_Fragments.snap
@@ -1,20 +1,38 @@
 {
-  "errors": [
-    {
-      "message": "Unknown type `Polygon`.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 10
-        }
+  "data": {
+    "test": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            30,
+            10
+          ],
+          [
+            40,
+            40
+          ],
+          [
+            20,
+            40
+          ],
+          [
+            10,
+            20
+          ],
+          [
+            30,
+            10
+          ]
+        ]
       ],
-      "path": [
-        "test"
+      "bbox": [
+        10,
+        10,
+        40,
+        40
       ],
-      "extensions": {
-        "typeCondition": "Polygon",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Fragment-Spread-Type-Existence"
-      }
+      "crs": 4326
     }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

- The six `*_Execution_With_Fragments` tests in `HotChocolate.Types.Spatial.Tests` now spread their fragments on the schema type names, for example `GeoJSONPolygonType`, instead of bare GeoJSON names that do not exist in the schema.
- Their snapshots previously recorded an "Unknown type" validation error, so the fragment path was never exercised. Each snapshot now holds the executed result, which is identical to the corresponding `*_Execution_Output` snapshot.

Test-only change, no product code is touched.

## Test plan

- `HotChocolate.Types.Spatial.Tests` passes on net10.0, with every `*_Execution_With_Fragments` snapshot matching its non-fragment sibling.
