### PR TITLE
Enable XML documentation generation in test projects

### DIFF
--- a/src/CookieCrumble/test/CookieCrumble.Tests/CookieCrumble.Tests.csproj
+++ b/src/CookieCrumble/test/CookieCrumble.Tests/CookieCrumble.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <AssemblyName>CookieCrumble.Tests</AssemblyName>
     <RootNamespace>CookieCrumble</RootNamespace>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/src/GreenDonut/test/Directory.Build.props
+++ b/src/GreenDonut/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/TestContext/Product.cs
+++ b/src/GreenDonut/test/GreenDonut.Data.EntityFramework.Tests/TestContext/Product.cs
@@ -34,7 +34,7 @@ public class Product
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
+    // Optional embedding for the catalog item's description.
     // [JsonIgnore]
     // public Vector Embedding { get; set; }
 

--- a/src/HotChocolate/Adapters/test/Directory.Build.props
+++ b/src/HotChocolate/Adapters/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/ApolloFederation/test/Directory.Build.props
+++ b/src/HotChocolate/ApolloFederation/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL.snap
@@ -5,13 +5,48 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")
@@ -21,8 +56,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -31,9 +77,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -54,7 +104,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -76,9 +128,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -100,7 +156,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -116,20 +174,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -140,24 +208,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL_Explicit_Route.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL_Explicit_Route.snap
@@ -5,13 +5,48 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")
@@ -21,8 +56,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -31,9 +77,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -54,7 +104,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -76,9 +128,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -100,7 +156,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -116,20 +174,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -140,24 +208,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL_Explicit_Route_Explicit_Pattern.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_SDL_Explicit_Route_Explicit_Pattern.snap
@@ -5,13 +5,48 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")
@@ -21,8 +56,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -31,9 +77,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -54,7 +104,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -76,9 +128,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -100,7 +156,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -116,20 +174,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -140,24 +208,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema.md
@@ -16,13 +16,48 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")
@@ -32,8 +67,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -42,9 +88,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -65,7 +115,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -87,9 +139,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -111,7 +167,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -127,20 +185,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -151,24 +219,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema_Slicing_Args_Enabled.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Schema_Slicing_Args_Enabled.md
@@ -16,13 +16,48 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")
@@ -32,8 +67,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -42,9 +88,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -64,7 +114,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -86,9 +138,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -109,7 +165,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -125,20 +183,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -149,24 +217,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Types_SDL.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Types_SDL.snap
@@ -1,11 +1,16 @@
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character."
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character."
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters."
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  "Gets a human by Id.\n\n\n**Returns:**\nThe human."
+  human("The Id of the human to retrieve." id: String!): Human
+  "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid."
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Types_SDL_Character_and_Query.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSchemaMiddlewareTests.Download_GraphQL_Types_SDL_Character_and_Query.snap
@@ -1,6 +1,10 @@
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -11,19 +15,27 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character."
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character."
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters."
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]! @cost(weight: "10")
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  "Gets a human by Id.\n\n\n**Returns:**\nThe human."
+  human("The Id of the human to retrieve." id: String!): Human
+  "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid."
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean! @cost(weight: "10")

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSemanticNonNullSchemaMiddlewareTests.Download_GraphQL_SemanticNonNull_Schema.md
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSemanticNonNullSchemaMiddlewareTests.Download_GraphQL_SemanticNonNull_Schema.md
@@ -16,15 +16,51 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character] @semanticNonNull(levels: [1])
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character]
+    @semanticNonNull(levels: [1])
   character(characterIds: [String!]!): [Character]
     @cost(weight: "10")
     @semanticNonNull(levels: [0, 1])
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long @semanticNonNull
   evict: Boolean @semanticNonNull
   wait(m: Int!): Boolean @cost(weight: "10") @semanticNonNull
@@ -34,8 +70,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -44,9 +91,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String @semanticNonNull
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -67,7 +118,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -89,9 +142,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -113,7 +170,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -129,20 +188,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int @semanticNonNull
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String @semanticNonNull
   length(unit: Unit): Float @semanticNonNull
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -153,24 +222,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSemanticNonNullSchemaMiddlewareTests.Download_GraphQL_SemanticNonNull_Schema_Explicit_Pattern.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpGetSemanticNonNullSchemaMiddlewareTests.Download_GraphQL_SemanticNonNull_Schema_Explicit_Pattern.snap
@@ -5,15 +5,51 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character] @semanticNonNull(levels: [1])
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character]
+    @semanticNonNull(levels: [1])
   character(characterIds: [String!]!): [Character]
     @cost(weight: "10")
     @semanticNonNull(levels: [0, 1])
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
   time: Long @semanticNonNull
   evict: Boolean @semanticNonNull
   wait(m: Int!): Boolean @cost(weight: "10") @semanticNonNull
@@ -23,8 +59,19 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
-    @cost(weight: "10")
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review! @cost(weight: "10")
   complete(episode: Episode!): Boolean! @cost(weight: "10")
 }
 
@@ -33,9 +80,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String @semanticNonNull
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -56,7 +107,9 @@ type Droid implements Character {
     )
     @cost(weight: "10")
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -78,9 +131,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -102,7 +159,9 @@ type Human implements Character {
     @cost(weight: "10")
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -118,20 +177,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String @cost(weight: "10")
+  "The number of stars given for this review."
   stars: Int @semanticNonNull
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String @semanticNonNull
   length(unit: Unit): Float @semanticNonNull
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String @semanticNonNull
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -142,24 +211,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/AspNetCore/test/Directory.Build.props
+++ b/src/HotChocolate/AspNetCore/test/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/HotChocolate/AzureFunctions/test/Directory.Build.props
+++ b/src/HotChocolate/AzureFunctions/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Caching/test/Directory.Build.props
+++ b/src/HotChocolate/Caching/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Core/test/Directory.Build.props
+++ b/src/HotChocolate/Core/test/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/__snapshots__/StarWarsCodeFirstTests.Ensure_Benchmark_Query_LargeQuery.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/__snapshots__/StarWarsCodeFirstTests.Ensure_Benchmark_Query_LargeQuery.snap
@@ -6100,11 +6100,11 @@
           "fields": [
             {
               "name": "hero",
-              "description": null,
+              "description": "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character.",
               "args": [
                 {
                   "name": "episode",
-                  "description": null,
+                  "description": "The episode to look up by.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6127,11 +6127,11 @@
             },
             {
               "name": "heroByTraits",
-              "description": null,
+              "description": "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character.",
               "args": [
                 {
                   "name": "traits",
-                  "description": null,
+                  "description": "The traits to look up by.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6154,11 +6154,11 @@
             },
             {
               "name": "heroes",
-              "description": null,
+              "description": "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters.",
               "args": [
                 {
                   "name": "episodes",
-                  "description": null,
+                  "description": "The episodes to look up by.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6272,11 +6272,11 @@
             },
             {
               "name": "human",
-              "description": null,
+              "description": "Gets a human by Id.\n\n\n**Returns:**\nThe human.",
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "The Id of the human to retrieve.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6299,11 +6299,11 @@
             },
             {
               "name": "droid",
-              "description": null,
+              "description": "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid.",
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "The Id of the droid.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6337,11 +6337,11 @@
           "fields": [
             {
               "name": "createReview",
-              "description": null,
+              "description": "Creates a review for a given Star Wars episode.\n\n\n**Returns:**\nThe created review.",
               "args": [
                 {
                   "name": "episode",
-                  "description": null,
+                  "description": "The episode to review.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6355,7 +6355,7 @@
                 },
                 {
                   "name": "review",
-                  "description": null,
+                  "description": "The review.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -6462,11 +6462,11 @@
         {
           "kind": "OBJECT",
           "name": "Human",
-          "description": null,
+          "description": "A human character in the Star Wars universe.",
           "fields": [
             {
               "name": "id",
-              "description": null,
+              "description": "The unique identifier for the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6482,7 +6482,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The name of the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6498,7 +6498,7 @@
             },
             {
               "name": "appearsIn",
-              "description": null,
+              "description": "The episodes the character appears in.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -6602,7 +6602,7 @@
             },
             {
               "name": "homePlanet",
-              "description": null,
+              "description": "The planet the character is originally from.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6614,7 +6614,7 @@
             },
             {
               "name": "traits",
-              "description": null,
+              "description": "The traits of this character.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6639,11 +6639,11 @@
         {
           "kind": "OBJECT",
           "name": "Droid",
-          "description": null,
+          "description": "A droid in the Star Wars universe.",
           "fields": [
             {
               "name": "id",
-              "description": null,
+              "description": "The unique identifier for the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6659,7 +6659,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The name of the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6675,7 +6675,7 @@
             },
             {
               "name": "appearsIn",
-              "description": null,
+              "description": "The episodes the character appears in.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -6767,7 +6767,7 @@
             },
             {
               "name": "primaryFunction",
-              "description": null,
+              "description": "The droid's primary function.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6779,7 +6779,7 @@
             },
             {
               "name": "traits",
-              "description": null,
+              "description": "The traits of this character.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6804,26 +6804,26 @@
         {
           "kind": "ENUM",
           "name": "Episode",
-          "description": null,
+          "description": "The Star Wars episodes.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
               "name": "NEW_HOPE",
-              "description": null,
+              "description": "Star Wars Episode IV: A New Hope",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "EMPIRE",
-              "description": null,
+              "description": "Star Wars Episode V: Empire Strikes Back",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "JEDI",
-              "description": null,
+              "description": "Star Wars Episode VI: Return of the Jedi",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -6853,11 +6853,11 @@
         {
           "kind": "INTERFACE",
           "name": "Character",
-          "description": null,
+          "description": "A character in the Star Wars universe.",
           "fields": [
             {
               "name": "id",
-              "description": null,
+              "description": "The unique identifier for the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6873,7 +6873,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The name of the character.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6889,7 +6889,7 @@
             },
             {
               "name": "friends",
-              "description": null,
+              "description": "The names of the character's friends.",
               "args": [
                 {
                   "name": "first",
@@ -6942,7 +6942,7 @@
             },
             {
               "name": "appearsIn",
-              "description": null,
+              "description": "The episodes the character appears in.",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -6958,7 +6958,7 @@
             },
             {
               "name": "traits",
-              "description": null,
+              "description": "The traits of this character.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6970,7 +6970,7 @@
             },
             {
               "name": "height",
-              "description": null,
+              "description": "The height of the character.",
               "args": [
                 {
                   "name": "unit",
@@ -7037,11 +7037,11 @@
         {
           "kind": "OBJECT",
           "name": "Review",
-          "description": null,
+          "description": "A review of a particular movie.",
           "fields": [
             {
               "name": "commentary",
-              "description": null,
+              "description": "An explanation for the rating.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -7053,7 +7053,7 @@
             },
             {
               "name": "stars",
-              "description": null,
+              "description": "The number of stars given for this review.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7076,12 +7076,12 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "ReviewInput",
-          "description": null,
+          "description": "A review of a particular movie.",
           "fields": null,
           "inputFields": [
             {
               "name": "stars",
-              "description": null,
+              "description": "The number of stars given for this review.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7095,7 +7095,7 @@
             },
             {
               "name": "commentary",
-              "description": null,
+              "description": "An explanation for the rating.",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -7184,7 +7184,7 @@
         {
           "kind": "ENUM",
           "name": "Unit",
-          "description": null,
+          "description": "Different units of measurement.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -7217,11 +7217,11 @@
         {
           "kind": "OBJECT",
           "name": "Starship",
-          "description": null,
+          "description": "A starship in the Star Wars universe.",
           "fields": [
             {
               "name": "id",
-              "description": null,
+              "description": "The Id of the starship.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7237,7 +7237,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The name of the starship.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",

--- a/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/__snapshots__/StarWarsCodeFirstTests.Schema.snap
+++ b/src/HotChocolate/Core/test/Execution.Tests/Integration/StarWarsCodeFirst/__snapshots__/StarWarsCodeFirstTests.Schema.snap
@@ -5,17 +5,64 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  """
+  Retrieve a hero by a particular Star Wars episode.
+  
+  
+  **Returns:**
+  The character.
+  """
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  """
+  Retrieve a hero by their traits.
+  
+  
+  **Returns:**
+  The character.
+  """
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  """
+  Retrieve heroes by particular Star Wars episodes.
+  
+  
+  **Returns:**
+  The characters.
+  """
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]!
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  """
+  Gets a human by Id.
+  
+  
+  **Returns:**
+  The human.
+  """
+  human("The Id of the human to retrieve." id: String!): Human
+  """
+  Get a particular droid by Id.
+  
+  
+  **Returns:**
+  The droid.
+  """
+  droid("The Id of the droid." id: String!): Droid
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
+  """
+  Creates a review for a given Star Wars episode.
+  
+  
+  **Returns:**
+  The created review.
+  """
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review!
   complete(episode: Episode!): Boolean!
 }
 
@@ -23,9 +70,13 @@ type Subscription {
   onReview(episode: Episode!): Review!
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -38,7 +89,9 @@ type Droid implements Character {
     before: String
   ): FriendsConnection
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -60,9 +113,13 @@ type FriendsEdge {
   node: Character
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -76,7 +133,9 @@ type Human implements Character {
   ): FriendsConnection
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
@@ -92,20 +151,30 @@ type PageInfo {
   endCursor: String
 }
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -116,24 +185,35 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS

--- a/src/HotChocolate/Core/test/StarWars/Query.cs
+++ b/src/HotChocolate/Core/test/StarWars/Query.cs
@@ -25,7 +25,7 @@ public class Query
     }
 
     /// <summary>
-    /// Retrieve a hero by a particular their traits.
+    /// Retrieve a hero by their traits.
     /// </summary>
     /// <param name="traits">The traits to look up by.</param>
     /// <returns>The character.</returns>
@@ -35,10 +35,10 @@ public class Query
     }
 
     /// <summary>
-    /// Retrieve a heros by a particular Star Wars episodes.
+    /// Retrieve heroes by particular Star Wars episodes.
     /// </summary>
-    /// <param name="episodes">The episode to look up by.</param>
-    /// <returns>The character.</returns>
+    /// <param name="episodes">The episodes to look up by.</param>
+    /// <returns>The characters.</returns>
     public IReadOnlyList<ICharacter> GetHeroes(IReadOnlyList<Episode> episodes)
     {
         var list = new List<ICharacter>();

--- a/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/IntegrationTests.Schema.graphql
+++ b/src/HotChocolate/Core/test/Types.Analyzers.Tests/__snapshots__/IntegrationTests.Schema.graphql
@@ -60,7 +60,15 @@ type Author implements Entity & Node {
   ): BooksConnection
   "This is some information."
   someInfo: String
-  additionalInfo(someArg: String!): String!
+  """
+  Gets the additional info.
+  
+  
+  **Returns:**
+  
+  Returns a string.
+  """
+  additionalInfo("Some argument" someArg: String!): String!
   additionalInfo1(someArg1: String!, someArg2: String!): String!
   authorsPure: [Author!]!
   authorsQuery: [Author!]!

--- a/src/HotChocolate/CostAnalysis/test/Directory.Build.props
+++ b/src/HotChocolate/CostAnalysis/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/TestContext/Product.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Pagination.Tests/TestContext/Product.cs
@@ -34,7 +34,7 @@ public class Product
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
+    // Optional embedding for the catalog item's description.
     // [JsonIgnore]
     // public Vector Embedding { get; set; }
 

--- a/src/HotChocolate/Data/test/Data.EntityFramework.Tests/TestContext/Product.cs
+++ b/src/HotChocolate/Data/test/Data.EntityFramework.Tests/TestContext/Product.cs
@@ -34,7 +34,7 @@ public class Product
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
+    // Optional embedding for the catalog item's description.
     // [JsonIgnore]
     // public Vector Embedding { get; set; }
 

--- a/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/TestContext/Product.cs
+++ b/src/HotChocolate/Data/test/Data.Filters.SqlServer.Tests/TestContext/Product.cs
@@ -34,7 +34,7 @@ public class Product
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
+    // Optional embedding for the catalog item's description.
     // [JsonIgnore]
     // public Vector Embedding { get; set; }
 

--- a/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.CreateSchema.graphql
+++ b/src/HotChocolate/Data/test/Data.PostgreSQL.Tests/__snapshots__/IntegrationTests.CreateSchema.graphql
@@ -129,14 +129,20 @@ type Brand implements Node @key(fields: "id") {
 }
 
 type BrandConnection @shareable {
+  "A list of edges."
   edges: [BrandEdge!]!
+  "A flattened list of the nodes."
   nodes: [Brand!]!
+  "Information to aid in pagination."
   pageInfo: ConnectionPageInfo!
+  "Identifies the total count of items in the connection."
   totalCount: Int! @cost(weight: "10")
 }
 
 type BrandEdge @shareable {
+  "The item at the end of the edge."
   node: Brand!
+  "A cursor for use in pagination."
   cursor: String!
 }
 
@@ -234,19 +240,28 @@ type Product implements Node @key(fields: "id") {
   availableStock: Int!
   restockThreshold: Int!
   maxStockThreshold: Int!
+  "True if item is on reorder"
   onReorder: Boolean!
 }
 
+"A connection to a list of items."
 type ProductConnection @shareable {
+  "A list of edges."
   edges: [ProductEdge!]
+  "A flattened list of the nodes."
   nodes: [Product!]
+  "Information to aid in pagination."
   pageInfo: ConnectionPageInfo!
+  "Identifies the total count of items in the connection."
   totalCount: Int! @cost(weight: "10")
   endCursors(count: Int!): [String!]!
 }
 
+"An edge in a connection."
 type ProductEdge @shareable {
+  "The item at the end of the edge."
   node: Product!
+  "A cursor for use in pagination."
   cursor: String!
 }
 
@@ -256,14 +271,20 @@ type ProductType {
 }
 
 type ProductTypeConnection @shareable {
+  "A list of edges."
   edges: [ProductTypeEdge!]!
+  "A flattened list of the nodes."
   nodes: [ProductType!]!
+  "Information to aid in pagination."
   pageInfo: ConnectionPageInfo!
+  "Identifies the total count of items in the connection."
   totalCount: Int! @cost(weight: "10")
 }
 
 type ProductTypeEdge @shareable {
+  "The item at the end of the edge."
   node: ProductType!
+  "A cursor for use in pagination."
   cursor: String!
 }
 
@@ -369,6 +390,7 @@ input ProductFilterInput {
   availableStock: IntOperationFilterInput
   restockThreshold: IntOperationFilterInput
   maxStockThreshold: IntOperationFilterInput
+  "True if item is on reorder"
   onReorder: BooleanOperationFilterInput
 }
 

--- a/src/HotChocolate/Data/test/Data.Tests/TestContext2/Product.cs
+++ b/src/HotChocolate/Data/test/Data.Tests/TestContext2/Product.cs
@@ -34,7 +34,7 @@ public class Product
     // Maximum number of units that can be in-stock at any time (due to physicial/logistical constraints in warehouses)
     public int MaxStockThreshold { get; set; }
 
-    /// <summary>Optional embedding for the catalog item's description.</summary>
+    // Optional embedding for the catalog item's description.
     // [JsonIgnore]
     // public Vector Embedding { get; set; }
 

--- a/src/HotChocolate/Data/test/Directory.Build.props
+++ b/src/HotChocolate/Data/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Diagnostics/test/Directory.Build.props
+++ b/src/HotChocolate/Diagnostics/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Fusion/test/Directory.Build.props
+++ b/src/HotChocolate/Fusion/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/AuditFixture.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/AuditFixture.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Fusion;
 /// <c>subgraphs/*.graphql</c>) vendored from the federation-gateway-audit repository
 /// under each suite's <c>Reference/</c> directory. Reference resources are material
 /// for porting a suite; the live tests inline their query literals via
-/// <see cref="ComplianceTestBase.RunAsync"/>.
+/// <see cref="ComplianceTestBase.RunAsync(string, string?, bool?)"/>.
 /// </summary>
 internal static class AuditFixture
 {

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/ComplianceTestBase.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/ComplianceTestBase.cs
@@ -7,10 +7,10 @@ namespace HotChocolate.Fusion;
 /// <summary>
 /// Base class for <c>graphql-hive/federation-gateway-audit</c> compliance suites.
 /// Each derived suite builds its gateway (via <see cref="BuildGatewayAsync"/>) and
-/// declares one <c>[Fact]</c> per audit test case that calls <see cref="RunAsync"/>
-/// with the inline query and expected response. The composed
-/// <see cref="FusionGateway"/> (subgraph <c>TestServer</c>s and the gateway service
-/// provider) is disposed automatically at the end of each test.
+/// declares one <c>[Fact]</c> per audit test case that calls
+/// <see cref="RunAsync(string, string?, bool?)"/> with the inline query and expected
+/// response. The composed <see cref="FusionGateway"/> (subgraph <c>TestServer</c>s
+/// and the gateway service provider) is disposed automatically at the end of each test.
 /// </summary>
 public abstract class ComplianceTestBase : IAsyncLifetime
 {
@@ -18,7 +18,7 @@ public abstract class ComplianceTestBase : IAsyncLifetime
 
     /// <summary>
     /// Builds the Fusion gateway for this suite. Called lazily from
-    /// <see cref="RunAsync"/> on the first invocation per test.
+    /// <see cref="RunAsync(string, string?, bool?)"/> on the first invocation per test.
     /// </summary>
     protected abstract Task<FusionGateway> BuildGatewayAsync();
 

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/FusionGateway.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/FusionGateway.cs
@@ -5,7 +5,7 @@ namespace HotChocolate.Fusion;
 
 /// <summary>
 /// A composed Fusion gateway over a set of Apollo Federation subgraph
-/// <see cref="WebApplication"/>s running in-process under
+/// <see cref="Microsoft.AspNetCore.Builder.WebApplication"/>s running in-process under
 /// <see cref="Microsoft.AspNetCore.TestHost.TestServer"/>. Disposing the gateway tears
 /// down the subgraph hosts and the gateway service provider.
 /// </summary>

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/FusionGatewayBuilder.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/FusionGatewayBuilder.cs
@@ -144,6 +144,12 @@ internal static class FusionGatewayBuilder
     /// <param name="nodeResolution">
     /// Determines how the gateway resolves the <c>Query.node</c> field.
     /// </param>
+    /// <param name="allowNonResolvableInterfaceObjects">
+    /// Allows <c>@interfaceObject</c> stand-ins whose keys are not resolvable.
+    /// </param>
+    /// <param name="shareableFieldRuntimeTypeRouting">
+    /// Determines how runtime types are routed for shareable fields with an abstract result type.
+    /// </param>
     /// <param name="subgraphs">Named subgraph factories.</param>
     public static Task<FusionGateway> ComposeAsync(
         SubgraphRequestCapture? capture,

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/SubgraphEndpointExtensions.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/SubgraphEndpointExtensions.cs
@@ -17,6 +17,7 @@ internal static class SubgraphEndpointExtensions
     /// required.
     /// </summary>
     /// <param name="app">The subgraph web application.</param>
+    /// <param name="enableBatching">Whether the endpoint allows HTTP batching.</param>
     public static void MapSubgraph(this WebApplication app, bool enableBatching = false)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/SubgraphEndpointExtensions.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Infrastructure/SubgraphEndpointExtensions.cs
@@ -9,15 +9,16 @@ namespace HotChocolate.Fusion;
 internal static class SubgraphEndpointExtensions
 {
     /// <summary>
-    /// Maps the subgraph's GraphQL endpoint with HTTP batching enabled. A plain
-    /// HotChocolate server does not allow batching by default, so the harness turns it
-    /// on to match the batching support a Fusion source-schema server exposes. With the
-    /// subgraphs accepting the standard batch wire formats, the gateway's uniform default
-    /// transport exchanges those formats with every subgraph, no settings declaration
-    /// required.
+    /// Maps the subgraph's GraphQL endpoint, optionally with HTTP batching enabled.
     /// </summary>
     /// <param name="app">The subgraph web application.</param>
-    /// <param name="enableBatching">Whether the endpoint allows HTTP batching.</param>
+    /// <param name="enableBatching">
+    /// Whether the endpoint allows HTTP batching. A plain HotChocolate server does not
+    /// allow batching by default; turning it on matches the batching support a Fusion
+    /// source-schema server exposes. With the subgraphs accepting the standard batch wire
+    /// formats, the gateway's uniform default transport exchanges those formats with
+    /// every subgraph, no settings declaration required.
+    /// </param>
     public static void MapSubgraph(this WebApplication app, bool enableBatching = false)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ComplexEntityCall/Link/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ComplexEntityCall/Link/QueryType.cs
@@ -7,7 +7,8 @@ namespace HotChocolate.Fusion.Suites.ComplexEntityCall.Link;
 /// Root <c>Query</c> placeholder for the <c>link</c> subgraph. The subgraph
 /// exposes no user-facing root fields; HotChocolate requires a <c>Query</c>
 /// type so the Apollo Federation interceptor can attach <c>_service</c> and
-/// <c>_entities</c>. <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <c>_entities</c>.
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/Mutations/B/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/Mutations/B/QueryType.cs
@@ -5,7 +5,8 @@ namespace HotChocolate.Fusion.Suites.Mutations.B;
 
 /// <summary>
 /// Root <c>Query</c> placeholder for the <c>b</c> subgraph. The subgraph
-/// declares no user-facing query fields; <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// declares no user-facing query fields;
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCall/B/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCall/B/QueryType.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Fusion.Suites.ParentEntityCall.B;
 /// SDL exposes no user-facing root fields on <c>b</c>; HotChocolate still
 /// requires a <c>Query</c> type so the Apollo Federation interceptor can
 /// attach <c>_service</c> and <c>_entities</c>.
-/// <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCall/C/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCall/C/QueryType.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Fusion.Suites.ParentEntityCall.C;
 /// SDL exposes no user-facing root fields on <c>c</c>; HotChocolate still
 /// requires a <c>Query</c> type so the Apollo Federation interceptor can
 /// attach <c>_service</c> and <c>_entities</c>.
-/// <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/A/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/A/QueryType.cs
@@ -7,7 +7,8 @@ namespace HotChocolate.Fusion.Suites.ParentEntityCallComplex.A;
 /// Root <c>Query</c> placeholder for the <c>a</c> subgraph. The subgraph
 /// exposes no user-facing root fields; HotChocolate requires a <c>Query</c>
 /// type so the Apollo Federation interceptor can attach <c>_service</c> and
-/// <c>_entities</c>. <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <c>_entities</c>.
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/B/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/B/QueryType.cs
@@ -7,7 +7,8 @@ namespace HotChocolate.Fusion.Suites.ParentEntityCallComplex.B;
 /// Root <c>Query</c> placeholder for the <c>b</c> subgraph. The subgraph
 /// exposes no user-facing root fields; HotChocolate requires a <c>Query</c>
 /// type so the Apollo Federation interceptor can attach <c>_service</c> and
-/// <c>_entities</c>. <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <c>_entities</c>.
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/C/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/ParentEntityCallComplex/C/QueryType.cs
@@ -7,7 +7,8 @@ namespace HotChocolate.Fusion.Suites.ParentEntityCallComplex.C;
 /// Root <c>Query</c> placeholder for the <c>c</c> subgraph. The subgraph
 /// exposes no user-facing root fields; HotChocolate requires a <c>Query</c>
 /// type so the Apollo Federation interceptor can attach <c>_service</c> and
-/// <c>_entities</c>. <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <c>_entities</c>.
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>.
 /// </summary>
 public sealed class QueryType : ObjectType

--- a/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/SimpleEntityCall/Nickname/QueryType.cs
+++ b/src/HotChocolate/Fusion/test/Fusion.Connectors.ApolloFederation.Compliance.Tests/Suites/SimpleEntityCall/Nickname/QueryType.cs
@@ -8,7 +8,7 @@ namespace HotChocolate.Fusion.Suites.SimpleEntityCall.Nickname;
 /// SDL declares no user-facing query fields, but HotChocolate requires a Query type
 /// to exist so the Apollo Federation type interceptor can attach
 /// <c>_service { sdl }</c> and <c>_entities(...)</c> fields. Applying
-/// <see cref="ApolloFederationObjectTypeDescriptorExtensions.ExtendServiceType"/>
+/// <see cref="ExtendServiceTypeDescriptorExtensions.ExtendServiceType(IObjectTypeDescriptor)"/>
 /// marks this type as extending the federated <c>Query</c>, so composition treats it
 /// as a pure entity provider.
 /// </summary>

--- a/src/HotChocolate/Json/test/Directory.Build.props
+++ b/src/HotChocolate/Json/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Language/test/Directory.Build.props
+++ b/src/HotChocolate/Language/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Marten/test/Directory.Build.props
+++ b/src/HotChocolate/Marten/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/MongoDb/test/Directory.Build.props
+++ b/src/HotChocolate/MongoDb/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Mutable/test/Directory.Build.props
+++ b/src/HotChocolate/Mutable/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/PersistedOperations/test/Directory.Build.props
+++ b/src/HotChocolate/PersistedOperations/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Primitives/test/Directory.Build.props
+++ b/src/HotChocolate/Primitives/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Raven/test/Directory.Build.props
+++ b/src/HotChocolate/Raven/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Spatial/test/Directory.Build.props
+++ b/src/HotChocolate/Spatial/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Utilities/test/Directory.Build.props
+++ b/src/HotChocolate/Utilities/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionClientTests.IntrospectServer.snap
+++ b/src/HotChocolate/Utilities/test/Utilities.Introspection.Tests/__snapshots__/IntrospectionClientTests.IntrospectServer.snap
@@ -5,13 +5,18 @@ schema {
 }
 
 type Query {
-  hero(episode: Episode! = NEW_HOPE): Character
-  heroByTraits(traits: Any!): Character
-  heroes(episodes: [Episode!]!): [Character!]
+  "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character."
+  hero("The episode to look up by." episode: Episode! = NEW_HOPE): Character
+  "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character."
+  heroByTraits("The traits to look up by." traits: Any!): Character
+  "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters."
+  heroes("The episodes to look up by." episodes: [Episode!]!): [Character!]
   character(characterIds: [String!]!): [Character!]!
   search(text: String!): [SearchResult]
-  human(id: String!): Human
-  droid(id: String!): Droid
+  "Gets a human by Id.\n\n\n**Returns:**\nThe human."
+  human("The Id of the human to retrieve." id: String!): Human
+  "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid."
+  droid("The Id of the droid." id: String!): Droid
   time: Long!
   evict: Boolean!
   wait(m: Int!): Boolean!
@@ -21,7 +26,13 @@ type Query {
 }
 
 type Mutation {
-  createReview(episode: Episode!, review: ReviewInput!): Review!
+  "Creates a review for a given Star Wars episode.\n\n\n**Returns:**\nThe created review."
+  createReview(
+    "The episode to review."
+    episode: Episode!
+    "The review."
+    review: ReviewInput!
+  ): Review!
   complete(episode: Episode!): Boolean!
 }
 
@@ -30,9 +41,13 @@ type Subscription {
   delay(delay: Int!, count: Int!): String!
 }
 
+"A human character in the Star Wars universe."
 type Human implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -46,13 +61,19 @@ type Human implements Character {
   ): FriendsConnection
   otherHuman: Human
   height(unit: Unit): Float
+  "The planet the character is originally from."
   homePlanet: String
+  "The traits of this character."
   traits: Any
 }
 
+"A droid in the Star Wars universe."
 type Droid implements Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The episodes the character appears in."
   appearsIn: [Episode]
   friends(
     "Returns the first _n_ elements from the list."
@@ -65,19 +86,29 @@ type Droid implements Character {
     before: String
   ): FriendsConnection
   height(unit: Unit): Float
+  "The droid's primary function."
   primaryFunction: String
+  "The traits of this character."
   traits: Any
 }
 
+"The Star Wars episodes."
 enum Episode {
+  "Star Wars Episode IV: A New Hope"
   NEW_HOPE
+  "Star Wars Episode V: Empire Strikes Back"
   EMPIRE
+  "Star Wars Episode VI: Return of the Jedi"
   JEDI
 }
 
+"A character in the Star Wars universe."
 interface Character {
+  "The unique identifier for the character."
   id: ID!
+  "The name of the character."
   name: String!
+  "The names of the character's friends."
   friends(
     "Returns the first _n_ elements from the list."
     first: Int
@@ -88,20 +119,29 @@ interface Character {
     "Returns the elements in the list that come before the specified cursor."
     before: String
   ): FriendsConnection
+  "The episodes the character appears in."
   appearsIn: [Episode]
+  "The traits of this character."
   traits: Any
+  "The height of the character."
   height(unit: Unit): Float
 }
 
 union SearchResult = Starship | Human | Droid
 
+"A review of a particular movie."
 type Review {
+  "An explanation for the rating."
   commentary: String
+  "The number of stars given for this review."
   stars: Int!
 }
 
+"A review of a particular movie."
 input ReviewInput {
+  "The number of stars given for this review."
   stars: Int!
+  "An explanation for the rating."
   commentary: String
 }
 
@@ -115,6 +155,7 @@ type FriendsConnection {
   nodes: [Character]
 }
 
+"Different units of measurement."
 enum Unit {
   FOOT
   METERS
@@ -123,8 +164,11 @@ enum Unit {
 "The `Any` scalar type represents any valid GraphQL value."
 scalar Any
 
+"A starship in the Star Wars universe."
 type Starship {
+  "The Id of the starship."
   id: ID!
+  "The name of the starship."
   name: String!
   length(unit: Unit): Float!
 }

--- a/src/Mocha/test/Directory.Build.props
+++ b/src/Mocha/test/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Mocha/test/Mocha.Transport.InMemory.Tests/Routing/InMemoryNeutralSchemeGatingTests.cs
+++ b/src/Mocha/test/Mocha.Transport.InMemory.Tests/Routing/InMemoryNeutralSchemeGatingTests.cs
@@ -4,9 +4,11 @@ using Mocha.Transport.InMemory.Tests.Helpers;
 namespace Mocha.Transport.InMemory.Tests.Routing;
 
 /// <summary>
-/// Verifies that <see cref="InMemoryMessagingTransport.CreateEndpointConfiguration(IMessagingConfigurationContext, Uri)"/>
-/// can describe supported neutral-scheme URIs (<c>queue:</c> and <c>topic:</c>). The central
-/// endpoint router applies the cross-transport selection rules.
+/// Verifies that
+/// <see cref="MessagingTransport.CreateEndpointConfiguration(IMessagingConfigurationContext, Uri)"/>
+/// on an <see cref="InMemoryMessagingTransport"/> can describe supported neutral-scheme URIs
+/// (<c>queue:</c> and <c>topic:</c>). The central endpoint router applies the cross-transport
+/// selection rules.
 /// </summary>
 public class InMemoryNeutralSchemeGatingTests
 {

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/CodexHooksCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/CodexHooksCommandTests.cs
@@ -1,17 +1,14 @@
 namespace ChilliCream.Nitro.CommandLine.Tests.Agents;
 
 /// <summary>
-/// Command wiring (help text) only for <c>agent hooks codex
-/// install/status/uninstall</c>. Unlike Claude's <c>--scope project</c>
-/// round trip in <c>HooksCommandTests</c>, Codex's path resolver has no
-/// per-workspace override (<c>CODEX_HOME</c> is a per-user concept, not a
-/// project one) and this test harness has no plumbing to redirect it away
-/// from the real <c>~/.codex</c> - so, per this ticket's hard constraint,
-/// nothing here ever actually installs. The deep install/status/uninstall
-/// and config.toml wrap/restore behavior is exercised directly against
-/// <c>CodexHooksEditor</c>/<c>CodexConfigTomlNotifyEditor</c>/
-/// <c>CodexHooksInstallerService</c> in their own dedicated test classes,
-/// all fixture- and temp-directory-driven.
+/// Command wiring (help text) only for <c>agent hooks codex install/status/uninstall</c>. Unlike
+/// Claude's <c>--scope project</c> round trip in <c>HooksCommandTests</c>, Codex's path resolver
+/// has no per-workspace override (<c>CODEX_HOME</c> is a per-user concept, not a project one) and
+/// this test harness has no plumbing to redirect it away from the real <c>~/.codex</c> - so, per
+/// this ticket's hard constraint, nothing here ever actually installs. The deep
+/// install/status/uninstall and config.toml wrap/restore behavior is exercised directly against
+/// <c>CodexHooksEditor</c>/<c>CodexConfigTomlNotifyEditor</c>/<c>CodexHooksInstallerService</c> in
+/// their own dedicated test classes, all fixture- and temp-directory-driven.
 /// </summary>
 public sealed class CodexHooksCommandTests(NitroCommandFixture fixture) : AgentCommandTestBase(fixture)
 {

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/CodexHooksCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/CodexHooksCommandTests.cs
@@ -4,11 +4,11 @@ namespace ChilliCream.Nitro.CommandLine.Tests.Agents;
 /// Command wiring (help text) only for <c>agent hooks codex install/status/uninstall</c>. Unlike
 /// Claude's <c>--scope project</c> round trip in <c>HooksCommandTests</c>, Codex's path resolver
 /// has no per-workspace override (<c>CODEX_HOME</c> is a per-user concept, not a project one) and
-/// this test harness has no plumbing to redirect it away from the real <c>~/.codex</c> - so, per
-/// this ticket's hard constraint, nothing here ever actually installs. The deep
-/// install/status/uninstall and config.toml wrap/restore behavior is exercised directly against
-/// <c>CodexHooksEditor</c>/<c>CodexConfigTomlNotifyEditor</c>/<c>CodexHooksInstallerService</c> in
-/// their own dedicated test classes, all fixture- and temp-directory-driven.
+/// this test harness has no plumbing to redirect it away from the real <c>~/.codex</c>. Per this
+/// ticket's hard constraint, nothing here ever actually installs. The deep install/status/uninstall
+/// and config.toml wrap/restore behavior is exercised directly against <c>CodexHooksEditor</c>/
+/// <c>CodexConfigTomlNotifyEditor</c>/<c>CodexHooksInstallerService</c> in their own dedicated test
+/// classes, all fixture- and temp-directory-driven.
 /// </summary>
 public sealed class CodexHooksCommandTests(NitroCommandFixture fixture) : AgentCommandTestBase(fixture)
 {

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/Mail/MailCommandTestBase.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/Mail/MailCommandTestBase.cs
@@ -53,7 +53,7 @@ public abstract class MailCommandTestBase : CommandTestBase
     /// additionally wired with the instance id and global config directory
     /// providers <see cref="MailWakePolicy.Enqueue"/> requires, pinned to
     /// <paramref name="instanceId"/> so a directly-enqueued generation lines
-    /// up with a command run under the matching <see cref="SetupInstanceId"/>.
+    /// up with a command run under the matching <see cref="CommandTestBase.SetupInstanceId"/>.
     /// </summary>
     internal MailStore CreateWakeStore(string instanceId)
         => new(
@@ -112,7 +112,7 @@ public abstract class MailCommandTestBase : CommandTestBase
     /// <summary>
     /// Seeds an alive, explicitly-claimed <c>codex-thread</c> session for
     /// <paramref name="agentName"/> directly against the workspace database,
-    /// on the host id <see cref="SetupInstanceId"/> was pointed at (a test
+    /// on the host id <see cref="CommandTestBase.SetupInstanceId"/> was pointed at (a test
     /// calling this must call that first, so the notifier's own host
     /// resolution matches this row). Used to exercise auto-ping through the
     /// CLI without a live harness process.
@@ -143,7 +143,7 @@ public abstract class MailCommandTestBase : CommandTestBase
 
     /// <summary>
     /// Seeds an alive <c>agent_sessions</c> row directly against the
-    /// workspace database, on the host id <see cref="SetupInstanceId"/> was
+    /// workspace database, on the host id <see cref="CommandTestBase.SetupInstanceId"/> was
     /// pointed at (a test calling this must call that first, so the
     /// notifier's own host resolution matches this row). A null
     /// <paramref name="agentName"/> seeds an unbound row. Used to exercise

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/Mail/WatchMailCommandTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/Agent/Mail/WatchMailCommandTests.cs
@@ -433,7 +433,7 @@ public sealed class WatchMailCommandTests(NitroCommandFixture fixture)
     /// Advances the fake clock by one second at a time, on a short real
     /// interval, until the watch command's task completes. The real delay
     /// only paces test synchronization; the simulated one-second poll
-    /// cadence and any --timeout are driven entirely by <see cref="FakeTime"/>.
+    /// cadence and any --timeout are driven entirely by <see cref="CommandTestBase.FakeTime"/>.
     /// </summary>
     private async Task<CommandResult> AdvanceUntilCompleteAsync(
         Task<CommandResult> runTask,

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/CommandTestBase.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Commands/CommandTestBase.cs
@@ -93,12 +93,6 @@ public abstract class CommandTestBase
     }
 
     /// <summary>
-    /// Points the global memory store at a fixed directory instead of the
-    /// real machine's application data directory, so tests that exercise
-    /// <c>--scope global</c> stay isolated to their own temp directory.
-    /// </summary>
-
-    /// <summary>
     /// Points the Nitro instance id resolution at a fixed value instead of
     /// hashing the real machine's id, so tests that seed rows by host stay
     /// isolated from the machine running them.

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Hook/CodexQueueClientTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Hook/CodexQueueClientTests.cs
@@ -4,8 +4,8 @@ using ChilliCream.Nitro.CommandLine.Services.Hook;
 namespace ChilliCream.Nitro.CommandLine.Tests.Hook;
 
 /// <summary>
-/// Exercises the <see cref="ProcessStartInfo"/> built for the <c>codex
-/// queue</c> subprocess directly: it must strip the actor identity a real
+/// Exercises the <see cref="ProcessStartInfo"/> built for the
+/// <c>codex queue</c> subprocess directly: it must strip the actor identity a real
 /// invocation would otherwise inherit and suppress the child's own hook
 /// re-entry, so a queued message's own notify firing is never misattributed
 /// to the actor that queued it and never re-triggers a ping of its own.

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Editing/FakeTaskStore.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Editing/FakeTaskStore.cs
@@ -1,4 +1,5 @@
 using ChilliCream.Nitro.CommandLine.Services.Tasks;
+using ChilliCream.Nitro.CommandLine.Tui.Editing;
 
 namespace ChilliCream.Nitro.CommandLine.Tests.Tui.Editing;
 

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Mail/FakeMailStore.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Mail/FakeMailStore.cs
@@ -119,7 +119,7 @@ internal sealed class FakeMailStore : IMailStore
     /// <see cref="MailWakePolicy.Enqueue"/>, every recipient gets a
     /// <see cref="MailWakeReceipt"/> (an incrementing generation, mirroring
     /// the real store's own per-recipient counter), matching the shape
-    /// <see cref="Commands.Mail.MailWakeDispatch.RunAsync"/> expects.
+    /// <see cref="MailMessage.WakeReceipts"/> carries.
     /// </summary>
     public async Task<MailMessage> SendMessageAsync(MailMessageCreation creation, CancellationToken cancellationToken)
     {

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Shell/FakeTaskStore.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Shell/FakeTaskStore.cs
@@ -1,4 +1,5 @@
 using ChilliCream.Nitro.CommandLine.Services.Tasks;
+using ChilliCream.Nitro.CommandLine.Tui.Shell;
 
 namespace ChilliCream.Nitro.CommandLine.Tests.Tui.Shell;
 

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Shell/TaskItemBuilder.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Tui/Shell/TaskItemBuilder.cs
@@ -1,4 +1,5 @@
 using ChilliCream.Nitro.CommandLine.Services.Tasks;
+using ChilliCream.Nitro.CommandLine.Tui.Shell;
 
 namespace ChilliCream.Nitro.CommandLine.Tests.Tui.Shell;
 

--- a/src/Nitro/CommandLine/test/Directory.Build.props
+++ b/src/Nitro/CommandLine/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/Nitro/Common/test/Directory.Build.props
+++ b/src/Nitro/Common/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/StrawberryShake/Client/test/Directory.Build.props
+++ b/src/StrawberryShake/Client/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/__snapshots__/StarWarsIntrospectionTest.Execute_StarWarsIntrospection_Test.snap
+++ b/src/StrawberryShake/CodeGeneration/test/CodeGeneration.CSharp.Tests/Integration/__snapshots__/StarWarsIntrospectionTest.Execute_StarWarsIntrospection_Test.snap
@@ -1189,11 +1189,11 @@
           "Fields": [
             {
               "Name": "hero",
-              "Description": null,
+              "Description": "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character.",
               "Args": [
                 {
                   "Name": "episode",
-                  "Description": null,
+                  "Description": "The episode to look up by.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1216,11 +1216,11 @@
             },
             {
               "Name": "heroByTraits",
-              "Description": null,
+              "Description": "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character.",
               "Args": [
                 {
                   "Name": "traits",
-                  "Description": null,
+                  "Description": "The traits to look up by.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1243,11 +1243,11 @@
             },
             {
               "Name": "heroes",
-              "Description": null,
+              "Description": "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters.",
               "Args": [
                 {
                   "Name": "episodes",
-                  "Description": null,
+                  "Description": "The episodes to look up by.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1361,11 +1361,11 @@
             },
             {
               "Name": "human",
-              "Description": null,
+              "Description": "Gets a human by Id.\n\n\n**Returns:**\nThe human.",
               "Args": [
                 {
                   "Name": "id",
-                  "Description": null,
+                  "Description": "The Id of the human to retrieve.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1388,11 +1388,11 @@
             },
             {
               "Name": "droid",
-              "Description": null,
+              "Description": "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid.",
               "Args": [
                 {
                   "Name": "id",
-                  "Description": null,
+                  "Description": "The Id of the droid.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1426,11 +1426,11 @@
           "Fields": [
             {
               "Name": "createReview",
-              "Description": null,
+              "Description": "Creates a review for a given Star Wars episode.\n\n\n**Returns:**\nThe created review.",
               "Args": [
                 {
                   "Name": "episode",
-                  "Description": null,
+                  "Description": "The episode to review.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1444,7 +1444,7 @@
                 },
                 {
                   "Name": "review",
-                  "Description": null,
+                  "Description": "The review.",
                   "Type": {
                     "Kind": "NonNull",
                     "Name": null,
@@ -1551,11 +1551,11 @@
         {
           "Kind": "Object",
           "Name": "Human",
-          "Description": null,
+          "Description": "A human character in the Star Wars universe.",
           "Fields": [
             {
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1571,7 +1571,7 @@
             },
             {
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1587,7 +1587,7 @@
             },
             {
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "Kind": "List",
@@ -1691,7 +1691,7 @@
             },
             {
               "Name": "homePlanet",
-              "Description": null,
+              "Description": "The planet the character is originally from.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -1703,7 +1703,7 @@
             },
             {
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -1728,11 +1728,11 @@
         {
           "Kind": "Object",
           "Name": "Droid",
-          "Description": null,
+          "Description": "A droid in the Star Wars universe.",
           "Fields": [
             {
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1748,7 +1748,7 @@
             },
             {
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1764,7 +1764,7 @@
             },
             {
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "Kind": "List",
@@ -1856,7 +1856,7 @@
             },
             {
               "Name": "primaryFunction",
-              "Description": null,
+              "Description": "The droid's primary function.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -1868,7 +1868,7 @@
             },
             {
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -1893,26 +1893,26 @@
         {
           "Kind": "Enum",
           "Name": "Episode",
-          "Description": null,
+          "Description": "The Star Wars episodes.",
           "Fields": null,
           "InputFields": null,
           "Interfaces": null,
           "EnumValues": [
             {
               "Name": "NEW_HOPE",
-              "Description": null,
+              "Description": "Star Wars Episode IV: A New Hope",
               "IsDeprecated": false,
               "DeprecationReason": null
             },
             {
               "Name": "EMPIRE",
-              "Description": null,
+              "Description": "Star Wars Episode V: Empire Strikes Back",
               "IsDeprecated": false,
               "DeprecationReason": null
             },
             {
               "Name": "JEDI",
-              "Description": null,
+              "Description": "Star Wars Episode VI: Return of the Jedi",
               "IsDeprecated": false,
               "DeprecationReason": null
             }
@@ -1942,11 +1942,11 @@
         {
           "Kind": "Interface",
           "Name": "Character",
-          "Description": null,
+          "Description": "A character in the Star Wars universe.",
           "Fields": [
             {
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1962,7 +1962,7 @@
             },
             {
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -1978,7 +1978,7 @@
             },
             {
               "Name": "friends",
-              "Description": null,
+              "Description": "The names of the character's friends.",
               "Args": [
                 {
                   "Name": "first",
@@ -2031,7 +2031,7 @@
             },
             {
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "Kind": "List",
@@ -2047,7 +2047,7 @@
             },
             {
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -2059,7 +2059,7 @@
             },
             {
               "Name": "height",
-              "Description": null,
+              "Description": "The height of the character.",
               "Args": [
                 {
                   "Name": "unit",
@@ -2126,11 +2126,11 @@
         {
           "Kind": "Object",
           "Name": "Review",
-          "Description": null,
+          "Description": "A review of a particular movie.",
           "Fields": [
             {
               "Name": "commentary",
-              "Description": null,
+              "Description": "An explanation for the rating.",
               "Args": [],
               "Type": {
                 "Kind": "Scalar",
@@ -2142,7 +2142,7 @@
             },
             {
               "Name": "stars",
-              "Description": null,
+              "Description": "The number of stars given for this review.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -2165,12 +2165,12 @@
         {
           "Kind": "InputObject",
           "Name": "ReviewInput",
-          "Description": null,
+          "Description": "A review of a particular movie.",
           "Fields": null,
           "InputFields": [
             {
               "Name": "stars",
-              "Description": null,
+              "Description": "The number of stars given for this review.",
               "Type": {
                 "Kind": "NonNull",
                 "Name": null,
@@ -2184,7 +2184,7 @@
             },
             {
               "Name": "commentary",
-              "Description": null,
+              "Description": "An explanation for the rating.",
               "Type": {
                 "Kind": "Scalar",
                 "Name": "String",
@@ -2273,7 +2273,7 @@
         {
           "Kind": "Enum",
           "Name": "Unit",
-          "Description": null,
+          "Description": "Different units of measurement.",
           "Fields": null,
           "InputFields": null,
           "Interfaces": null,
@@ -2306,11 +2306,11 @@
         {
           "Kind": "Object",
           "Name": "Starship",
-          "Description": null,
+          "Description": "A starship in the Star Wars universe.",
           "Fields": [
             {
               "Name": "id",
-              "Description": null,
+              "Description": "The Id of the starship.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -2326,7 +2326,7 @@
             },
             {
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the starship.",
               "Args": [],
               "Type": {
                 "Kind": "NonNull",
@@ -4858,12 +4858,12 @@
             {
               "__typename": "__Field",
               "Name": "hero",
-              "Description": null,
+              "Description": "Retrieve a hero by a particular Star Wars episode.\n\n\n**Returns:**\nThe character.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "episode",
-                  "Description": null,
+                  "Description": "The episode to look up by.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -4908,12 +4908,12 @@
             {
               "__typename": "__Field",
               "Name": "heroByTraits",
-              "Description": null,
+              "Description": "Retrieve a hero by their traits.\n\n\n**Returns:**\nThe character.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "traits",
-                  "Description": null,
+                  "Description": "The traits to look up by.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -4958,12 +4958,12 @@
             {
               "__typename": "__Field",
               "Name": "heroes",
-              "Description": null,
+              "Description": "Retrieve heroes by particular Star Wars episodes.\n\n\n**Returns:**\nThe characters.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "episodes",
-                  "Description": null,
+                  "Description": "The episodes to look up by.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -5218,12 +5218,12 @@
             {
               "__typename": "__Field",
               "Name": "human",
-              "Description": null,
+              "Description": "Gets a human by Id.\n\n\n**Returns:**\nThe human.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "id",
-                  "Description": null,
+                  "Description": "The Id of the human to retrieve.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -5268,12 +5268,12 @@
             {
               "__typename": "__Field",
               "Name": "droid",
-              "Description": null,
+              "Description": "Get a particular droid by Id.\n\n\n**Returns:**\nThe droid.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "id",
-                  "Description": null,
+                  "Description": "The Id of the droid.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -5331,12 +5331,12 @@
             {
               "__typename": "__Field",
               "Name": "createReview",
-              "Description": null,
+              "Description": "Creates a review for a given Star Wars episode.\n\n\n**Returns:**\nThe created review.",
               "Args": [
                 {
                   "__typename": "__InputValue",
                   "Name": "episode",
-                  "Description": null,
+                  "Description": "The episode to review.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -5365,7 +5365,7 @@
                 {
                   "__typename": "__InputValue",
                   "Name": "review",
-                  "Description": null,
+                  "Description": "The review.",
                   "Type": {
                     "__typename": "__Type",
                     "Name": null,
@@ -5564,12 +5564,12 @@
           "__typename": "__Type",
           "Name": "Human",
           "Kind": "Object",
-          "Description": null,
+          "Description": "A human character in the Star Wars universe.",
           "Fields": [
             {
               "__typename": "__Field",
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5600,7 +5600,7 @@
             {
               "__typename": "__Field",
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5631,7 +5631,7 @@
             {
               "__typename": "__Field",
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5814,7 +5814,7 @@
             {
               "__typename": "__Field",
               "Name": "homePlanet",
-              "Description": null,
+              "Description": "The planet the character is originally from.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5834,7 +5834,7 @@
             {
               "__typename": "__Field",
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5875,12 +5875,12 @@
           "__typename": "__Type",
           "Name": "Droid",
           "Kind": "Object",
-          "Description": null,
+          "Description": "A droid in the Star Wars universe.",
           "Fields": [
             {
               "__typename": "__Field",
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5911,7 +5911,7 @@
             {
               "__typename": "__Field",
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -5942,7 +5942,7 @@
             {
               "__typename": "__Field",
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6105,7 +6105,7 @@
             {
               "__typename": "__Field",
               "Name": "primaryFunction",
-              "Description": null,
+              "Description": "The droid's primary function.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6125,7 +6125,7 @@
             {
               "__typename": "__Field",
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6166,7 +6166,7 @@
           "__typename": "__Type",
           "Name": "Episode",
           "Kind": "Enum",
-          "Description": null,
+          "Description": "The Star Wars episodes.",
           "Fields": null,
           "InputFields": null,
           "Interfaces": null,
@@ -6174,21 +6174,21 @@
             {
               "__typename": "__EnumValue",
               "Name": "NEW_HOPE",
-              "Description": null,
+              "Description": "Star Wars Episode IV: A New Hope",
               "IsDeprecated": false,
               "DeprecationReason": null
             },
             {
               "__typename": "__EnumValue",
               "Name": "EMPIRE",
-              "Description": null,
+              "Description": "Star Wars Episode V: Empire Strikes Back",
               "IsDeprecated": false,
               "DeprecationReason": null
             },
             {
               "__typename": "__EnumValue",
               "Name": "JEDI",
-              "Description": null,
+              "Description": "Star Wars Episode VI: Return of the Jedi",
               "IsDeprecated": false,
               "DeprecationReason": null
             }
@@ -6224,12 +6224,12 @@
           "__typename": "__Type",
           "Name": "Character",
           "Kind": "Interface",
-          "Description": null,
+          "Description": "A character in the Star Wars universe.",
           "Fields": [
             {
               "__typename": "__Field",
               "Name": "id",
-              "Description": null,
+              "Description": "The unique identifier for the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6260,7 +6260,7 @@
             {
               "__typename": "__Field",
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6291,7 +6291,7 @@
             {
               "__typename": "__Field",
               "Name": "friends",
-              "Description": null,
+              "Description": "The names of the character's friends.",
               "Args": [
                 {
                   "__typename": "__InputValue",
@@ -6384,7 +6384,7 @@
             {
               "__typename": "__Field",
               "Name": "appearsIn",
-              "Description": null,
+              "Description": "The episodes the character appears in.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6415,7 +6415,7 @@
             {
               "__typename": "__Field",
               "Name": "traits",
-              "Description": null,
+              "Description": "The traits of this character.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6435,7 +6435,7 @@
             {
               "__typename": "__Field",
               "Name": "height",
-              "Description": null,
+              "Description": "The height of the character.",
               "Args": [
                 {
                   "__typename": "__InputValue",
@@ -6556,12 +6556,12 @@
           "__typename": "__Type",
           "Name": "Review",
           "Kind": "Object",
-          "Description": null,
+          "Description": "A review of a particular movie.",
           "Fields": [
             {
               "__typename": "__Field",
               "Name": "commentary",
-              "Description": null,
+              "Description": "An explanation for the rating.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6581,7 +6581,7 @@
             {
               "__typename": "__Field",
               "Name": "stars",
-              "Description": null,
+              "Description": "The number of stars given for this review.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6620,13 +6620,13 @@
           "__typename": "__Type",
           "Name": "ReviewInput",
           "Kind": "InputObject",
-          "Description": null,
+          "Description": "A review of a particular movie.",
           "Fields": null,
           "InputFields": [
             {
               "__typename": "__InputValue",
               "Name": "stars",
-              "Description": null,
+              "Description": "The number of stars given for this review.",
               "Type": {
                 "__typename": "__Type",
                 "Name": null,
@@ -6655,7 +6655,7 @@
             {
               "__typename": "__InputValue",
               "Name": "commentary",
-              "Description": null,
+              "Description": "An explanation for the rating.",
               "Type": {
                 "__typename": "__Type",
                 "Name": "String",
@@ -6809,7 +6809,7 @@
           "__typename": "__Type",
           "Name": "Unit",
           "Kind": "Enum",
-          "Description": null,
+          "Description": "Different units of measurement.",
           "Fields": null,
           "InputFields": null,
           "Interfaces": null,
@@ -6848,12 +6848,12 @@
           "__typename": "__Type",
           "Name": "Starship",
           "Kind": "Object",
-          "Description": null,
+          "Description": "A starship in the Star Wars universe.",
           "Fields": [
             {
               "__typename": "__Field",
               "Name": "id",
-              "Description": null,
+              "Description": "The Id of the starship.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",
@@ -6884,7 +6884,7 @@
             {
               "__typename": "__Field",
               "Name": "name",
-              "Description": null,
+              "Description": "The name of the starship.",
               "Args": [],
               "Type": {
                 "__typename": "__Type",

--- a/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
+++ b/src/StrawberryShake/CodeGeneration/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>

--- a/src/StrawberryShake/Tooling/test/Directory.Build.props
+++ b/src/StrawberryShake/Tooling/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
-
-  <PropertyGroup>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
## Summary

- Every test project now generates its XML documentation file, so `GenerateDocumentationFile` is on for the whole repository. This is the prerequisite for enforcing IDE0005 (unnecessary usings) in the build: the compiler only reports it when documentation comments are parsed ([dotnet/roslyn#41640](https://github.com/dotnet/roslyn/issues/41640)).
- The `GenerateDocumentationFile=false` overrides are removed from the test-level `Directory.Build.props` files and from CookieCrumble.Tests. The 24 props files left with only the parent import are deleted, since MSBuild finds the parent on its own.
- Compiling the doc comments in tests surfaced 31 compiler warnings (unresolved or ambiguous `cref` targets, missing `<param>` tags, a `///` comment on commented-out code) and 3 Roslynator findings. These are fixed.

## Test plan

- `dotnet build src/All.slnx` passes with the default warnings-as-errors setting.
- CI.
