### PR TITLE
Re-enable the point input test for a missing geometry type

### DIFF
--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPointSerializerTests.cs
@@ -66,7 +66,7 @@ public class GeoJsonPointSerializerTests
     }
 
     [Theory]
-    [InlineData(PointInputName, Skip = "TODO: Pascal needs to review this one")]
+    [InlineData(PointInputName)]
     [InlineData(GeometryTypeName)]
     public void ParseLiteral_Should_Throw_When_NoGeometryType(string typeName)
     {


### PR DESCRIPTION
## Summary

- Re-enables the `GeoJSONPointInput` case of `ParseLiteral_Should_Throw_When_NoGeometryType` in `GeoJsonPointSerializerTests`, which had been skipped with a review note since January 2023.
- The case failed because the input parser used to fill a missing nullable value-type field with the type's default value, which turned a missing `type` into `Point` and let the literal parse. #8754 removed that fallback, so a missing `type` now reaches the serializer as `null` and the expected `LeafCoercionException` is thrown.

## Test plan

- `HotChocolate.Types.Spatial.Tests` passes on net10.0 with no skipped tests.
