### PR TITLE
Return 405 for MCP GET and DELETE in stateless mode

### DIFF
--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/McpEndpointRouteBuilderExtensions.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Extensions/McpEndpointRouteBuilderExtensions.cs
@@ -45,22 +45,17 @@ public static class McpEndpointRouteBuilderExtensions
                     contentTypes: ["text/event-stream"]))
             .WithMetadata(new ProducesResponseTypeMetadata(StatusCodes.Status202Accepted));
 
-        if (!streamableHttpHandler.HttpServerTransportOptions.Stateless)
-        {
-            // The GET endpoint is not mapped in Stateless mode since there's no way to send
-            // unsolicited messages. Resuming streams via GET is currently not supported in
-            // Stateless mode.
-            streamableHttpGroup
-                .MapGet("", streamableHttpHandler.HandleGetRequestAsync)
-                .WithMetadata(
-                    new ProducesResponseTypeMetadata(
-                        StatusCodes.Status200OK,
-                        contentTypes: ["text/event-stream"]));
+        streamableHttpGroup
+            .MapGet("", streamableHttpHandler.HandleGetRequestAsync)
+            .WithMetadata(
+                new ProducesResponseTypeMetadata(
+                    StatusCodes.Status200OK,
+                    contentTypes: ["text/event-stream"]))
+            .WithMetadata(new ProducesResponseTypeMetadata(StatusCodes.Status405MethodNotAllowed));
 
-            // The DELETE endpoint is not mapped in Stateless mode since there is no server-side
-            // state for the DELETE to clean up.
-            streamableHttpGroup.MapDelete("", streamableHttpHandler.HandleDeleteRequestAsync);
-        }
+        streamableHttpGroup
+            .MapDelete("", streamableHttpHandler.HandleDeleteRequestAsync)
+            .WithMetadata(new ProducesResponseTypeMetadata(StatusCodes.Status405MethodNotAllowed));
 
         return mcpGroup;
     }

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/McpRequestExecutorProxy.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/McpRequestExecutorProxy.cs
@@ -17,16 +17,6 @@ internal sealed class McpRequestExecutorProxy(
 {
     private McpExecutorSession? _session;
 
-    public McpExecutorSession GetOrCreateSession()
-    {
-        return _session
-            ?? Task.Factory
-                .StartNew(async () => await GetOrCreateSessionAsync(CancellationToken.None))
-                .Unwrap()
-                .GetAwaiter()
-                .GetResult();
-    }
-
     public async ValueTask<McpExecutorSession> GetOrCreateSessionAsync(
         CancellationToken cancellationToken)
     {

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/StreamableHttpHandlerProxy.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/StreamableHttpHandlerProxy.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using ModelContextProtocol.AspNetCore;
 
 namespace HotChocolate.Adapters.Mcp.Proxies;
 
@@ -13,9 +12,6 @@ internal sealed class StreamableHttpHandlerProxy
         _mcpRequestExecutor = mcpRequestExecutor;
     }
 
-    public HttpServerTransportOptions HttpServerTransportOptions
-        => _mcpRequestExecutor.GetOrCreateSession().StreamableHttpHandler.HttpServerTransportOptions;
-
     public async Task HandlePostRequestAsync(HttpContext context)
     {
         var session = await _mcpRequestExecutor.GetOrCreateSessionAsync(context.RequestAborted);
@@ -25,12 +21,31 @@ internal sealed class StreamableHttpHandlerProxy
     public async Task HandleGetRequestAsync(HttpContext context)
     {
         var session = await _mcpRequestExecutor.GetOrCreateSessionAsync(context.RequestAborted);
+
+        if (IsStateless(session))
+        {
+            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+
+            return;
+        }
+
         await session.StreamableHttpHandler.HandleGetRequestAsync(context);
     }
 
     public async Task HandleDeleteRequestAsync(HttpContext context)
     {
         var session = await _mcpRequestExecutor.GetOrCreateSessionAsync(context.RequestAborted);
+
+        if (IsStateless(session))
+        {
+            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+
+            return;
+        }
+
         await session.StreamableHttpHandler.HandleDeleteRequestAsync(context);
     }
+
+    private static bool IsStateless(McpExecutorSession session)
+        => session.StreamableHttpHandler.HttpServerTransportOptions.Stateless;
 }

--- a/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/StreamableHttpHandlerProxy.cs
+++ b/src/HotChocolate/Adapters/src/Adapters.Mcp.Core/Proxies/StreamableHttpHandlerProxy.cs
@@ -24,7 +24,7 @@ internal sealed class StreamableHttpHandlerProxy
 
         if (IsStateless(session))
         {
-            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            WriteMethodNotAllowed(context);
 
             return;
         }
@@ -38,7 +38,7 @@ internal sealed class StreamableHttpHandlerProxy
 
         if (IsStateless(session))
         {
-            context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+            WriteMethodNotAllowed(context);
 
             return;
         }
@@ -48,4 +48,10 @@ internal sealed class StreamableHttpHandlerProxy
 
     private static bool IsStateless(McpExecutorSession session)
         => session.StreamableHttpHandler.HttpServerTransportOptions.Stateless;
+
+    private static void WriteMethodNotAllowed(HttpContext context)
+    {
+        context.Response.Headers.Allow = "POST";
+        context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+    }
 }

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/CoreIntegrationTests.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/CoreIntegrationTests.cs
@@ -81,6 +81,44 @@ public sealed class CoreIntegrationTests : IntegrationTestBase
     }
 
     [Fact]
+    public void MapGraphQLMcp_Should_NotBuildSchema_When_Mapping()
+    {
+        // arrange
+        var schemaBuilt = false;
+        var schemaBuiltWhileMapping = false;
+        var builder = new WebHostBuilder()
+            .ConfigureServices(
+                services => services
+                    .AddRouting()
+                    .AddGraphQLServer()
+                    .ConfigureSchemaServices(_ => schemaBuilt = true)
+                    .AddAuthorization()
+                    .AddQueryType<TestSchema.Query>()
+                    .AddMutationType<TestSchema.Mutation>()
+                    .AddInterfaceType<TestSchema.IPet>()
+                    .AddUnionType<TestSchema.IPet>()
+                    .AddObjectType<TestSchema.Cat>()
+                    .AddObjectType<TestSchema.Dog>()
+                    .AddMcp()
+                    .AddMcpStorage(new TestMcpStorage()))
+            .Configure(
+                app => app
+                    .UseRouting()
+                    .UseEndpoints(
+                        endpoints =>
+                        {
+                            endpoints.MapGraphQLMcp();
+                            schemaBuiltWhileMapping = schemaBuilt;
+                        }));
+
+        // act
+        _ = new TestServer(builder);
+
+        // assert
+        Assert.False(schemaBuiltWhileMapping);
+    }
+
+    [Fact]
     public async Task ListTools_AfterSchemaUpdate_ReturnsUpdatedTools()
     {
         // arrange

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -705,6 +705,7 @@ public abstract class IntegrationTestBase
 
         // assert
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("POST", Assert.Single(response.Content.Headers.Allow));
     }
 
     [Fact]
@@ -724,6 +725,7 @@ public abstract class IntegrationTestBase
 
         // assert
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("POST", Assert.Single(response.Content.Headers.Allow));
     }
 
     [Fact]

--- a/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
+++ b/src/HotChocolate/Adapters/test/Adapters.Mcp.Tests/IntegrationTestBase.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -684,6 +686,62 @@ public abstract class IntegrationTestBase
 
         // assert
         Assert.Equal("get_books_with_title1", Assert.Single(tools).Name);
+    }
+
+    [Fact]
+    public async Task GetRequest_StatelessTransport_ReturnsMethodNotAllowed()
+    {
+        // arrange
+        var server =
+            await CreateTestServerAsync(
+                new TestMcpStorage(),
+                configureMcpServer: b => b.WithHttpTransport(o => o.Stateless = true));
+        var client = server.CreateClient();
+
+        // act
+        using var response = await client.GetAsync(
+            "/graphql/mcp",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteRequest_StatelessTransport_ReturnsMethodNotAllowed()
+    {
+        // arrange
+        var server =
+            await CreateTestServerAsync(
+                new TestMcpStorage(),
+                configureMcpServer: b => b.WithHttpTransport(o => o.Stateless = true));
+        var client = server.CreateClient();
+
+        // act
+        using var response = await client.DeleteAsync(
+            "/graphql/mcp",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetRequest_StatefulTransportWithoutSessionId_ReturnsBadRequest()
+    {
+        // arrange
+        var server = await CreateTestServerAsync(new TestMcpStorage());
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        // act
+        using var response = await client.GetAsync(
+            "/graphql/mcp",
+            TestContext.Current.CancellationToken);
+
+        // assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `MapGraphQLMcp` now maps the Streamable HTTP GET and DELETE endpoints unconditionally. When the transport is configured for stateless mode, both answer `405 Method Not Allowed` — the same status ASP.NET Core routing already produced for the unmapped methods, and the status the [2026-07-28 MCP revision](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http#earlier-streamable-http-revisions) prescribes for servers that no longer carry protocol-level sessions.
- Endpoint mapping no longer reads anything out of the schema services, so `MapGraphQLMcp` no longer forces a blocking schema build while the application is still wiring up its endpoints. Users who opt out of warm-up with `LazyInitialization` get the lazy behavior they asked for. The synchronous session accessor that existed only to serve that read is removed.

## Test plan

- New integration tests, run for both the Core and Fusion adapters: a stateless GET and DELETE return 405, and a stateful GET without a session ID still reaches the transport handler.
- A new test asserts that no schema services are configured while `MapGraphQLMcp` runs. It fails against the previous mapping code.
- MCP adapter suite: 1076 tests green across net8.0, net9.0, net10.0, and net11.0, plus the Core and Fusion MCP diagnostics activity suites on net10.0.
