### PR TITLE
Deliver each mail wake nudge at most once per session

### DIFF
--- a/src/Nitro/CommandLine/src/CommandLine/Services/Notify/MailNudge.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Services/Notify/MailNudge.cs
@@ -7,8 +7,10 @@ namespace ChilliCream.Nitro.CommandLine.Services.Notify;
 internal sealed class MailNudge(
     IAgentSessionRegistry sessions,
     IMailStore mail,
+    ISessionDeliveryLedger ledger,
     IClaudePeerClient claudePeerClient,
-    ICodexQueueClient codexQueueClient) : IMailNudge
+    ICodexQueueClient codexQueueClient,
+    TimeProvider timeProvider) : IMailNudge
 {
     public async Task NudgeAsync(IReadOnlyList<string> actors, CancellationToken cancellationToken)
     {
@@ -17,35 +19,63 @@ internal sealed class MailNudge(
             return;
         }
 
-        var participants = await sessions.ListParticipantsAsync(cancellationToken);
-
         foreach (var actor in actors.Distinct(StringComparer.Ordinal))
         {
-            // No liveness check: the nudge is best effort, so trying and
-            // failing costs the same as asking first and is never stale.
-            var targets = participants
-                .Where(participant => participant.Session.AgentName == actor)
-                .ToArray();
+            var target = await ResolveTargetAsync(actor, cancellationToken);
 
-            if (targets.Length == 0)
+            if (target is null)
             {
                 continue;
             }
 
-            var unread = await mail.CountUnreadAsync(actor, cancellationToken);
+            var unread = await mail.QueryInboxAsync(
+                new MailInboxFilter { Actor = actor, UnreadOnly = true, Limit = PingPolicy.MaxDigestMessages },
+                cancellationToken);
 
-            if (unread == 0)
+            if (unread.Count == 0)
             {
                 continue;
             }
 
-            var text = MailNudgeText.Format(actor, unread);
+            // Reserve-then-emit on the shared ping channel: the wake daemon
+            // dispatches the same nudge for the same message, and only one of
+            // the two may claim it.
+            var reserved = await ledger.ReserveAsync(
+                target.Harness,
+                target.SessionId,
+                unread.Select(message => message.Id).ToList(),
+                AgentSessionChannel.Ping,
+                timeProvider.GetUtcNow(),
+                cancellationToken);
 
-            foreach (var target in targets)
+            if (reserved.Count == 0)
             {
-                await SendAsync(target.Session, text, cancellationToken);
+                continue;
             }
+
+            await SendAsync(
+                target,
+                MailNudgeText.Format(actor, await mail.CountUnreadAsync(actor, cancellationToken)),
+                cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// The single session this nudge fires at: the most recently seen live
+    /// coding session bound to <paramref name="actor"/> that advertises a
+    /// push endpoint, or null when the actor has none.
+    /// </summary>
+    private async Task<AgentSessionRecord?> ResolveTargetAsync(
+        string actor,
+        CancellationToken cancellationToken)
+    {
+        var live = await sessions.FindLiveClaimedByAgentNameAsync(actor, cancellationToken);
+
+        return live
+            .Where(session => session.Harness != AgentSessionHarness.NitroBoard)
+            .Where(session => session.EndpointKind
+                is AgentSessionEndpointKind.ClaudePeer or AgentSessionEndpointKind.CodexThread)
+            .MaxBy(session => session.LastBeatAt);
     }
 
     /// <summary>

--- a/src/Nitro/CommandLine/src/CommandLine/Services/Notify/PingSessionExecutor.cs
+++ b/src/Nitro/CommandLine/src/CommandLine/Services/Notify/PingSessionExecutor.cs
@@ -9,6 +9,7 @@ internal sealed class PingSessionExecutor(
     ICodexQueueClient queueClient,
     IClaudePeerClient claudePeerClient,
     IAgentSessionRegistry sessionRegistry,
+    ISessionDeliveryLedger ledger,
     IPingLeaseStore leaseStore,
     TimeProvider timeProvider) : IPingSessionExecutor
 {
@@ -89,7 +90,7 @@ internal sealed class PingSessionExecutor(
 
             try
             {
-                digest = await BuildDigestAsync(actorName, linkedSource.Token);
+                digest = await BuildDigestAsync(harness, sessionId, actorName, linkedSource.Token);
             }
             catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
             {
@@ -99,10 +100,11 @@ internal sealed class PingSessionExecutor(
 
             if (digest is null)
             {
-                // The unread mail that triggered this ping was already read
-                // by the time the attempt actually ran (a benign race, not
-                // a failure): nothing left to say, so this is a success
-                // with no transport call.
+                // The unread mail that triggered this ping was already read,
+                // or already announced to this session on the ping channel,
+                // by the time the attempt actually ran (a benign race, not a
+                // failure): nothing left to say, so this is a success with no
+                // transport call.
                 return await WriteResultAsync(harness, sessionId, attemptId, PingAttemptReason.Ok, null);
             }
 
@@ -135,13 +137,30 @@ internal sealed class PingSessionExecutor(
         }
     }
 
-    private async Task<string?> BuildDigestAsync(string actorName, CancellationToken cancellationToken)
+    private async Task<string?> BuildDigestAsync(
+        string harness,
+        string sessionId,
+        string actorName,
+        CancellationToken cancellationToken)
     {
         var unread = await mailStore.QueryInboxAsync(
             new MailInboxFilter { Actor = actorName, UnreadOnly = true, Limit = PingPolicy.MaxDigestMessages },
             cancellationToken);
 
         if (unread.Count == 0)
+        {
+            return null;
+        }
+
+        var reserved = await ledger.ReserveAsync(
+            harness,
+            sessionId,
+            unread.Select(message => message.Id).ToList(),
+            AgentSessionChannel.Ping,
+            timeProvider.GetUtcNow(),
+            cancellationToken);
+
+        if (reserved.Count == 0)
         {
             return null;
         }

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/ActorWakeDispatcherTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/ActorWakeDispatcherTests.cs
@@ -517,7 +517,8 @@ public sealed class ActorWakeDispatcherTests : IDisposable
 
         var queueClient = new FakeCodexQueueClient();
         var executor = new PingSessionExecutor(
-            _mail, queueClient, new NoopClaudePeerClient(), _sessions, _leases, _timeProvider);
+            _mail, queueClient, new NoopClaudePeerClient(), _sessions,
+            new SessionDeliveryLedger(_fileSystem, _database), _leases, _timeProvider);
         var dispatcher = new ActorWakeDispatcher(
             _batches,
             _sessions,

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/NotifierTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/NotifierTests.cs
@@ -113,7 +113,8 @@ public sealed class NotifierTests
             var gateCoordinator = new SessionGateCoordinator(gates, leases);
             var queueClient = new FakeCodexQueueClient();
             var executor = new PingSessionExecutor(
-                mail, queueClient, new NoopClaudePeerClient(), sessions, leases, timeProvider);
+                mail, queueClient, new NoopClaudePeerClient(), sessions,
+                new SessionDeliveryLedger(fileSystem, database), leases, timeProvider);
             var dispatcher = new ActorWakeDispatcher(
                 batches,
                 sessions,

--- a/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/PingSessionExecutorTests.cs
+++ b/src/Nitro/CommandLine/test/CommandLine.Tests/Services/Notify/PingSessionExecutorTests.cs
@@ -374,6 +374,7 @@ public sealed class PingSessionExecutorTests : IDisposable
             new NeverCompletingCodexQueueClient(),
             _claudePeerClient,
             _sessions,
+            new SessionDeliveryLedger(_fileSystem, _database),
             _leases,
             _timeProvider);
 
@@ -416,7 +417,9 @@ public sealed class PingSessionExecutorTests : IDisposable
     }
 
     private PingSessionExecutor CreateExecutor()
-        => new(_mail, _queueClient, _claudePeerClient, _sessions, _leases, _timeProvider);
+        => new(
+            _mail, _queueClient, _claudePeerClient, _sessions,
+            new SessionDeliveryLedger(_fileSystem, _database), _leases, _timeProvider);
 
     /// <summary>
     /// A deadline generous enough that a test's own real-time transport work


### PR DESCRIPTION
## The issue

When an agent sends mail, two things happen in `SendMailCommand` (same for reply and broadcast):

1. The message is written with `WakePolicy = MailWakePolicy.Enqueue`, which bumps a row in `mail_wake_outbox` for each recipient inside the same transaction.
2. Right after commit, `MailNudge.NudgeAsync` pushes "You have N unread nitro messages" straight into the recipient's live session (Claude peer or Codex thread).

Step 1 is not inert. If a `nitro agent` TUI is open anywhere, its `MailWakeDaemonCoordinator` polls that outbox every 200 ms, claims the pending generation through `ActorWakeDispatcher`, and hands it to `PingSessionExecutor`, which builds the exact same nudge text and pushes it into the same session. The two paths were written independently and neither knew about the other. The daemon's only guard was "unread count is still above zero", so unless the agent had already marked the mail read in the gap, it got the nudge twice.

Two things made it worse:

- No delivery ledger. The repo already has `session_deliveries`, an at-most-once table keyed by (session, message, channel), and a `AgentSessionChannel.Ping` constant reserved for exactly this. Only the hook paths used it (`digest` on UserPromptSubmit, `gate` on Stop). Neither push path did, so every daemon retry (backoff, offered-retry after 30 s, lost batch lease, new leader) re-announced mail that had already been announced.
- Stale nudges ("1 unread", inbox empty) are the tail of this. The first copy got read and acked; the second copy was still in flight carrying a count that was true when computed.

## The changes

Both push paths now go through the ledger on the ping channel, reserve-then-emit, so whichever fires first claims the message ids and the other sees an empty reservation and stays silent.

`MailNudge.cs`

- Takes `ISessionDeliveryLedger` and `TimeProvider`.
- Fetches the unread messages (ids, capped at `PingPolicy.MaxDigestMessages`) instead of just the count, reserves them on `AgentSessionChannel.Ping` for the target session, and sends only if something was newly reserved.
- Picks one target via `FindLiveClaimedByAgentNameAsync`, newest beat first, excluding the board and sessions without a push endpoint. Previously it took every `agent_sessions` row matching the name with no liveness or host filter. This also makes it aim at the same session `ActorWakeDispatcher.ResolveCandidatesAsync` picks, which is what makes the two reservations collide.

`PingSessionExecutor.cs`

- Takes `ISessionDeliveryLedger`.
- `BuildDigestAsync` now receives harness and session id, reserves the unread ids on the ping channel, and returns null when nothing was newly reserved. Null already meant "nothing to say, record Ok, no transport", which settles the outbox generation cleanly.

Tests: four construction sites gained `new SessionDeliveryLedger(fileSystem, database)`. `Nitro.CommandLine.Tests` passes (3599/3599 on net10.0).

## One tradeoff to know about

`MailNudge.SendAsync` swallows transport failures. Reserving before sending means a failed push burns the ping reservation, so the daemon will not retry that message. The turn-boundary hooks still catch it on their own channels, which is what the existing "the recipient's next turn reports the unread mail" comment already relied on. If the daemon retry should be preserved, the follow-up is a ledger release on transport failure.
