### PR TITLE
Backport #9984: run resolver cleanup before scheduler completion (15.x)

### DIFF
--- a/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntitiesResolverTests.cs
+++ b/src/HotChocolate/ApolloFederation/test/ApolloFederation.Tests/EntitiesResolverTests.cs
@@ -3,6 +3,7 @@ using HotChocolate.ApolloFederation.Resolvers;
 using HotChocolate.ApolloFederation.Types;
 using HotChocolate.Execution;
 using HotChocolate.Language;
+using HotChocolate.Resolvers;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using static HotChocolate.ApolloFederation.TestHelper;
@@ -242,6 +243,100 @@ public class EntitiesResolverTests
         Assert.Equal("testId", obj.Detail!.Id);
     }
 
+    [Fact]
+    public async Task ResolveAsync_Should_NotFaultClonedContext_When_EntitiesResolvedConcurrently()
+    {
+        // arrange
+        var schema = await new ServiceCollection()
+            .AddGraphQL()
+            .AddApolloFederation()
+            .AddType<AsyncEntity>()
+            .AddQueryType()
+            .BuildSchemaAsync(cancellationToken: CancellationToken.None);
+
+        var executor = schema.MakeExecutable();
+
+        const string request =
+            """
+            query {
+                _entities(representations: [
+                    { id: "1", __typename: "AsyncEntity" }
+                ]) {
+                    ... on AsyncEntity { id }
+                }
+            }
+            """;
+
+        // The entities resolver clones the resolver context per representation and completes each
+        // clone as a cleanup task on the shared operation context. When that completion observes
+        // the operation context after it has been recycled, it throws an ObjectDisposedException.
+        // The faulted completion is never awaited, so it only surfaces through the unobserved task
+        // exception event when the faulted task is finalized.
+        var unobservedExceptions = new List<Exception>();
+        void OnUnobserved(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            lock (unobservedExceptions)
+            {
+                unobservedExceptions.AddRange(e.Exception.Flatten().InnerExceptions);
+            }
+
+            e.SetObserved();
+        }
+
+        TaskScheduler.UnobservedTaskException += OnUnobserved;
+
+        try
+        {
+            // act
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(8);
+            var workers = new Task[256];
+
+            for (var i = 0; i < workers.Length; i++)
+            {
+                workers[i] = Task.Run(
+                    async () =>
+                    {
+                        while (DateTimeOffset.UtcNow < deadline && HasNoFault(unobservedExceptions))
+                        {
+                            await executor.ExecuteAsync(request, CancellationToken.None);
+                        }
+                    },
+                    CancellationToken.None);
+            }
+
+            // periodically force finalization so the faulted completion tasks surface quickly.
+            while (DateTimeOffset.UtcNow < deadline && HasNoFault(unobservedExceptions))
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(25, CancellationToken.None);
+            }
+
+            await Task.WhenAll(workers);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= OnUnobserved;
+        }
+
+        // assert
+        // Resolving entities concurrently must never fault a cloned entity context by observing the
+        // shared operation context after it has been recycled back to the pool.
+        Assert.Empty(
+            unobservedExceptions.Select(ex => $"{ex.GetType().Name}: {ex.Message}"));
+    }
+
+    private static bool HasNoFault(List<Exception> exceptions)
+    {
+        lock (exceptions)
+        {
+            return exceptions.Count == 0;
+        }
+    }
+
     public class Query
     {
         public ForeignType ForeignType { get; set; } = default!;
@@ -265,6 +360,32 @@ public class EntitiesResolverTests
         public static TypeWithReferenceResolver Get([LocalState] ObjectValueNode data)
         {
             return new TypeWithReferenceResolver {Id = "1", SomeField = "SomeField"};
+        }
+    }
+
+    [ReferenceResolver(EntityResolver = nameof(Get))]
+    public sealed class AsyncEntity
+    {
+        [Key]
+        public string Id { get; set; } = null!;
+
+        public string SomeField { get; set; } = null!;
+
+        public static async Task<AsyncEntity> Get(IResolverContext context, string id)
+        {
+            // Yielding forces the reference resolver to complete asynchronously, which is what
+            // opens the window for the shared operation context to be recycled before the cloned
+            // entity context is completed.
+            await Task.Yield();
+
+            // Registering an asynchronous cleanup task on the cloned entity context mirrors what
+            // resolver-scoped services do (for example disposing an async dependency injection
+            // scope). The cleanup runs while the cloned context is being completed, suspending the
+            // parent completion long enough for the shared operation context to be recycled on
+            // another thread.
+            ((IMiddlewareContext)context).RegisterForCleanup(static async () => await Task.Yield());
+
+            return new AsyncEntity { Id = id, SomeField = "SomeField" };
         }
     }
 

--- a/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
+++ b/src/HotChocolate/Core/src/Execution/Processing/Tasks/ResolverTask.Execute.cs
@@ -54,14 +54,18 @@ internal sealed partial class ResolverTask
         }
         finally
         {
-            _operationContext.Scheduler.Complete(this);
-
-            if (_context.HasCleanupTasks)
+            try
             {
-                await _context.ExecuteCleanupTasksAsync().ConfigureAwait(false);
+                if (_context.HasCleanupTasks)
+                {
+                    await _context.ExecuteCleanupTasksAsync().ConfigureAwait(false);
+                }
             }
-
-            objectPool.Return(this);
+            finally
+            {
+                _operationContext.Scheduler.Complete(this);
+                objectPool.Return(this);
+            }
         }
     }
 


### PR DESCRIPTION
Backport of #9984 to `main-version-15`. Fixes #9971 for the 15.1.x line.

On 15.1.17 and 15.1.18, `ResolverTask.ExecuteAsync` signals `Scheduler.Complete(this)` before running the resolver's cleanup tasks. When the resolver was the last running task, the scheduler completes the request and returns the `OperationContext` to the pool while cleanup is still pending. Any cleanup that touches the operation context, such as the `CompleteUnsafeAsync` registered by `IResolverContext.Clone()`, then throws `ObjectDisposedException` ("The specified object was not initialized and is no longer usable"). The faulted task is never awaited, so it surfaces as an `UnobservedTaskException` on the finalizer thread.

The fix on `main` reorders the `finally` block so cleanup runs first and `Scheduler.Complete` plus the pool return happen in a nested `finally`. This is a cherry-pick of 6e5b640 with no API changes. The only adjustment is in the test: this branch uses xunit v2, so `TestContext.Current.CancellationToken` was replaced with `CancellationToken.None`.

Verified locally on this branch (net9.0): the backported test `ResolveAsync_Should_NotFaultClonedContext_When_EntitiesResolvedConcurrently` fails within ~650 ms on the unpatched `main-version-15` source with a list of `ObjectDisposedException`s, and passes with the fix applied.

We hit this in production on 15.1.17 through the Relay `node(id:)` field, which clones the resolver context in `NodeFieldResolvers`. Any `@refetchable` Relay fragment on a `Node` type triggers it, so it is not limited to Apollo Federation `_entities` as described in #9971. Responses stay correct, but the exception is logged on every occurrence. Upgrading to 16.x is not an option for us yet because a shared internal package pins HotChocolate to `[15.1.14, 16.0.0)`.
