### PR TITLE
Fix the polygon input execution test passing a single ring literal

### DIFF
--- a/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPolygonInputTests.cs
+++ b/src/HotChocolate/Spatial/test/Types.Tests/GeoJsonPolygonInputTests.cs
@@ -180,7 +180,7 @@ public class GeoJsonPolygonInputTests
 
         // act
         var result = await executor.ExecuteAsync(
-            "{ test(arg: { type: Polygon, coordinates:[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]] })}",
+            "{ test(arg: { type: Polygon, coordinates: [[[30, 10], [40, 40], [20, 40], [10, 20], [30, 10]]] })}",
             TestContext.Current.CancellationToken);
 
         // assert

--- a/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonInputTests.Execution_Tests.snap
+++ b/src/HotChocolate/Spatial/test/Types.Tests/__snapshots__/GeoJsonPolygonInputTests.Execution_Tests.snap
@@ -1,22 +1,5 @@
 {
-  "errors": [
-    {
-      "message": "The specified value type of field `coordinates` does not match the field type.",
-      "locations": [
-        {
-          "line": 1,
-          "column": 42
-        }
-      ],
-      "path": [
-        "test"
-      ],
-      "extensions": {
-        "fieldName": "coordinates",
-        "fieldType": "[[Position]]",
-        "locationType": "[[Position]]",
-        "specifiedBy": "https://spec.graphql.org/September2025/#sec-Values-of-Correct-Type"
-      }
-    }
-  ]
+  "data": {
+    "test": "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
+  }
 }


### PR DESCRIPTION
## Summary

- The `Execution_Tests` query in `GeoJsonPolygonInputTests` passed `coordinates` as a single ring's positions, a two-level list, while `GeoJSONPolygonInput.coordinates` has been `[[Position]]`, a list of rings, since #4394. Validation rejected the literal and the snapshot had pinned that error, which #9795 reported as a parser bug.
- The literal is now nested one level deeper and the snapshot holds the parsed polygon. The parser needed no change: the `ParseLiteral_*` tests in the same class already use the list-of-rings shape.

## Test plan

- `HotChocolate.Types.Spatial.Tests` passes on net10.0.

Closes #9795
