### PR TITLE
Create the schema export directory when it does not exist

### DIFF
--- a/src/HotChocolate/Core/src/Types/Execution/Internal/SchemaFileExporter.cs
+++ b/src/HotChocolate/Core/src/Types/Execution/Internal/SchemaFileExporter.cs
@@ -38,7 +38,7 @@ internal static class SchemaFileExporter
 
         var directory = System.IO.Path.GetDirectoryName(schemaFileName)!;
 
-        if (Directory.Exists(directory))
+        if (directory.Length > 0)
         {
             Directory.CreateDirectory(directory);
         }

--- a/src/HotChocolate/Core/test/Types.Tests/Execution/Internal/SchemaFileExporterTests.cs
+++ b/src/HotChocolate/Core/test/Types.Tests/Execution/Internal/SchemaFileExporterTests.cs
@@ -18,7 +18,6 @@ public class SchemaFileExporterTests : IDisposable
             .AddGraphQL()
             .AddQueryType(d => d.Name("Query").Field("foo").Resolve("bar"));
         var executor = await GetExecutorAsync(services);
-        Directory.CreateDirectory(_directory);
 
         // act
         var result = await SchemaFileExporter.Export(
@@ -64,7 +63,6 @@ public class SchemaFileExporterTests : IDisposable
             .AddGraphQL()
             .AddQueryType(d => d.Name("Query").Field("foo").Resolve("bar"));
         var executor = await GetExecutorAsync(services);
-        Directory.CreateDirectory(_directory);
 
         // act
         var result = await SchemaFileExporter.Export(
@@ -96,6 +94,28 @@ public class SchemaFileExporterTests : IDisposable
               }
             }
             """ + "\n");
+    }
+
+    [Fact]
+    public async Task Export_Should_CreateDirectory_When_DirectoryDoesNotExist()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        services
+            .AddGraphQL()
+            .AddQueryType(d => d.Name("Query").Field("foo").Resolve("bar"));
+        var executor = await GetExecutorAsync(services);
+
+        // act
+        var result = await SchemaFileExporter.Export(
+            System.IO.Path.Combine(_directory, "nested", "schema.graphqls"),
+            executor,
+            rewriteToSemanticNonNull: false,
+            TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.True(File.Exists(result.SchemaFileName));
+        Assert.True(File.Exists(result.SettingsFileName));
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

- `SchemaFileExporter.Export` now creates the target directory before writing the schema and settings files. The previous guard only called `Directory.CreateDirectory` when the directory already existed, so exporting into a path that did not exist yet failed with `DirectoryNotFoundException`.
- The guard keeps skipping an empty directory component, which is what a bare relative file name such as `schema.graphqls` yields and what `Directory.CreateDirectory` rejects.

## Test plan

- New `Export_Should_CreateDirectory_When_DirectoryDoesNotExist` exports into a nested path that does not exist and asserts both files are written. It failed with `DirectoryNotFoundException` before the change.
- The two existing `SchemaFileExporterTests` no longer pre-create the directory themselves and still pass.
