### PR TITLE
Declare Mocha's temporary RabbitMQ queues durable with auto-delete and expiry

### DIFF
--- a/src/CookieCrumble/src/CookieCrumble.Resources.RabbitMQ/RabbitMQResource.cs
+++ b/src/CookieCrumble/src/CookieCrumble.Resources.RabbitMQ/RabbitMQResource.cs
@@ -27,7 +27,7 @@ public class RabbitMQResource : ContainerResource<RabbitMqContainer>
 
     protected override RabbitMqContainer Build()
         => Configure(
-            new RabbitMqBuilder("rabbitmq:3.11")
+            new RabbitMqBuilder("rabbitmq:4.3")
                 .WithUsername("guest")
                 .WithPassword("guest"))
             .Build();

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Configurations/RabbitMQQueueDescriptorConfiguration.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Configurations/RabbitMQQueueDescriptorConfiguration.cs
@@ -62,6 +62,12 @@ public sealed class RabbitMQQueueDescriptorConfiguration : MessagingConfiguratio
     public bool IsTemporary { get; set; }
 
     /// <summary>
+    /// Gets or sets the queue expiry applied when this queue's receive endpoint is temporary. When
+    /// <see langword="null"/>, <see cref="RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.Expiry"/> applies.
+    /// </summary>
+    public TimeSpan? TemporaryExpiry { get; set; }
+
+    /// <summary>
     /// Gets the receive middleware configurations applied when this queue materializes an endpoint.
     /// </summary>
     public List<ReceiveMiddlewareConfiguration> ReceiveMiddlewares { get; } = [];

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Configurations/RabbitMQReceiveEndpointConfiguration.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Configurations/RabbitMQReceiveEndpointConfiguration.cs
@@ -15,4 +15,24 @@ public sealed class RabbitMQReceiveEndpointConfiguration : ReceiveEndpointConfig
     /// Defaults to 100.
     /// </summary>
     public ushort MaxPrefetch { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the queue expiry applied to a temporary endpoint's queue. When <see langword="null"/>
+    /// and <see cref="ReceiveEndpointConfiguration.IsTemporary"/> is set, <see cref="TemporaryDefaults.Expiry"/> applies.
+    /// </summary>
+    public TimeSpan? TemporaryExpiry { get; set; }
+
+    public static class TemporaryDefaults
+    {
+        /// <summary>
+        /// The queue expiry applied to a temporary endpoint marked via the parameterless
+        /// <c>Temporary()</c> overload.
+        /// </summary>
+        public static readonly TimeSpan Expiry = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// The longest queue expiry the transport can declare through <c>x-expires</c>.
+        /// </summary>
+        public static readonly TimeSpan MaximumExpiry = TimeSpan.FromMilliseconds(int.MaxValue);
+    }
 }

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQQueueDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQQueueDescriptor.cs
@@ -112,11 +112,22 @@ public interface IRabbitMQQueueDescriptor : IMessagingDescriptor<RabbitMQQueueDe
     IRabbitMQQueueDescriptor MaxConcurrency(int maxConcurrency);
 
     /// <summary>
-    /// Marks this queue's receive endpoint as temporary, provisioning a non-durable, auto-delete
-    /// queue whose lifecycle is scoped to the lifetime of the consuming process.
+    /// Marks this queue's receive endpoint as temporary, provisioning a durable, auto-delete queue
+    /// with the default queue expiry.
     /// </summary>
     /// <returns>The descriptor for method chaining.</returns>
     IRabbitMQQueueDescriptor Temporary();
+
+    /// <summary>
+    /// Marks this queue's receive endpoint as temporary with an explicit queue expiry, after which
+    /// the broker removes the queue once it has no consumers.
+    /// </summary>
+    /// <param name="expiry">
+    /// The queue expiry. Must be positive and at most
+    /// <see cref="RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.MaximumExpiry"/>.
+    /// </param>
+    /// <returns>The descriptor for method chaining.</returns>
+    IRabbitMQQueueDescriptor Temporary(TimeSpan expiry);
 
     /// <summary>
     /// Adds receive middleware to this queue's endpoint pipeline.

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/IRabbitMQReceiveEndpointDescriptor.cs
@@ -40,6 +40,17 @@ public interface IRabbitMQReceiveEndpointDescriptor : IReceiveEndpointDescriptor
     new IRabbitMQReceiveEndpointDescriptor Temporary();
 
     /// <summary>
+    /// Marks this receive endpoint as temporary with an explicit queue expiry, after which the
+    /// broker removes the queue once it has no consumers.
+    /// </summary>
+    /// <param name="expiry">
+    /// The queue expiry. Must be positive and at most
+    /// <see cref="RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.MaximumExpiry"/>.
+    /// </param>
+    /// <returns>The descriptor for method chaining.</returns>
+    IRabbitMQReceiveEndpointDescriptor Temporary(TimeSpan expiry);
+
+    /// <summary>
     /// Sets the address of the fault endpoint where failed messages are forwarded.
     /// </summary>
     /// <param name="address">The fault endpoint address.</param>

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQMessagingTransportDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQMessagingTransportDescriptor.cs
@@ -268,6 +268,13 @@ public sealed class RabbitMQMessagingTransportDescriptor
         var queue = DeclareQueue(configuration.Name!);
         ApplyQueueConfiguration(configuration.Queue, queue);
 
+        if (configuration.IsTemporary && configuration.Queue.Arguments?.ContainsKey("x-expires") is not true)
+        {
+            queue.Expires(
+                configuration.TemporaryExpiry
+                ?? RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.Expiry);
+        }
+
         var schema = Configuration.Schema ?? RabbitMQTransportConfiguration.DefaultSchema;
         foreach (var binding in configuration.SourceBindings)
         {
@@ -318,6 +325,7 @@ public sealed class RabbitMQMessagingTransportDescriptor
         if (configuration.IsTemporary)
         {
             target.IsTemporary = true;
+            target.TemporaryExpiry ??= configuration.TemporaryExpiry;
         }
 
         target.ReceiveMiddlewares.AddRange(configuration.ReceiveMiddlewares);

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQQueueDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQQueueDescriptor.cs
@@ -130,7 +130,20 @@ internal sealed class RabbitMQQueueDescriptor
     public IRabbitMQQueueDescriptor Temporary()
     {
         Configuration.IsTemporary = true;
-        Configuration.Queue.Durable = false;
+        Configuration.Queue.AutoDelete = true;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IRabbitMQQueueDescriptor Temporary(TimeSpan expiry)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(expiry, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            expiry,
+            RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.MaximumExpiry);
+
+        Configuration.IsTemporary = true;
+        Configuration.TemporaryExpiry = expiry;
         Configuration.Queue.AutoDelete = true;
         return this;
     }

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQReceiveEndpointDescriptor.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Descriptors/RabbitMQReceiveEndpointDescriptor.cs
@@ -105,6 +105,20 @@ internal sealed class RabbitMQReceiveEndpointDescriptor
     }
 
     /// <inheritdoc />
+    public IRabbitMQReceiveEndpointDescriptor Temporary(TimeSpan expiry)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(expiry, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            expiry,
+            RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.MaximumExpiry);
+
+        base.Temporary();
+        Configuration.TemporaryExpiry = expiry;
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public IRabbitMQReceiveEndpointDescriptor FaultEndpoint(Uri address)
     {
         ArgumentNullException.ThrowIfNull(address);

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/ThrowHelper.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/ThrowHelper.cs
@@ -1,0 +1,13 @@
+namespace Mocha.Transport.RabbitMQ;
+
+internal static class ThrowHelper
+{
+    public static Exception BeforeAndAfterConflict()
+        => Mocha.ThrowHelper.BeforeAndAfterConflict();
+
+    public static Exception TemporaryEndpointQueueConflict(string queueName, string? endpointName)
+        => new InvalidOperationException(
+            $"Queue '{queueName}' is explicitly declared without auto-delete, which conflicts with "
+            + $"receive endpoint '{endpointName}' being marked Temporary(). Declare the queue with "
+            + "AutoDelete(), or remove Temporary() from the endpoint.");
+}

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Topology/RabbitMQQueue.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Topology/RabbitMQQueue.cs
@@ -75,12 +75,13 @@ public sealed class RabbitMQQueue : TopologyResource<RabbitMQQueueConfiguration>
     }
 
     /// <summary>
-    /// Marks this queue as non-durable and auto-delete.
+    /// Marks this queue as auto-delete and sets the queue expiry after which the broker removes it
+    /// when it has no consumers.
     /// </summary>
-    internal void MarkTemporary()
+    internal void MarkTemporary(TimeSpan expiry)
     {
-        Durable = false;
         AutoDelete = true;
+        Arguments = Arguments.SetItem("x-expires", (int)expiry.TotalMilliseconds);
     }
 
     /// <summary>

--- a/src/Mocha/src/Mocha.Transport.RabbitMQ/Topology/RabbitMQRoutingStrategy.cs
+++ b/src/Mocha/src/Mocha.Transport.RabbitMQ/Topology/RabbitMQRoutingStrategy.cs
@@ -210,14 +210,13 @@ public sealed class RabbitMQRoutingStrategy : RoutingStrategy<RabbitMQMessagingT
 
         if (rabbitConfiguration.IsTemporary)
         {
-            EnsureNoDurableQueueConflict(rabbitConfiguration);
+            EnsureNoTemporaryQueueConflict(rabbitConfiguration);
         }
 
         var queue = _topology.GetOrAddQueue(
             rabbitConfiguration.QueueName,
             _ => new RabbitMQQueueConfiguration
             {
-                Durable = rabbitConfiguration.IsTemporary ? false : null,
                 AutoDelete = rabbitConfiguration.IsTemporary,
                 AutoProvision = rabbitConfiguration.AutoProvision,
                 Origin = TopologyOrigin.Endpoint
@@ -225,7 +224,8 @@ public sealed class RabbitMQRoutingStrategy : RoutingStrategy<RabbitMQMessagingT
 
         if (rabbitConfiguration.IsTemporary && queue.Origin is not TopologyOrigin.Declared)
         {
-            queue.MarkTemporary();
+            queue.MarkTemporary(rabbitConfiguration.TemporaryExpiry ??
+                RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.Expiry);
         }
 
         if (rabbitEndpoint.Kind == ReceiveEndpointKind.Default)
@@ -465,7 +465,7 @@ public sealed class RabbitMQRoutingStrategy : RoutingStrategy<RabbitMQMessagingT
         }
     }
 
-    private void EnsureNoDurableQueueConflict(RabbitMQReceiveEndpointConfiguration rabbitConfiguration)
+    private void EnsureNoTemporaryQueueConflict(RabbitMQReceiveEndpointConfiguration rabbitConfiguration)
     {
         var existingQueue = _topology.Queues.FirstOrDefault(q => q.Name == rabbitConfiguration.QueueName);
         if (existingQueue is not { Origin: TopologyOrigin.Declared })
@@ -473,13 +473,9 @@ public sealed class RabbitMQRoutingStrategy : RoutingStrategy<RabbitMQMessagingT
             return;
         }
 
-        if (existingQueue.Durable || !existingQueue.AutoDelete)
+        if (!existingQueue.AutoDelete)
         {
-            throw new InvalidOperationException(
-                $"Queue '{rabbitConfiguration.QueueName}' is explicitly declared as durable or "
-                + "non-auto-delete, which conflicts with receive endpoint "
-                + $"'{rabbitConfiguration.Name}' being marked Temporary(). Declare the queue as "
-                + "non-durable and auto-delete, or remove Temporary() from the endpoint.");
+            throw ThrowHelper.TemporaryEndpointQueueConflict(existingQueue.Name, rabbitConfiguration.Name);
         }
     }
 

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Behaviors/RequestReplyTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Behaviors/RequestReplyTests.cs
@@ -1,3 +1,4 @@
+using CookieCrumble;
 using Microsoft.Extensions.DependencyInjection;
 using Mocha.Transport.RabbitMQ.Tests.Helpers;
 
@@ -127,6 +128,57 @@ public class RequestReplyTests
         Assert.Equal("Shipped", orderResponse.Status);
         Assert.Equal("TRK-1", shipmentResponse.TrackingNumber);
         Assert.Equal("InTransit", shipmentResponse.Status);
+    }
+
+    [Fact]
+    public async Task Transport_Should_DeclareDurableAutoDeleteReplyQueue_When_Started()
+    {
+        // arrange
+        // The broker denies non-durable, non-exclusive queues by default since RabbitMQ 4.3, so a
+        // host that starts at all proves the reply queue shape is accepted. The listing pins it.
+        await using var vhost = await _fixture.CreateVhostAsync();
+        await using var bus = await new ServiceCollection()
+            .AddSingleton(vhost.ConnectionFactory)
+            .AddMessageBus()
+            .AddRequestHandler<GetOrderStatusHandler>()
+            .AddRabbitMQ()
+            .BuildTestBusAsync();
+
+        // act
+        var output = await _fixture.InvokeCommandAsync(
+            [
+                "rabbitmqctl",
+                "list_queues",
+                "name",
+                "durable",
+                "auto_delete",
+                "exclusive",
+                "arguments",
+                "-p",
+                vhost.VhostName,
+                "--no-table-headers"
+            ]);
+        var replyQueue = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Single(line => line.StartsWith("response-", StringComparison.Ordinal))
+            .Split('\t');
+
+        // assert
+        new
+        {
+            Durable = replyQueue[1],
+            AutoDelete = replyQueue[2],
+            Exclusive = replyQueue[3],
+            Arguments = replyQueue[4]
+        }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": "true",
+              "AutoDelete": "true",
+              "Exclusive": "false",
+              "Arguments": "[{\"x-expires\",1800000},{\"x-queue-type\",\"classic\"}]"
+            }
+            """);
     }
 
     public sealed class ProcessPaymentHandler(MessageRecorder recorder) : IEventRequestHandler<ProcessPayment>

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Descriptors/RabbitMQUnifiedQueueTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Descriptors/RabbitMQUnifiedQueueTests.cs
@@ -297,11 +297,11 @@ public class RabbitMQUnifiedQueueTests
     }
 
     [Fact]
-    public void Queue_Should_MaterializeNonDurableAutoDeleteQueue_When_TemporaryCalled()
+    public void Queue_Should_MaterializeDurableAutoDeleteQueueWithExpiry_When_TemporaryCalled()
     {
         // arrange
-        // Temporary() on the Queue() descriptor must produce a non-durable, auto-delete queue,
-        // matching the lifecycle contract of a directly-declared temporary receive endpoint.
+        // Temporary() on the Queue() descriptor must produce the same durable, auto-delete queue
+        // with a queue expiry as a temporary receive endpoint.
         var runtime = CreateRuntime(
             b => { },
             t =>
@@ -313,12 +313,51 @@ public class RabbitMQUnifiedQueueTests
         var topology = (RabbitMQMessagingTopology)transport.Topology;
 
         // act
-        var queue = topology.Queues.SingleOrDefault(q => q.Name == "temp-audit");
+        var queue = topology.Queues.Single(q => q.Name == "temp-audit");
 
         // assert
-        Assert.NotNull(queue);
-        Assert.False(queue.Durable);
-        Assert.True(queue.AutoDelete);
+        new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void Queue_Should_UseConfiguredExpiry_When_TemporaryCalledWithExpiry()
+    {
+        // arrange
+        var runtime = CreateRuntime(
+            b => { },
+            t =>
+            {
+                t.BindExplicitly();
+                t.Queue("temp-audit").Temporary(TimeSpan.FromMinutes(5));
+            });
+        var transport = runtime.Transports.OfType<RabbitMQMessagingTransport>().Single();
+        var topology = (RabbitMQMessagingTopology)transport.Topology;
+
+        // act
+        var queue = topology.Queues.Single(q => q.Name == "temp-audit");
+
+        // assert
+        new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 300000
+              }
+            }
+            """);
     }
 
     private static MessagingRuntime CreateRuntime(

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQEndpointQueueOwnershipTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/RabbitMQEndpointQueueOwnershipTests.cs
@@ -120,10 +120,11 @@ public class RabbitMQEndpointQueueOwnershipTests
     }
 
     [Fact]
-    public void EndpointQueue_Should_MaterializeNonDurableAutoDeleteQueue_When_EndpointMarkedTemporary()
+    public void EndpointQueue_Should_MaterializeDurableAutoDeleteQueueWithExpiry_When_EndpointMarkedTemporary()
     {
         // arrange
-        // Temporary() on an explicit receive endpoint must map to a non-durable, auto-delete queue.
+        // RabbitMQ 4.3 denies non-durable, non-exclusive queues, so Temporary() keeps the queue
+        // durable and scopes its lifetime through auto-delete plus a queue expiry.
         var runtime = CreateRuntime(
             b => b.AddConsumer<OrderSpyConsumer>(),
             t =>
@@ -135,12 +136,68 @@ public class RabbitMQEndpointQueueOwnershipTests
         var topology = (RabbitMQMessagingTopology)transport.Topology;
 
         // act
-        var queue = topology.Queues.SingleOrDefault(q => q.Name == "temp-orders");
+        var queue = topology.Queues.Single(q => q.Name == "temp-orders");
 
         // assert
-        Assert.NotNull(queue);
-        Assert.False(queue.Durable);
-        Assert.True(queue.AutoDelete);
+        DescribeQueue(queue).MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void EndpointQueue_Should_UseConfiguredExpiry_When_TemporaryCalledWithExpiry()
+    {
+        // arrange
+        var runtime = CreateRuntime(
+            b => b.AddConsumer<OrderSpyConsumer>(),
+            t =>
+            {
+                t.BindExplicitly();
+                t.Endpoint("temp-orders").Temporary(TimeSpan.FromMinutes(5)).Consumer<OrderSpyConsumer>();
+            });
+        var transport = runtime.Transports.OfType<RabbitMQMessagingTransport>().Single();
+        var topology = (RabbitMQMessagingTopology)transport.Topology;
+
+        // act
+        var queue = topology.Queues.Single(q => q.Name == "temp-orders");
+
+        // assert
+        DescribeQueue(queue).MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 300000
+              }
+            }
+            """);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Endpoint_Should_Throw_When_TemporaryExpiryIsNotPositive(int seconds)
+    {
+        // arrange
+        var expiry = TimeSpan.FromSeconds(seconds);
+
+        // act
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => CreateRuntime(
+            b => b.AddConsumer<OrderSpyConsumer>(),
+            t => t.Endpoint("temp-orders").Temporary(expiry).Consumer<OrderSpyConsumer>()));
+
+        // assert
+        Assert.Equal("expiry", exception.ParamName);
     }
 
     [Theory]
@@ -178,17 +235,26 @@ public class RabbitMQEndpointQueueOwnershipTests
         var queue = topology.Queues.Single(q => q.Name == "shared");
 
         // assert
-        Assert.False(queue.Durable);
-        Assert.True(queue.AutoDelete);
+        DescribeQueue(queue).MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
     }
 
     [Fact]
-    public void EndpointQueue_Should_ThrowOnBuild_When_TemporaryEndpointConflictsWithDeclaredDurableQueue()
+    public void EndpointQueue_Should_ThrowOnBuild_When_TemporaryEndpointConflictsWithDeclaredNonAutoDeleteQueue()
     {
         // arrange
-        // A queue explicitly declared as durable (the default) conflicts with a receive endpoint
-        // for the same queue name marked Temporary(): the broker-native lifecycle it requests can
-        // never be honored.
+        // A queue explicitly declared without auto-delete (the default) conflicts with a receive
+        // endpoint for the same queue name marked Temporary(): the broker-native lifecycle it
+        // requests can never be honored.
         var exception = Assert.Throws<InvalidOperationException>(() => CreateRuntime(
             b => b.AddConsumer<OrderSpyConsumer>(),
             t =>
@@ -199,8 +265,43 @@ public class RabbitMQEndpointQueueOwnershipTests
             }));
 
         // assert
-        Assert.Contains("orders", exception.Message);
-        Assert.Contains("Temporary()", exception.Message);
+        Assert.Equal(
+            "Queue 'orders' is explicitly declared without auto-delete, which conflicts with receive "
+            + "endpoint 'orders' being marked Temporary(). Declare the queue with AutoDelete(), or "
+            + "remove Temporary() from the endpoint.",
+            exception.Message);
+    }
+
+    [Fact]
+    public void EndpointQueue_Should_ReuseDeclaredQueue_When_DeclaredAutoDeleteAndEndpointMarkedTemporary()
+    {
+        // arrange
+        // A durable queue declared with auto-delete satisfies Temporary(); the declared queue is
+        // kept as declared and no expiry is added on its behalf.
+        var runtime = CreateRuntime(
+            b => b.AddConsumer<OrderSpyConsumer>(),
+            t =>
+            {
+                t.BindExplicitly();
+                t.DeclareQueue("orders").AutoDelete();
+                t.Endpoint("orders").Temporary().Consumer<OrderSpyConsumer>();
+            });
+        var transport = runtime.Transports.OfType<RabbitMQMessagingTransport>().Single();
+        var topology = (RabbitMQMessagingTopology)transport.Topology;
+
+        // act
+        var queue = topology.Queues.Single(q => q.Name == "orders");
+
+        // assert
+        DescribeQueue(queue).MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {}
+            }
+            """);
     }
 
     private static MessagingRuntime CreateRuntime(
@@ -219,6 +320,9 @@ public class RabbitMQEndpointQueueOwnershipTests
             .BuildRuntime();
         return runtime;
     }
+
+    private static object DescribeQueue(RabbitMQQueue queue)
+        => new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments };
 
     public sealed class OrderSpyConsumer : IConsumer<OrderCreated>
     {

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Routing/RabbitMQReceiveTopologyConventionTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Routing/RabbitMQReceiveTopologyConventionTests.cs
@@ -136,11 +136,11 @@ public class RabbitMQReceiveTopologyConventionTests
     }
 
     [Fact]
-    public void DiscoverTopology_Should_MaterializeNonDurableAutoDeleteQueue_When_RouteIsReply()
+    public void DiscoverTopology_Should_MaterializeDurableAutoDeleteQueueWithExpiry_When_RouteIsReply()
     {
         // arrange
         // The generated reply endpoint sets IsTemporary, and the reply queue must go through the
-        // same non-durable, auto-delete lifecycle path as any other temporary endpoint.
+        // same durable, auto-delete plus queue expiry lifecycle path as any other temporary endpoint.
         var services = new ServiceCollection();
         services.AddInMemorySagas();
         var builder = services.AddMessageBus();
@@ -162,8 +162,17 @@ public class RabbitMQReceiveTopologyConventionTests
         var queue = topology.Queues.Single(q => q.Name == replyEndpoint.Queue.Name);
 
         // assert
-        Assert.False(queue.Durable);
-        Assert.True(queue.AutoDelete);
+        new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
     }
 
     [Fact]

--- a/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Topology/RabbitMQReplyQueueTests.cs
+++ b/src/Mocha/test/Mocha.Transport.RabbitMQ.Tests/Topology/RabbitMQReplyQueueTests.cs
@@ -1,0 +1,79 @@
+using CookieCrumble;
+using Microsoft.Extensions.DependencyInjection;
+using Mocha.Transport.RabbitMQ.Tests.Helpers;
+
+namespace Mocha.Transport.RabbitMQ.Tests.Topology;
+
+public class RabbitMQReplyQueueTests
+{
+    [Fact]
+    public void ReplyQueue_Should_BeDurableAutoDeleteWithExpiry_When_RequestHandlerRegistered()
+    {
+        // arrange
+        // RabbitMQ 4.3 denies non-durable, non-exclusive queues by default, so the per-instance
+        // reply queue must stay durable and rely on auto-delete plus a queue expiry.
+        var runtime = CreateRuntime(_ => { });
+        var transport = runtime.Transports.OfType<RabbitMQMessagingTransport>().Single();
+        var topology = (RabbitMQMessagingTopology)transport.Topology;
+
+        // act
+        var queue = topology.Queues.Single(q => q.Name.StartsWith("response-", StringComparison.Ordinal));
+
+        // assert
+        new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
+    }
+
+    [Fact]
+    public void ReplyQueue_Should_StayClassic_When_QuorumDefaultsConfigured()
+    {
+        // arrange
+        // Quorum queues reject auto-delete, so bus defaults must not reach the reply queue.
+        var runtime = CreateRuntime(t => t.ConfigureDefaults(d =>
+        {
+            d.Queue.QueueType = RabbitMQQueueType.Quorum;
+            d.Queue.Arguments["x-delivery-limit"] = 5;
+        }));
+        var transport = runtime.Transports.OfType<RabbitMQMessagingTransport>().Single();
+        var topology = (RabbitMQMessagingTopology)transport.Topology;
+
+        // act
+        var queue = topology.Queues.Single(q => q.Name.StartsWith("response-", StringComparison.Ordinal));
+
+        // assert
+        new { queue.Durable, queue.Exclusive, queue.AutoDelete, queue.Arguments }.MatchInlineSnapshot(
+            """
+            {
+              "Durable": true,
+              "Exclusive": false,
+              "AutoDelete": true,
+              "Arguments": {
+                "x-expires": 1800000
+              }
+            }
+            """);
+    }
+
+    private static MessagingRuntime CreateRuntime(Action<IRabbitMQMessagingTransportDescriptor> configureTransport)
+    {
+        var services = new ServiceCollection();
+        return services
+            .AddMessageBus()
+            .AddRequestHandler<GetOrderStatusHandler>()
+            .AddRabbitMQ(t =>
+            {
+                t.ConnectionProvider(_ => new StubConnectionProvider());
+                configureTransport(t);
+            })
+            .BuildRuntime();
+    }
+}

--- a/website/content/docs/mocha/routing-and-endpoints.md
+++ b/website/content/docs/mocha/routing-and-endpoints.md
@@ -421,12 +421,12 @@ A uniquely named temporary queue binds to its publish topic or exchange the same
 
 Each transport maps `Temporary()` to a different native mechanism:
 
-| Transport         | Mapping                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------- |
-| Azure Service Bus | `AutoDeleteOnIdle` on the queue (24-hour default, `Temporary(TimeSpan)` for a custom idle window) |
-| RabbitMQ          | A non-durable, auto-delete queue                                                                  |
-| PostgreSQL        | `AutoDelete` on the queue row, cascaded from the owning consumer's heartbeat and expiry           |
-| InMemory          | API parity only - a temporary queue's lifetime is the hosting process's own runtime disposal      |
+| Transport         | Mapping                                                                                                         |
+| ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| Azure Service Bus | `AutoDeleteOnIdle` on the queue (24-hour default, `Temporary(TimeSpan)` for a custom idle window)               |
+| RabbitMQ          | A durable, auto-delete queue with a queue expiry (30-minute default, `Temporary(TimeSpan)` for a custom expiry) |
+| PostgreSQL        | `AutoDelete` on the queue row, cascaded from the owning consumer's heartbeat and expiry                         |
+| InMemory          | API parity only - a temporary queue's lifetime is the hosting process's own runtime disposal                    |
 
 See the transport pages under [Transports](./transports/index.md) for the full mapping, defaults, and conflict-detection behavior for each transport.
 

--- a/website/content/docs/mocha/transports/rabbitmq.md
+++ b/website/content/docs/mocha/transports/rabbitmq.md
@@ -330,9 +330,17 @@ transport.Queue($"tenant-events-{instanceId}")
     .Receives<TenantEvent>();
 ```
 
-`Temporary()` marks the queue non-durable and auto-delete (`Durable = false`, `AutoDelete = true`). The broker removes the queue once its last consumer disconnects, independent of any idle-time window.
+`Temporary()` marks the queue auto-delete and sets a queue expiry (`AutoDelete = true`, `x-expires`), leaving it durable. The broker removes the queue once its last consumer disconnects, and a queue that never gets a consumer is removed when the expiry elapses. The default expiry is 30 minutes; pass a `TimeSpan` to `Temporary(...)` to choose a different one:
 
-If the queue is already explicitly declared as durable or non-auto-delete, for example through `DeclareQueue(...)` without matching settings, startup fails with an explicit configuration error instead of silently ignoring `Temporary()`.
+```csharp
+transport.Queue($"tenant-events-{instanceId}")
+    .Temporary(TimeSpan.FromMinutes(5))
+    .Receives<TenantEvent>();
+```
+
+RabbitMQ 4.3 and later deny non-durable, non-exclusive queues by default. Temporary queues and the transport's per-instance reply queue are declared durable and pass that check.
+
+If the queue is already explicitly declared without auto-delete, for example through `DeclareQueue(...)`, startup fails with an explicit configuration error instead of silently ignoring `Temporary()`.
 
 # Control auto-provisioning
 


### PR DESCRIPTION
## Summary

On a RabbitMQ 4.3 broker with default settings, a Mocha host using the RabbitMQ transport cannot start. RabbitMQ 4.3 moved the deprecated feature `transient_nonexcl_queues` from permitted to denied by default, and the transport declared its per-instance reply queue as non-durable, auto-delete and non-exclusive. The broker refuses that declare with `INTERNAL_ERROR - Feature transient_nonexcl_queues is deprecated`, `MessagingRuntimeHostedService.StartAsync` faults and the host exits. Every `Temporary()` queue had the same shape. The suite did not catch it because the shared Testcontainers image was pinned to `rabbitmq:3.11`.

## Changes

- `Temporary()` on the RabbitMQ transport now means durable + auto-delete + `x-expires`, which the RabbitMQ docs name as the replacement for transient non-exclusive queues. `RabbitMQQueue.MarkTemporary` no longer clears `Durable`, the routing strategy stops forcing `Durable = false`, and the declared-queue conflict check only rejects a queue that is not auto-delete.
- New `Temporary(TimeSpan expiry)` overload on `IRabbitMQReceiveEndpointDescriptor` and `IRabbitMQQueueDescriptor`, mirroring the Azure Service Bus transport. The default is 30 minutes via `RabbitMQReceiveEndpointConfiguration.TemporaryDefaults.Expiry`. Non-positive values and values beyond the `x-expires` integer range throw.
- Quorum or stream bus defaults still do not reach temporary queues, so the reply queue stays a classic queue.
- New `ThrowHelper` for the RabbitMQ transport project.
- Shared test image bumped from `rabbitmq:3.11` to `rabbitmq:4.3` in `CookieCrumble.Resources.RabbitMQ`, so the RabbitMQ suites run against a broker that denies the old shape.
- Docs: transport mapping table in `routing-and-endpoints.md` and the temporary endpoints section of `transports/rabbitmq.md`.

## Tests

- Existing tests that asserted the non-durable shape are rewritten as inline snapshots.
- New unit tests cover the reply queue shape with and without quorum defaults, a custom expiry, an invalid expiry, and a declared auto-delete queue being accepted with `Temporary()`.
- New integration test lists the reply queue through `rabbitmqctl` and pins `durable=true`, `auto_delete=true`, `exclusive=false`, `arguments=[{"x-expires",1800000},{"x-queue-type","classic"}]`.
- `Mocha.Transport.RabbitMQ.Tests`: 472 passed against `rabbitmq:4.3`. `HotChocolate.Subscriptions.RabbitMQ.Tests`: 8 passed against the same image.

## Behavior change

A `Temporary()` queue with a stable name that still exists on a broker as non-durable fails redeclaration with `PRECONDITION_FAILED` until its old consumer disconnects and auto-delete removes it. This only matters when an old and a new instance overlap on the same queue name. Reply queues use a fresh name per instance and are unaffected.
