### PR TITLE
Resolve MCP handler services from the schema in stateless mode

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/ServiceCollectionExtensions.cs
@@ -115,9 +115,19 @@ internal static class ServiceCollectionExtensions
 
         var schemaServices = new McpSchemaServiceProvider();
 
+        // The factory of a singleton is always invoked with the root service provider.
+        services.AddSingleton(
+            sp =>
+            {
+                schemaServices.Bind(sp);
+
+                return schemaServices;
+            });
+
         services
             .AddOptions<McpServerOptions>()
-            .Configure<IServiceProvider>((_, provider) => schemaServices.Bind(provider));
+            .Configure<IServiceProvider>(
+                (_, provider) => provider.GetRequiredService<McpSchemaServiceProvider>());
 
         var mcpServerBuilder =
             services

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/ServiceCollectionExtensions.cs
@@ -113,6 +113,12 @@ internal static class ServiceCollectionExtensions
         var mcpServers = new ConcurrentDictionary<string, McpServer>();
         services.AddSingleton(mcpServers);
 
+        var schemaServices = new McpSchemaServiceProvider();
+
+        services
+            .AddOptions<McpServerOptions>()
+            .Configure<IServiceProvider>((_, provider) => schemaServices.Bind(provider));
+
         var mcpServerBuilder =
             services
                 .AddMcpServer(options =>
@@ -151,14 +157,18 @@ internal static class ServiceCollectionExtensions
 #pragma warning restore MCPEXP002
                 })
                 .WithListPromptsHandler(
-                    (context, _) => ValueTask.FromResult(ListPromptsHandler.Handle(context)))
+                    (_, _) => ValueTask.FromResult(ListPromptsHandler.Handle(schemaServices)))
                 .WithGetPromptHandler(
-                    (context, _) => ValueTask.FromResult(GetPromptHandler.Handle(context)))
+                    (context, _) =>
+                        ValueTask.FromResult(GetPromptHandler.Handle(context, schemaServices)))
                 .WithReadResourceHandler(
-                    (context, _) => ValueTask.FromResult(ReadResourceHandler.Handle(context)))
+                    (context, _) =>
+                        ValueTask.FromResult(ReadResourceHandler.Handle(context, schemaServices)))
                 .WithListToolsHandler(
-                    (context, _) => ValueTask.FromResult(ListToolsHandler.Handle(context)))
-                .WithCallToolHandler(CallToolHandler.HandleAsync);
+                    (_, _) => ValueTask.FromResult(ListToolsHandler.Handle(schemaServices)))
+                .WithCallToolHandler(
+                    (context, cancellationToken) =>
+                        CallToolHandler.HandleAsync(context, schemaServices, cancellationToken));
 
         foreach (var modifier in setup.ServerModifiers)
         {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/CallToolHandler.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/CallToolHandler.cs
@@ -24,10 +24,10 @@ internal static class CallToolHandler
 #endif
     public static async ValueTask<CallToolResult> HandleAsync(
         RequestContext<CallToolRequestParams> context,
+        IServiceProvider schemaServices,
         CancellationToken cancellationToken)
     {
-        var services = context.Services!;
-        var registry = services.GetRequiredService<McpFeatureRegistry>();
+        var registry = schemaServices.GetRequiredService<McpFeatureRegistry>();
 
         if (!registry.TryGetTool(context.Params!.Name, out var tool))
         {
@@ -59,8 +59,9 @@ internal static class CallToolHandler
             };
         }
 
-        var requestExecutor = services.GetRequiredService<IRequestExecutor>();
-        var rootServiceProvider = services.GetRequiredService<IRootServiceProviderAccessor>().ServiceProvider;
+        var requestExecutor = schemaServices.GetRequiredService<IRequestExecutor>();
+        var rootServiceProvider =
+            schemaServices.GetRequiredService<IRootServiceProviderAccessor>().ServiceProvider;
         var httpContext = rootServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext!;
         var diagnosticEvents = requestExecutor.Schema.Services.GetRequiredService<IServerDiagnosticEvents>();
         var requestBuilder = CreateRequestBuilder(httpContext);

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/GetPromptHandler.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/GetPromptHandler.cs
@@ -11,9 +11,11 @@ namespace HotChocolate.Adapters.Mcp.Handlers;
 
 internal static partial class GetPromptHandler
 {
-    public static GetPromptResult Handle(RequestContext<GetPromptRequestParams> context)
+    public static GetPromptResult Handle(
+        RequestContext<GetPromptRequestParams> context,
+        IServiceProvider schemaServices)
     {
-        var registry = context.Services!.GetRequiredService<McpFeatureRegistry>();
+        var registry = schemaServices.GetRequiredService<McpFeatureRegistry>();
 
         if (!registry.TryGetPrompt(context.Params!.Name, out var prompt))
         {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ListPromptsHandler.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ListPromptsHandler.cs
@@ -1,14 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
 
 namespace HotChocolate.Adapters.Mcp.Handlers;
 
 internal static class ListPromptsHandler
 {
-    public static ListPromptsResult Handle(RequestContext<ListPromptsRequestParams> context)
+    public static ListPromptsResult Handle(IServiceProvider schemaServices)
     {
-        var registry = context.Services!.GetRequiredService<McpFeatureRegistry>();
+        var registry = schemaServices.GetRequiredService<McpFeatureRegistry>();
 
         return new ListPromptsResult
         {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ListToolsHandler.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ListToolsHandler.cs
@@ -1,14 +1,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
 
 namespace HotChocolate.Adapters.Mcp.Handlers;
 
 internal static class ListToolsHandler
 {
-    public static ListToolsResult Handle(RequestContext<ListToolsRequestParams> context)
+    public static ListToolsResult Handle(IServiceProvider schemaServices)
     {
-        var registry = context.Services!.GetRequiredService<McpFeatureRegistry>();
+        var registry = schemaServices.GetRequiredService<McpFeatureRegistry>();
 
         return new ListToolsResult
         {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ReadResourceHandler.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Handlers/ReadResourceHandler.cs
@@ -8,9 +8,11 @@ namespace HotChocolate.Adapters.Mcp.Handlers;
 
 internal static class ReadResourceHandler
 {
-    public static ReadResourceResult Handle(RequestContext<ReadResourceRequestParams> context)
+    public static ReadResourceResult Handle(
+        RequestContext<ReadResourceRequestParams> context,
+        IServiceProvider schemaServices)
     {
-        var registry = context.Services!.GetRequiredService<McpFeatureRegistry>();
+        var registry = schemaServices.GetRequiredService<McpFeatureRegistry>();
 
         if (!registry.TryGetToolByViewResourceUri(context.Params!.Uri, out var tool))
         {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpSchemaServiceProvider.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpSchemaServiceProvider.cs
@@ -4,7 +4,7 @@ namespace HotChocolate.Adapters.Mcp;
 /// Provides the schema-scoped services that the MCP request handlers resolve from.
 /// </summary>
 /// <remarks>
-/// The provider is bound to the schema services when the MCP server options are built.
+/// The provider is bound to the schema services the first time it is resolved from them.
 /// </remarks>
 internal sealed class McpSchemaServiceProvider : IServiceProvider
 {
@@ -17,5 +17,13 @@ internal sealed class McpSchemaServiceProvider : IServiceProvider
         _schemaServices = schemaServices;
     }
 
-    public object? GetService(Type serviceType) => _schemaServices?.GetService(serviceType);
+    public object? GetService(Type serviceType)
+    {
+        if (_schemaServices is null)
+        {
+            throw new InvalidOperationException("The MCP schema services have not been bound.");
+        }
+
+        return _schemaServices.GetService(serviceType);
+    }
 }

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpSchemaServiceProvider.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/McpSchemaServiceProvider.cs
@@ -1,0 +1,21 @@
+namespace HotChocolate.Adapters.Mcp;
+
+/// <summary>
+/// Provides the schema-scoped services that the MCP request handlers resolve from.
+/// </summary>
+/// <remarks>
+/// The provider is bound to the schema services when the MCP server options are built.
+/// </remarks>
+internal sealed class McpSchemaServiceProvider : IServiceProvider
+{
+    private IServiceProvider? _schemaServices;
+
+    public void Bind(IServiceProvider schemaServices)
+    {
+        ArgumentNullException.ThrowIfNull(schemaServices);
+
+        _schemaServices = schemaServices;
+    }
+
+    public object? GetService(Type serviceType) => _schemaServices?.GetService(serviceType);
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/Handlers/CallToolHandlerTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/Handlers/CallToolHandlerTests.cs
@@ -14,10 +14,13 @@ public sealed class CallToolHandlerTests
     public async Task HandleAsync_MissingTool_ReturnsCallToolResultWithError()
     {
         // arrange
-        var context = await CreateRequestContextAsync("unknown");
+        var (context, schemaServices) = await CreateRequestContextAsync("unknown");
 
         // act
-        var result = await CallToolHandler.HandleAsync(context, CancellationToken.None);
+        var result = await CallToolHandler.HandleAsync(
+            context,
+            schemaServices,
+            CancellationToken.None);
 
         // assert
         Assert.True(result.IsError);
@@ -25,8 +28,8 @@ public sealed class CallToolHandlerTests
         Assert.Equal("The tool 'unknown' was not found.", textContentBlock.Text);
     }
 
-    private static async Task<RequestContext<CallToolRequestParams>> CreateRequestContextAsync(
-        string toolName)
+    private static async Task<(RequestContext<CallToolRequestParams>, IServiceProvider)>
+        CreateRequestContextAsync(string toolName)
     {
         var storage = new TestMcpStorage();
         await storage.AddOrUpdateToolAsync(
@@ -49,15 +52,16 @@ public sealed class CallToolHandlerTests
         var executorProvider = serviceProvider.GetRequiredService<IRequestExecutorProvider>();
         var executor = await executorProvider.GetExecutorAsync();
         Mock<McpServer> mockServer = new();
-        mockServer.SetupGet(s => s.Services).Returns(executor.Schema.Services);
         var request = new JsonRpcRequest { Method = RequestMethods.ToolsCall };
 
-        return new RequestContext<CallToolRequestParams>(
-            mockServer.Object,
-            request,
-            new CallToolRequestParams
-            {
-                Name = toolName
-            });
+        return (
+            new RequestContext<CallToolRequestParams>(
+                mockServer.Object,
+                request,
+                new CallToolRequestParams
+                {
+                    Name = toolName
+                }),
+            executor.Schema.Services);
     }
 }

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -10,6 +10,7 @@ using HotChocolate.Language;
 using HotChocolate.Types;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using ModelContextProtocol;
 using ModelContextProtocol.Client;
@@ -1488,6 +1489,38 @@ public abstract class IntegrationTestBase
         Assert.EndsWith("Resource not found.", exception.Message);
         Assert.Equal(-32002, (int)exception.ErrorCode);
         Assert.Equal("ui://views/missing.html", exception.Data["uri"]);
+    }
+
+    [Fact]
+    public async Task ListTools_ServerOptionsMaterializedInScope_ReturnsTools()
+    {
+        // arrange
+        var storage = new TestMcpStorage();
+        await storage.AddOrUpdateToolAsync(
+            new OperationToolDefinition(
+                Utf8GraphQLParser.Parse(
+                    await File.ReadAllTextAsync(
+                        "__resources__/GetBooksWithTitle1.graphql",
+                        TestContext.Current.CancellationToken))),
+            TestContext.Current.CancellationToken);
+        var server = await CreateTestServerAsync(storage);
+        var mcpClient = await CreateMcpClientAsync(server.CreateClient());
+        await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var executor = await server.Services.GetRequiredService<IRequestExecutorProvider>().GetExecutorAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // arrange: materialize the server options in a scope that is disposed again
+        using (var scope = executor.Schema.Services.CreateScope())
+        {
+            _ = scope.ServiceProvider
+                .GetRequiredService<IOptionsSnapshot<McpServerOptions>>().Value;
+        }
+
+        // act
+        var tools = await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal("get_books_with_title1", Assert.Single(tools).Name);
     }
 
     [Fact]

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -661,6 +661,31 @@ public abstract class IntegrationTestBase
     }
 
     [Fact]
+    public async Task ListTools_StatelessTransport_ReturnsTools()
+    {
+        // arrange
+        var storage = new TestMcpStorage();
+        await storage.AddOrUpdateToolAsync(
+            new OperationToolDefinition(
+                Utf8GraphQLParser.Parse(
+                    await File.ReadAllTextAsync(
+                        "__resources__/GetBooksWithTitle1.graphql",
+                        TestContext.Current.CancellationToken))),
+            TestContext.Current.CancellationToken);
+        var server =
+            await CreateTestServerAsync(
+                storage,
+                configureMcpServer: b => b.WithHttpTransport(o => o.Stateless = true));
+        var mcpClient = await CreateMcpClientAsync(server.CreateClient());
+
+        // act
+        var tools = await mcpClient.ListToolsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal("get_books_with_title1", Assert.Single(tools).Name);
+    }
+
+    [Fact]
     public async Task ListTools_AfterToolsUpdate_ReturnsUpdatedTools()
     {
         // arrange
@@ -1365,6 +1390,33 @@ public abstract class IntegrationTestBase
 
         // assert
         Assert.Equal("Hello, World!", ((TextContentBlock)result.Content[0]).Text);
+    }
+
+    [Fact]
+    public async Task CallTool_StatelessTransport_ReturnsExpectedResult()
+    {
+        // arrange
+        var storage = new TestMcpStorage();
+        await storage.AddOrUpdateToolAsync(
+            new OperationToolDefinition(
+                Utf8GraphQLParser.Parse(
+                    await File.ReadAllTextAsync(
+                        "__resources__/GetBooksWithTitle1.graphql",
+                        TestContext.Current.CancellationToken))),
+            TestContext.Current.CancellationToken);
+        var server =
+            await CreateTestServerAsync(
+                storage,
+                configureMcpServer: b => b.WithHttpTransport(o => o.Stateless = true));
+        var mcpClient = await CreateMcpClientAsync(server.CreateClient());
+
+        // act
+        var result = await mcpClient.CallToolAsync(
+            "get_books_with_title1",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // assert
+        result.StructuredContent.MatchSnapshot(extension: ".json");
     }
 
     [Fact]

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/McpSchemaServiceProviderTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/McpSchemaServiceProviderTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotChocolate.Adapters.Mcp;
+
+public sealed class McpSchemaServiceProviderTests
+{
+    [Fact]
+    public void GetService_NotBound_ThrowsInvalidOperationException()
+    {
+        // arrange
+        var schemaServices = new McpSchemaServiceProvider();
+
+        // act
+        void Act() => schemaServices.GetService(typeof(TestService));
+
+        // assert
+        var exception = Assert.Throws<InvalidOperationException>(Act);
+        Assert.Equal("The MCP schema services have not been bound.", exception.Message);
+    }
+
+    [Fact]
+    public void GetService_Bound_ReturnsServiceFromBoundProvider()
+    {
+        // arrange
+        var expectedService = new TestService();
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(expectedService)
+            .BuildServiceProvider();
+        var schemaServices = new McpSchemaServiceProvider();
+        schemaServices.Bind(serviceProvider);
+
+        // act
+        var service = schemaServices.GetService(typeof(TestService));
+
+        // assert
+        Assert.Same(expectedService, service);
+    }
+
+    private sealed class TestService;
+}

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/IntegrationTestBase.CallTool_StatelessTransport_ReturnsExpectedResult.json
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/__snapshots__/IntegrationTestBase.CallTool_StatelessTransport_ReturnsExpectedResult.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "books": [
+      {
+        "title": "Title"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- The MCP request handlers resolved `McpFeatureRegistry`, `IRequestExecutor`, and `IRootServiceProviderAccessor` from `RequestContext.Services`. With `HttpServerTransportOptions.Stateless = true` the SDK builds the per-request server from the ASP.NET Core request scope, which does not contain those schema-scoped singletons, so every `tools/list` and `tools/call` failed against a stateless server.
- The handlers now take the schema services as a parameter. `McpSchemaServiceProvider` is bound to the schema services when the MCP server options are built, which holds in both stateful and stateless mode, and one instance is created per schema-services build so it follows schema swaps.
- Stateful behavior is unchanged. All three services are schema-services singletons, so resolving them from the schema provider rather than from a per-request child scope returns the same instances.

Stateless mode is opted into with `AddMcp(configureServer: b => b.WithHttpTransport(o => o.Stateless = true))`. A first-class HotChocolate option for it, which would also let `MapGraphQLMcp` decide the GET and DELETE endpoint mapping without building the schema, is a separate change.

Reported in #10376, which also asks for the move to v2 of the MCP C# SDK; that update is not part of this change.

## Test plan

- Added `ListTools_StatelessTransport_ReturnsTools` and `CallTool_StatelessTransport_ReturnsExpectedResult` to `IntegrationTestBase`, so `CoreIntegrationTests` and `FusionIntegrationTests` both run them. Without the fix, `tools/list` fails with a remote handler error and `tools/call` returns an error result.
- `HotChocolate.Adapters.Mcp.Tests` passes on net8.0, net9.0, net10.0, and net11.0, 258 tests each.
