### PR TITLE
Report the reason for rejected batch requests to server diagnostics

### DIFF
--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/ExecutorSession.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/ExecutorSession.cs
@@ -99,7 +99,9 @@ public sealed class ExecutorSession
         {
             if (!options.Batching.HasFlag(AllowedBatching.VariableBatching))
             {
-                _diagnosticEvents.HttpRequestError(context, ErrorHelper.VariableBatchingDisabled());
+                _diagnosticEvents.HttpRequestError(
+                    context,
+                    Handle(ErrorHelper.VariableBatchingDisabled()));
                 var error = Handle(ErrorHelper.InvalidRequest());
                 return OperationResult.FromError(error);
             }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/ExecutorSession.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/ExecutorSession.cs
@@ -99,6 +99,7 @@ public sealed class ExecutorSession
         {
             if (!options.Batching.HasFlag(AllowedBatching.VariableBatching))
             {
+                _diagnosticEvents.HttpRequestError(context, ErrorHelper.VariableBatchingDisabled());
                 var error = Handle(ErrorHelper.InvalidRequest());
                 return OperationResult.FromError(error);
             }
@@ -108,6 +109,7 @@ public sealed class ExecutorSession
                 && variableBatch.VariableValues.Document.RootElement.GetArrayLength() > maxBatchSize)
             {
                 var error = Handle(ErrorHelper.BatchSizeExceeded(maxBatchSize));
+                _diagnosticEvents.HttpRequestError(context, error);
                 return OperationResult.FromError(error);
             }
         }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
@@ -156,7 +156,7 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
                         result = OperationResult.FromError(error);
                         session.DiagnosticEvents.HttpRequestError(
                             context,
-                            ErrorHelper.RequestBatchingDisabled());
+                            session.Handle(ErrorHelper.RequestBatchingDisabled()));
                     }
                     else if (string.IsNullOrEmpty(operationNames)
                         || !TryParseOperations(operationNames, out var ops))
@@ -199,7 +199,7 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
                         result = OperationResult.FromError(error);
                         session.DiagnosticEvents.HttpRequestError(
                             context,
-                            ErrorHelper.RequestBatchingDisabled());
+                            session.Handle(ErrorHelper.RequestBatchingDisabled()));
                     }
                     break;
             }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/HttpPostMiddlewareBase.cs
@@ -149,18 +149,26 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
                 {
                     string? operationNames = context.Request.Query[BatchOperations];
 
-                    if (!string.IsNullOrEmpty(operationNames)
-                        && TryParseOperations(operationNames, out var ops)
-                        && options.Batching.HasFlag(AllowedBatching.RequestBatching))
+                    if (!options.Batching.HasFlag(AllowedBatching.RequestBatching))
                     {
-                        result = await session.ExecuteOperationBatchAsync(context, requests[0], requestFlags, ops);
+                        var error = session.Handle(ErrorHelper.InvalidRequest());
+                        statusCode = HttpStatusCode.BadRequest;
+                        result = OperationResult.FromError(error);
+                        session.DiagnosticEvents.HttpRequestError(
+                            context,
+                            ErrorHelper.RequestBatchingDisabled());
                     }
-                    else
+                    else if (string.IsNullOrEmpty(operationNames)
+                        || !TryParseOperations(operationNames, out var ops))
                     {
                         var error = session.Handle(ErrorHelper.InvalidRequest());
                         statusCode = HttpStatusCode.BadRequest;
                         result = OperationResult.FromError(error);
                         session.DiagnosticEvents.HttpRequestError(context, error);
+                    }
+                    else
+                    {
+                        result = await session.ExecuteOperationBatchAsync(context, requests[0], requestFlags, ops);
                     }
 
                     break;
@@ -189,7 +197,9 @@ public abstract class HttpPostMiddlewareBase : MiddlewareBase
                         var error = session.Handle(ErrorHelper.InvalidRequest());
                         statusCode = HttpStatusCode.BadRequest;
                         result = OperationResult.FromError(error);
-                        session.DiagnosticEvents.HttpRequestError(context, error);
+                        session.DiagnosticEvents.HttpRequestError(
+                            context,
+                            ErrorHelper.RequestBatchingDisabled());
                     }
                     break;
             }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Properties/AspNetCorePipelineResources.Designer.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Properties/AspNetCorePipelineResources.Designer.cs
@@ -284,5 +284,17 @@ namespace HotChocolate.AspNetCore.Properties {
                 return ResourceManager.GetString("ErrorHelper_BatchSizeExceeded", resourceCulture);
             }
         }
+        
+        internal static string ErrorHelper_VariableBatchingDisabled {
+            get {
+                return ResourceManager.GetString("ErrorHelper_VariableBatchingDisabled", resourceCulture);
+            }
+        }
+        
+        internal static string ErrorHelper_RequestBatchingDisabled {
+            get {
+                return ResourceManager.GetString("ErrorHelper_RequestBatchingDisabled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Properties/AspNetCorePipelineResources.resx
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Properties/AspNetCorePipelineResources.resx
@@ -138,4 +138,10 @@
   <data name="ErrorHelper_BatchSizeExceeded" xml:space="preserve">
     <value>The batch size exceeds the maximum allowed batch size of {0}.</value>
   </data>
+  <data name="ErrorHelper_VariableBatchingDisabled" xml:space="preserve">
+    <value>Variable batching is disabled. Enable it with GraphQLServerOptions.Batching.</value>
+  </data>
+  <data name="ErrorHelper_RequestBatchingDisabled" xml:space="preserve">
+    <value>Request batching is disabled. Enable it with GraphQLServerOptions.Batching.</value>
+  </data>
 </root>

--- a/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/ErrorHelper.cs
+++ b/src/HotChocolate/AspNetCore/src/AspNetCore.Pipeline/Utilities/ErrorHelper.cs
@@ -99,4 +99,16 @@ internal static class ErrorHelper
             .SetMessage(ErrorHelper_BatchSizeExceeded, maxBatchSize)
             .SetCode(ErrorCodes.Server.RequestInvalid)
             .Build();
+
+    public static IError VariableBatchingDisabled()
+        => ErrorBuilder.New()
+            .SetMessage(ErrorHelper_VariableBatchingDisabled)
+            .SetCode(ErrorCodes.Server.RequestInvalid)
+            .Build();
+
+    public static IError RequestBatchingDisabled()
+        => ErrorBuilder.New()
+            .SetMessage(ErrorHelper_RequestBatchingDisabled)
+            .SetCode(ErrorCodes.Server.RequestInvalid)
+            .Build();
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
@@ -888,6 +888,155 @@ public class HttpPostMiddlewareTests(TestServerFactory serverFactory) : ServerTe
                 """);
     }
 
+    [Fact]
+    public async Task VariableBatch_Should_ReportReasonToDiagnostics_When_BatchingIsDisabled()
+    {
+        // arrange
+        var listener = new RecordingListener();
+        var server = CreateStarWarsServer(
+            configureServices: s => s
+                .AddGraphQLServer()
+                .AddDiagnosticEventListener(_ => listener)
+                .ModifyServerOptions(o => o.Batching = AllowedBatching.None));
+
+        // act
+        var result = await server.PostAsync(
+            """
+            {
+              "query": "query($episode: Episode!) { hero(episode: $episode) { name } }",
+              "variables": [{ "episode": "NEW_HOPE" }, { "episode": "EMPIRE" }]
+            }
+            """);
+
+        // assert
+        var diagnosticError = Assert.Single(listener.Errors);
+        Assert.Equal(
+            "Variable batching is disabled. Enable it with GraphQLServerOptions.Batching.",
+            diagnosticError.Message);
+        Assert.NotNull(result.Errors);
+        var responseError = Assert.Single(result.Errors);
+        Assert.Equal("Invalid GraphQL Request.", responseError["message"]);
+    }
+
+    [Fact]
+    public async Task VariableBatch_Should_ReportBatchSizeToDiagnostics_When_MaxSizeIsExceeded()
+    {
+        // arrange
+        var listener = new RecordingListener();
+        var server = CreateStarWarsServer(
+            configureServices: s => s
+                .AddGraphQLServer()
+                .AddDiagnosticEventListener(_ => listener)
+                .ModifyServerOptions(o => o.MaxBatchSize = 1));
+
+        // act
+        var result = await server.PostAsync(
+            """
+            {
+              "query": "query($episode: Episode!) { hero(episode: $episode) { name } }",
+              "variables": [{ "episode": "NEW_HOPE" }, { "episode": "EMPIRE" }]
+            }
+            """);
+
+        // assert
+        var diagnosticError = Assert.Single(listener.Errors);
+        Assert.Equal(
+            "The batch size exceeds the maximum allowed batch size of 1.",
+            diagnosticError.Message);
+        Assert.NotNull(result.Errors);
+        var responseError = Assert.Single(result.Errors);
+        Assert.Equal(
+            "The batch size exceeds the maximum allowed batch size of 1.",
+            responseError["message"]);
+    }
+
+    [Fact]
+    public async Task RequestBatch_Should_ReportReasonToDiagnostics_When_BatchingIsDisabled()
+    {
+        // arrange
+        var listener = new RecordingListener();
+        var server = CreateStarWarsServer(
+            configureServices: s => s
+                .AddGraphQLServer()
+                .AddDiagnosticEventListener(_ => listener)
+                .ModifyServerOptions(o => o.Batching = AllowedBatching.None));
+
+        // act
+        var result = await server.PostAsync(
+            """
+            [
+              { "query": "{ hero(episode: NEW_HOPE) { name } }" },
+              { "query": "{ hero(episode: EMPIRE) { name } }" }
+            ]
+            """);
+
+        // assert
+        var diagnosticError = Assert.Single(listener.Errors);
+        Assert.Equal(
+            "Request batching is disabled. Enable it with GraphQLServerOptions.Batching.",
+            diagnosticError.Message);
+        Assert.NotNull(result.Errors);
+        var responseError = Assert.Single(result.Errors);
+        Assert.Equal("Invalid GraphQL Request.", responseError["message"]);
+    }
+
+    [Fact]
+    public async Task OperationBatch_Should_ReportReasonToDiagnostics_When_BatchingIsDisabled()
+    {
+        // arrange
+        var listener = new RecordingListener();
+        var server = CreateStarWarsServer(
+            configureServices: s => s
+                .AddGraphQLServer()
+                .AddDiagnosticEventListener(_ => listener)
+                .ModifyServerOptions(o => o.Batching = AllowedBatching.None));
+
+        // act
+        var result = await server.PostAsync(
+            """
+            {
+              "query": "query a { __typename } query b { __typename }"
+            }
+            """,
+            "/graphql?batchOperations=[a,b]");
+
+        // assert
+        var diagnosticError = Assert.Single(listener.Errors);
+        Assert.Equal(
+            "Request batching is disabled. Enable it with GraphQLServerOptions.Batching.",
+            diagnosticError.Message);
+        Assert.NotNull(result.Errors);
+        var responseError = Assert.Single(result.Errors);
+        Assert.Equal("Invalid GraphQL Request.", responseError["message"]);
+    }
+
+    [Fact]
+    public async Task OperationBatch_Should_ReportGenericError_When_OperationNamesAreInvalid()
+    {
+        // arrange
+        var listener = new RecordingListener();
+        var server = CreateStarWarsServer(
+            configureServices: s => s
+                .AddGraphQLServer()
+                .AddDiagnosticEventListener(_ => listener));
+
+        // act
+        var result = await server.PostAsync(
+            """
+            {
+              "query": "query a { __typename } query b { __typename }"
+            }
+            """,
+            "/graphql?batchOperations=");
+
+        // assert
+        var diagnosticError = Assert.Single(listener.Errors);
+        Assert.Equal("Invalid GraphQL Request.", diagnosticError.Message);
+        Assert.NotNull(result.Errors);
+        var responseError = Assert.Single(result.Errors);
+        Assert.Equal("Invalid GraphQL Request.", responseError["message"]);
+    }
+
     public class ErrorRequestInterceptor : DefaultHttpRequestInterceptor
     {
         public override ValueTask OnCreateAsync(
@@ -914,5 +1063,13 @@ public class HttpPostMiddlewareTests(TestServerFactory serverFactory) : ServerTe
     public class NullListQuery
     {
         public List<string?> NullValues => [null, "abc", null];
+    }
+
+    public sealed class RecordingListener : ServerDiagnosticEventListener
+    {
+        public List<IError> Errors { get; } = [];
+
+        public override void HttpRequestError(HttpContext context, IError error)
+            => Errors.Add(error);
     }
 }

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/HttpPostMiddlewareTests.cs
@@ -1011,6 +1011,28 @@ public class HttpPostMiddlewareTests(TestServerFactory serverFactory) : ServerTe
     }
 
     [Fact]
+    public async Task OperationBatch_Should_ExecuteEachOperation_When_BatchingIsEnabled()
+    {
+        // arrange
+        var server = CreateStarWarsServer();
+
+        // act
+        var results = await server.PostOperationAsync(
+            new ClientQueryRequest
+            {
+                Query =
+                    """
+                    query a { hero(episode: NEW_HOPE) { name } }
+                    query b { hero(episode: EMPIRE) { name } }
+                    """
+            },
+            "a,b");
+
+        // assert
+        results.MatchSnapshot();
+    }
+
+    [Fact]
     public async Task OperationBatch_Should_ReportGenericError_When_OperationNamesAreInvalid()
     {
         // arrange

--- a/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.OperationBatch_Should_ExecuteEachOperation_When_BatchingIsEnabled.snap
+++ b/src/HotChocolate/AspNetCore/test/AspNetCore.Tests/__snapshots__/HttpPostMiddlewareTests.OperationBatch_Should_ExecuteEachOperation_When_BatchingIsEnabled.snap
@@ -1,0 +1,24 @@
+[
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "hero": {
+        "name": "R2-D2"
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  },
+  {
+    "ContentType": "application/json; charset=utf-8",
+    "StatusCode": "OK",
+    "Data": {
+      "hero": {
+        "name": "Luke Skywalker"
+      }
+    },
+    "Errors": null,
+    "Extensions": null
+  }
+]


### PR DESCRIPTION
## Summary

- A request rejected because variable or request batching is disabled now raises `IServerDiagnosticEvents.HttpRequestError` with an error that names the disabled mode and points at `GraphQLServerOptions.Batching`. The client response is unchanged and still says `Invalid GraphQL Request.` with code `HC0009`.
- The variable batch paths in `ExecutorSession.ExecuteSingleAsync` previously returned without raising any diagnostic event, both for disabled batching and for an exceeded `MaxBatchSize`. Both now raise `HttpRequestError`, so listeners such as the OpenTelemetry instrumentation record the reason on the request span.
- The operation batch branch in `HttpPostMiddlewareBase` checks the batching flag before the `batchOperations` value, so the reported reason is the check that rejected the request. A missing or unparseable `batchOperations` value keeps reporting the generic error.

## Test plan

- New tests in `HttpPostMiddlewareTests` use a recording `ServerDiagnosticEventListener` to assert the reported message and the unchanged response body for a variable batch, a request batch, and an operation batch with batching disabled, a variable batch over `MaxBatchSize`, and an operation batch with an invalid `batchOperations` value.
- `HttpPostMiddlewareTests` and `GraphQLOverHttpSpecTests` pass.
