### PR TITLE
Widen the subscription timer reset test's outer deadline to 30 seconds

### DIFF
--- a/src/HotChocolate/Core/test/Execution.Tests/Pipeline/SubscriptionEventTimeoutTests.cs
+++ b/src/HotChocolate/Core/test/Execution.Tests/Pipeline/SubscriptionEventTimeoutTests.cs
@@ -50,7 +50,7 @@ public sealed class SubscriptionEventTimeoutTests
         // arrange
         // Budget is short, but each event completes quickly. No event should time out
         // and the subscription must keep running across multiple fires.
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         var executor = await new ServiceCollection()
             .AddGraphQL()


### PR DESCRIPTION
## Summary

- `SubscriptionEventTimeoutTests.Timer_Should_Be_Reset_Between_Events` guarded its whole run with a 10-second CTS and hit it in CI inside a `Task.Delay(600)`, after every event had already completed without errors. The outer guard is now 30 seconds, matching the other tests in the file.
- The lost time is thread-pool queueing, not the per-event timer. Every await in the test resumes on the thread pool (in-memory subscription channel hops and `Task.Delay`), and when `Issue9500Tests` runs concurrently its 100k-node DataLoader query fills the pool for the 13 to 18 seconds it takes under coverage. A probe measured a 600 ms delay resuming after 3 seconds with 4335 pending work items. The per-event 1-second budget is armed only after an event is dequeued, so the wider outer guard does not weaken what the test asserts.

## Test plan

- Ran `SubscriptionEventTimeoutTests` alone and alongside `Issue9500Tests` and `StarWarsCodeFirstTests` on 4 pinned cores with `--coverage`: 1.8 s alone, 4.6 to 5.4 s under contention, all green.
- In the [failing CI run](https://github.com/ChilliCream/graphql-platform/actions/runs/33762094482/job/100670774542) the test took 10.08 s while overlapping `Issue9500Tests` (18 s); the re-run had no overlap and the test took 2.18 s.
